### PR TITLE
feat(chara_detail): quarantine undecodable records instead of deleting

### DIFF
--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -7,7 +7,9 @@
             "draw": "ペイント",
             "submit": "フィードバックを送信"
         },
-        "file_deletion_error": "ファイルの削除が許可されていません。エクスプローラーで削除してください。"
+        "file_deletion_error": "ファイルの削除が許可されていません。エクスプローラーで削除してください。",
+        "record_quarantined": "読み込めない記録を {count} 件 隔離フォルダへ退避しました。（クリックでフォルダを開く）",
+        "record_quarantine_error": "読み込めない記録 {count} 件の退避に失敗しました。"
     },
     "pages": {
         "dashboard": {
@@ -96,6 +98,11 @@
                 "tooltip": "表示列を新規追加"
             },
             "regenerating_message": "認識結果を更新しています",
+            "quarantine_banner": {
+                "message": "読み込めない記録が {count} 件 隔離フォルダに退避されています。",
+                "open": "フォルダを開く",
+                "refresh": "更新"
+            },
             "error": {
                 "building_grid": "殿堂入り管理画面の表の生成に失敗したため、リセットしました。",
                 "loading_spec": "殿堂入り管理画面の列の読み込みに失敗しました。内容を確認してください。"

--- a/lib/src/chara_detail/chara_detail_record.dart
+++ b/lib/src/chara_detail/chara_detail_record.dart
@@ -278,6 +278,32 @@ class Metadata extends JsonEquatable with MetadataMappable {
       ];
 }
 
+/// Outcome of attempting to load a single record directory.
+///
+/// Returned by [CharaDetailRecord.load] so the (potentially isolate-bound)
+/// loader can report what happened as data, leaving any UI surfacing to the
+/// caller on the main isolate.
+sealed class RecordLoadResult {
+  const RecordLoadResult();
+}
+
+/// The record decoded successfully.
+class RecordLoaded extends RecordLoadResult {
+  final CharaDetailRecord record;
+
+  const RecordLoaded(this.record);
+}
+
+/// The record could not be decoded and its directory was quarantined.
+///
+/// [destination] is the quarantine folder it was moved to, or `null` if the
+/// move itself failed (e.g. a file lock), leaving the directory in place.
+class RecordQuarantined extends RecordLoadResult {
+  final DirectoryPath? destination;
+
+  const RecordQuarantined(this.destination);
+}
+
 @MappableClass(caseStyle: CaseStyle.snakeCase)
 class CharaDetailRecord extends JsonEquatable with CharaDetailRecordMappable {
   final Metadata metadata;
@@ -340,17 +366,42 @@ class CharaDetailRecord extends JsonEquatable with CharaDetailRecordMappable {
 
   DateTime get trainedDateAsDateTime => trainedDate.replaceAll("/", "-").toDateTime();
 
-  static CharaDetailRecord? load(DirectoryPath directory) {
+  /// Loads the record in [directory], quarantining it if it cannot be decoded.
+  ///
+  /// Returns a [RecordLoaded] on success, or a [RecordQuarantined] if decoding
+  /// failed. This runs inside a `compute` isolate on the bulk/reload paths, so
+  /// it performs no UI side effects: surfacing the outcome (a toast) is the
+  /// caller's responsibility on the main isolate, driven by the returned value.
+  static RecordLoadResult load(DirectoryPath directory) {
     try {
       final content = directory.filePath("record.json").readAsStringSync();
-      return CharaDetailRecordMapper.fromJson(content);
+      return RecordLoaded(CharaDetailRecordMapper.fromJson(content));
     } catch (exception, stackTrace) {
       logger.e("Failed to load record.json.", exception, stackTrace);
       logger.i(directory.listSync().map((e) => e.name).join(", "));
       captureException(exception, stackTrace);
     }
-    directory.deleteSyncSafeWithCheck();
-    return null;
+    // A record that fails to decode (unknown enum value, missing required
+    // field, legacy/hand-edited file) is moved aside instead of being deleted,
+    // so its images and json survive for later inspection or recovery.
+    return RecordQuarantined(quarantine(directory));
+  }
+
+  /// Moves a record directory whose `record.json` could not be decoded into a
+  /// sibling `quarantine/` folder, preserving it for recovery.
+  ///
+  /// Records live at `<root>/active/<id>`; the quarantine folder is the sibling
+  /// `<root>/quarantine/`, which lies outside the scanned `active/` tree so a
+  /// quarantined record is not re-loaded (and re-quarantined) on restart. A name
+  /// collision with an already-quarantined id is resolved with an `_<n>` suffix.
+  /// Returns the destination, or `null` if the move failed.
+  static DirectoryPath? quarantine(DirectoryPath directory) {
+    final quarantineRoot = directory.parent.parent / "quarantine";
+    var destination = quarantineRoot / directory.name;
+    for (var n = 1; destination.existsSync(); n++) {
+      destination = quarantineRoot / "${directory.name}_$n";
+    }
+    return directory.moveSyncSafe(destination);
   }
 
   /// Determines if another record represents the same character based on key attributes.

--- a/lib/src/chara_detail/storage.dart
+++ b/lib/src/chara_detail/storage.dart
@@ -100,7 +100,9 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> {
     rootDirectory = pathInfo.charaDetailActiveDir;
     final List<CharaDetailRecord> records = [];
     if (rootDirectory.existsSync()) {
-      records.addAll(await compute(_loadAllCharaDetailRecord, rootDirectory));
+      final results = await compute(_loadAllCharaDetailRecord, rootDirectory);
+      records.addAll(results.whereType<RecordLoaded>().map((e) => e.record));
+      _surfaceQuarantines(results.whereType<RecordQuarantined>().toList());
     }
     // Safe to write other providers here: we are past the `await` above, so the
     // synchronous build frame (which the modify-during-build guard checks) is done.
@@ -162,14 +164,43 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> {
     }
   }
 
-  void addIfNotNull(CharaDetailRecord? record) {
-    if (record != null) {
-      add(record);
+  void addFromFile(String id) {
+    final result = CharaDetailRecord.load(rootDirectory / id);
+    switch (result) {
+      case RecordLoaded(:final record):
+        add(record);
+      case RecordQuarantined():
+        _surfaceQuarantines([result]);
     }
   }
 
-  void addFromFile(String id) {
-    addIfNotNull(CharaDetailRecord.load(rootDirectory / id));
+  /// Shows a single aggregated toast for records quarantined during a load.
+  ///
+  /// Centralized here on the main isolate so every load path surfaces the
+  /// outcome: the bulk startup load and [reload] run [CharaDetailRecord.load]
+  /// inside a `compute` isolate, where `Toaster.show` would be a no-op.
+  void _surfaceQuarantines(List<RecordQuarantined> quarantined) {
+    if (quarantined.isEmpty) {
+      return;
+    }
+    final destinations = quarantined.map((e) => e.destination).whereType<DirectoryPath>().toList();
+    final failed = quarantined.length - destinations.length;
+    if (destinations.isNotEmpty) {
+      // All quarantined records share the same quarantine folder; tapping the
+      // toast opens it in the file explorer so the user can inspect/recover them.
+      final quarantineDir = destinations.first.parent;
+      Toaster.show(ToastData.warning(
+        description: "app.record_quarantined".tr(namedArgs: {"count": "${destinations.length}"}),
+        onTap: () => quarantineDir.launch(),
+      ));
+      // Refresh the persistent banner on the chara_detail tab.
+      ref.invalidate(charaDetailQuarantineCountProvider);
+    }
+    if (failed > 0) {
+      Toaster.show(ToastData.error(
+        description: "app.record_quarantine_error".tr(namedArgs: {"count": "$failed"}),
+      ));
+    }
   }
 
   CharaDetailRecord? getBy({required String id}) {
@@ -228,8 +259,13 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> {
   }
 
   Future<void> reload(String id) async {
-    final record = await compute(_loadCharaDetailRecord, rootDirectory / id);
-    replaceBy(record!, id: id);
+    final result = await compute(_loadCharaDetailRecord, rootDirectory / id);
+    switch (result) {
+      case RecordLoaded(:final record):
+        replaceBy(record, id: id);
+      case RecordQuarantined():
+        _surfaceQuarantines([result]);
+    }
   }
 
   void delete(String id) {
@@ -254,17 +290,16 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> {
   }
 }
 
-CharaDetailRecord? _loadCharaDetailRecord(DirectoryPath directory) {
+RecordLoadResult _loadCharaDetailRecord(DirectoryPath directory) {
   initializeMappers();
   return CharaDetailRecord.load(directory);
 }
 
-List<CharaDetailRecord> _loadAllCharaDetailRecord(DirectoryPath directory) {
+List<RecordLoadResult> _loadAllCharaDetailRecord(DirectoryPath directory) {
   initializeMappers();
   return directory
       .listSync(recursive: false, followLinks: false)
       .map((e) => CharaDetailRecord.load(e.asDirectoryPath))
-      .nonNulls
       .toList();
 }
 
@@ -276,4 +311,17 @@ final charaDetailRecordStorageLoaderProvider =
 // charaDetailRecordStorageLoaderProvider.notifier instead.
 final charaDetailRecordStorageProvider = Provider<List<CharaDetailRecord>>((ref) {
   return ref.watch(charaDetailRecordStorageLoaderProvider).requireValue;
+});
+
+/// Number of records currently sitting in the quarantine folder.
+///
+/// Read from the filesystem, so it also reflects records quarantined in earlier
+/// sessions (which are never re-scanned from `active/`). [CharaDetailRecordStorage]
+/// invalidates this when it quarantines records at runtime so the banner updates.
+final charaDetailQuarantineCountProvider = Provider<int>((ref) {
+  final dir = ref.watch(pathInfoProvider).charaDetailQuarantineDir;
+  if (!dir.existsSync()) {
+    return 0;
+  }
+  return dir.listSync(recursive: false, followLinks: false).length;
 });

--- a/lib/src/core/path_entity.dart
+++ b/lib/src/core/path_entity.dart
@@ -193,6 +193,24 @@ class DirectoryPath extends PathEntity {
 
   Future<void> create({bool recursive = false}) => toDirectory().create(recursive: recursive);
 
+  /// Moves this directory to [destination], creating the destination's parent
+  /// folders as needed.
+  ///
+  /// Unlike [deleteSyncSafeWithCheck] this preserves the contents; it is meant
+  /// for quarantining data that must not be erased. Returns the destination on
+  /// success, or `null` if the move failed (e.g. a file lock), in which case the
+  /// directory is left untouched.
+  DirectoryPath? moveSyncSafe(DirectoryPath destination) {
+    try {
+      destination.parent.toDirectory().createSync(recursive: true);
+      toDirectory().renameSync(destination.path);
+      return destination;
+    } catch (error, stackTrace) {
+      logger.e("Failed to move directory.", error, stackTrace);
+      return null;
+    }
+  }
+
   void deleteSyncSafeWithCheck() {
     try {
       listSync(recursive: false, followLinks: false).forEach((e) => e.deleteSync(recursive: false));

--- a/lib/src/core/providers.dart
+++ b/lib/src/core/providers.dart
@@ -52,6 +52,8 @@ class PathInfo {
 
   DirectoryPath get charaDetailActiveDir => charaDetailDir / "active";
 
+  DirectoryPath get charaDetailQuarantineDir => charaDetailDir / "quarantine";
+
   DirectoryPath get charaDetailMetadataDir => charaDetailDir / "metadata";
 
   DirectoryPath get charaDetailRatingDir => charaDetailMetadataDir / "rating";

--- a/lib/src/gui/app_widget.dart
+++ b/lib/src/gui/app_widget.dart
@@ -358,7 +358,9 @@ class ApplicationWidgetState extends ConsumerState<ApplicationWidget> {
         localizationsDelegates: context.localizationDelegates,
         supportedLocales: context.supportedLocales,
         locale: context.locale,
-        routerConfig: widget.router.config(),
+        routerConfig: widget.router.config(
+          navigatorObservers: () => [AutoRouteObserver()],
+        ),
       ),
     );
   }

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -248,6 +248,61 @@ class _CharaDetailDataTablePreCheckLayer extends ConsumerWidget {
   }
 }
 
+/// Persistent banner shown at the top of the chara_detail tab while one or more
+/// records sit in the quarantine folder, with a shortcut to open that folder.
+class _QuarantineBannerWidget extends ConsumerWidget {
+  const _QuarantineBannerWidget();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(charaDetailQuarantineCountProvider);
+    if (count == 0) {
+      return const SizedBox.shrink();
+    }
+    final theme = Theme.of(context);
+    final quarantineDir = ref.watch(pathInfoProvider).charaDetailQuarantineDir;
+    // Flat buttons tinted with the banner's own foreground color so they read as
+    // part of the error-themed banner rather than standing out as separate chips.
+    final buttonStyle = TextButton.styleFrom(foregroundColor: theme.colorScheme.onErrorContainer);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Material(
+        color: theme.colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              Icon(Icons.warning_amber_rounded, color: theme.colorScheme.onErrorContainer),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  "$tr_chara_detail.quarantine_banner.message".tr(namedArgs: {"count": "$count"}),
+                  style: TextStyle(color: theme.colorScheme.onErrorContainer),
+                ),
+              ),
+              const SizedBox(width: 8),
+              TextButton.icon(
+                onPressed: () => ref.invalidate(charaDetailQuarantineCountProvider),
+                icon: const Icon(Icons.refresh),
+                label: Text("$tr_chara_detail.quarantine_banner.refresh".tr()),
+                style: buttonStyle,
+              ),
+              const SizedBox(width: 8),
+              TextButton.icon(
+                onPressed: () => quarantineDir.launch(),
+                icon: const Icon(Icons.folder_open),
+                label: Text("$tr_chara_detail.quarantine_banner.open".tr()),
+                style: buttonStyle,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class CharaDetailDataTableLoaderLayer extends ConsumerWidget {
   const CharaDetailDataTableLoaderLayer({super.key});
 
@@ -287,6 +342,7 @@ class CharaDetailDataTableLoaderLayer extends ConsumerWidget {
   Widget data(BuildContext context, WidgetRef ref) {
     return Column(
       children: const [
+        _QuarantineBannerWidget(),
         ColumnSpecTagWidget(),
         SizedBox(height: 8),
         _CharaDetailDataTablePreCheckLayer(),

--- a/lib/src/gui/chara_detail/page.dart
+++ b/lib/src/gui/chara_detail/page.dart
@@ -2,15 +2,34 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '/src/chara_detail/storage.dart';
 import '/src/gui/chara_detail/data_table_widget.dart';
 import '/src/gui/common.dart';
 
 @RoutePage()
-class CharaDetailPage extends ConsumerWidget {
+class CharaDetailPage extends ConsumerStatefulWidget {
   const CharaDetailPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<CharaDetailPage> createState() => _CharaDetailPageState();
+}
+
+class _CharaDetailPageState extends ConsumerState<CharaDetailPage>
+    with AutoRouteAwareStateMixin<CharaDetailPage> {
+  // Re-check the quarantine folder whenever this tab is opened, so the banner
+  // clears once the user has emptied the folder from outside the app.
+  @override
+  void didInitTabRoute(TabPageRoute? previousRoute) => _refreshQuarantine();
+
+  @override
+  void didChangeTabRoute(TabPageRoute previousRoute) => _refreshQuarantine();
+
+  void _refreshQuarantine() {
+    ref.invalidate(charaDetailQuarantineCountProvider);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return const SingleTilePageRootWidget(
       child: CharaDetailDataTableLoaderLayer(),
     );

--- a/test/record_quarantine_test.dart
+++ b/test/record_quarantine_test.dart
@@ -1,0 +1,90 @@
+// Verifies that a record whose `record.json` cannot be decoded is moved aside
+// into a sibling `quarantine/` folder instead of being deleted, so its images
+// and json survive for later inspection or recovery.
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/record_quarantine_test.dart
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/chara_detail/chara_detail_record.dart';
+import 'package:umacapture/src/core/mapper_init.dart';
+import 'package:umacapture/src/core/path_entity.dart';
+
+void main() {
+  setUpAll(initializeMappers);
+
+  late Directory tempRoot;
+
+  setUp(() {
+    tempRoot = Directory.systemTemp.createTempSync('umacapture_quarantine_test');
+  });
+
+  tearDown(() {
+    if (tempRoot.existsSync()) {
+      tempRoot.deleteSync(recursive: true);
+    }
+  });
+
+  // Seeds a record at <root>/active/<id>/ with the given record.json content and
+  // a dummy image, mirroring the on-disk layout the loader scans.
+  DirectoryPath seedRecord(String id, String recordJson) {
+    final dir = Directory('${tempRoot.path}/active/$id')..createSync(recursive: true);
+    File('${dir.path}/record.json').writeAsStringSync(recordJson);
+    File('${dir.path}/trainee.jpg').writeAsStringSync('image-bytes');
+    return DirectoryPath(dir);
+  }
+
+  test('record missing required fields is quarantined, not deleted', () {
+    // `{}` lacks every required field, so the strict dart_mappable decoder
+    // throws — the same failure mode a legacy/older-format record can hit.
+    final dir = seedRecord('id-001', '{}');
+
+    final result = CharaDetailRecord.load(dir);
+
+    expect(result, isA<RecordQuarantined>());
+    // The original active directory is gone (moved, not lingering)...
+    expect(Directory(dir.path).existsSync(), isFalse);
+    // ...and its contents are preserved under sibling quarantine/<id>.
+    final quarantined = Directory('${tempRoot.path}/quarantine/id-001');
+    expect(quarantined.existsSync(), isTrue);
+    expect(File('${quarantined.path}/record.json').existsSync(), isTrue);
+    expect(File('${quarantined.path}/trainee.jpg').readAsStringSync(), 'image-bytes');
+    final destination = (result as RecordQuarantined).destination;
+    expect(destination, isNotNull);
+    expect(destination!.name, 'id-001');
+    expect(destination.toDirectory().existsSync(), isTrue);
+  });
+
+  test('malformed json is quarantined', () {
+    final dir = seedRecord('id-002', 'not valid json');
+
+    expect(CharaDetailRecord.load(dir), isA<RecordQuarantined>());
+    expect(Directory('${tempRoot.path}/quarantine/id-002').existsSync(), isTrue);
+  });
+
+  test('quarantine is outside the scanned active tree', () {
+    final dir = seedRecord('id-003', '{}');
+
+    final destination = CharaDetailRecord.quarantine(dir);
+
+    expect(destination, isNotNull);
+    // active/ holds the records the loader scans; quarantine/ is its sibling, so
+    // a quarantined record is never re-loaded and re-quarantined on restart.
+    expect(destination!.parent.name, 'quarantine');
+    expect(dir.parent.name, 'active');
+    expect(destination.parent.parent.path, dir.parent.parent.path);
+  });
+
+  test('quarantine resolves id collisions with a numeric suffix', () {
+    // A record with this id was already quarantined in a previous run.
+    Directory('${tempRoot.path}/quarantine/id-004').createSync(recursive: true);
+    final dir = seedRecord('id-004', '{}');
+
+    final destination = CharaDetailRecord.quarantine(dir);
+
+    expect(destination, isNotNull);
+    expect(destination!.name, 'id-004_1');
+    expect(Directory('${tempRoot.path}/quarantine/id-004_1').existsSync(), isTrue);
+    expect(Directory(dir.path).existsSync(), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

`CharaDetailRecord.load()` previously **deleted** a record directory whenever its `record.json` failed to decode (unknown enum value, missing required field, legacy/hand-edited file). dart_mappable's stricter decoding made such throws easier to hit, turning a routine upgrade into silent, irreversible loss of captured records (images + json).

This PR changes the failure mode from **delete** to **quarantine**, surfaces it on every load path, and adds a persistent banner so the user can find and recover the affected records.

## Changes

- **Quarantine instead of delete.** An undecodable record directory is moved to a sibling `<root>/quarantine/<id>/` folder (outside the scanned `active/` tree, with `_<n>` collision suffixes) via `CharaDetailRecord.quarantine()` + `DirectoryPath.moveSyncSafe()`. Contents survive for inspection/recovery.
- **Surface on every load path.** `load()` no longer performs UI side effects — it runs inside a `compute` isolate where `Toaster.show` is a no-op. It now returns a sealed `RecordLoadResult` (`RecordLoaded` / `RecordQuarantined`), and the notifier shows a single **aggregated** toast on the main isolate for the bulk-startup, `addFromFile`, and `reload` paths. The toast opens the quarantine folder on tap.
- **reload() crash fix.** The previous `replaceBy(record!, …)` would crash if a regenerated record failed to decode; the result switch handles it safely.
- **Persistent banner** on the chara_detail tab while the quarantine folder is non-empty, with a manual refresh and an open-folder shortcut. The count is read from the filesystem (so it reflects records quarantined in earlier sessions) and re-checked whenever the tab is opened (`AutoRouteAwareStateMixin`; an `AutoRouteObserver` is registered for this).

## Tests

- `test/record_quarantine_test.dart`: move-not-delete, malformed json, quarantine-outside-active, collision suffixes.
- `test/decode_records_test.dart`: OK=70 / NG=0 against local data.

## Manual verification (Windows desktop)

Corrupted a real record (`stage` → unknown enum), launched the app:
- Record moved to `quarantine/<id>/` with all 13 files preserved; the other 69 loaded normally.
- Aggregated warning toast shown (startup path now surfaces, previously silent); tapping it opens the quarantine folder.
- Banner appears on the chara_detail tab with working refresh / open-folder; auto-refreshes on tab re-entry. Data restored from backup afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
