### PR TITLE
feat(chara_detail): add select-all/deselect-all and text search to character column

### DIFF
--- a/lib/src/chara_detail/spec/character.dart
+++ b/lib/src/chara_detail/spec/character.dart
@@ -7,7 +7,7 @@ import 'package:trina_grid/trina_grid.dart';
 import 'package:uuid/uuid.dart';
 
 import '/src/chara_detail/chara_detail_record.dart';
-import '/src/chara_detail/spec/base.dart';
+import '/src/chara_detail/spec/base.dart' hide tr_common;
 import '/src/chara_detail/spec/loader.dart';
 import '/src/chara_detail/spec/parser.dart';
 import '/src/core/callback.dart';
@@ -181,19 +181,102 @@ class _CharaCardChip extends ConsumerWidget {
   }
 }
 
-class _CharacterCardSelector extends ConsumerWidget {
+class _CharacterCardSelector extends ConsumerStatefulWidget {
   final String specId;
 
   const _CharacterCardSelector({required this.specId});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ConsumerStatefulWidget> createState() => _CharacterCardSelectorState();
+}
+
+class _CharacterCardSelectorState extends ConsumerState<_CharacterCardSelector> {
+  String textQuery = "";
+
+  List<AvailableCharaCardInfo> _filterCards(List<AvailableCharaCardInfo> cards) {
+    final normalizedQuery = textQuery.toLowerCase().trim();
+    if (normalizedQuery.isEmpty) {
+      return cards;
+    }
+    return cards.where((card) {
+      return card.cardInfo.names.any((name) => name.toLowerCase().contains(normalizedQuery));
+    }).toList();
+  }
+
+  Widget _controlWidget(BuildContext context, List<AvailableCharaCardInfo> candidates) {
+    final theme = Theme.of(context);
+    const EdgeInsetsGeometry padding = EdgeInsets.all(8);
+    return Align(
+      alignment: Alignment.topLeft,
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          ActionChip(
+            padding: padding,
+            avatar: const Icon(Icons.select_all, size: 20),
+            label: Text("$tr_common.selector.control.select_all.label".tr()),
+            tooltip: "$tr_common.selector.control.select_all.tooltip".tr(),
+            side: BorderSide.none,
+            backgroundColor: theme.colorScheme.primaryContainer,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            onPressed: () {
+              _clonedSpecProvider.update(ref, widget.specId, (spec) {
+                return spec.copyWith(
+                  predicate: CharacterCardPredicate(
+                    rejects: {...spec.predicate.rejects}..removeAll(candidates.map((e) => e.cardInfo.sid)),
+                  ),
+                );
+              });
+            },
+          ),
+          ActionChip(
+            padding: padding,
+            avatar: const Icon(Icons.deselect, size: 20),
+            label: Text("$tr_common.selector.control.deselect_all.label".tr()),
+            tooltip: "$tr_common.selector.control.deselect_all.tooltip".tr(),
+            side: BorderSide.none,
+            backgroundColor: theme.colorScheme.primaryContainer,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            onPressed: () {
+              _clonedSpecProvider.update(ref, widget.specId, (spec) {
+                return spec.copyWith(
+                  predicate: CharacterCardPredicate(
+                    rejects: {...spec.predicate.rejects}..addAll(candidates.map((e) => e.cardInfo.sid)),
+                  ),
+                );
+              });
+            },
+          ),
+          Tooltip(
+            message: "$tr_common.selector.control.text_search.tooltip".tr(),
+            child: DenseTextField(
+              initialText: "",
+              debounce: const Duration(milliseconds: 200),
+              hintText: "$tr_common.selector.control.text_search.label".tr(),
+              allowEmpty: true,
+              onChanged: (text) => setState(() => textQuery = text),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final charaCards = ref.watch(availableCharaCardsProvider);
-    final rejected = _clonedSpecProvider.watch(ref, specId).predicate.rejects;
+    final rejected = _clonedSpecProvider.watch(ref, widget.specId).predicate.rejects;
+    final candidates = _filterCards(charaCards);
     return FormGroup(
       title: Text("$tr_character.selection.label".tr()),
       description: Text("$tr_character.selection.description".tr()),
       children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 8, right: 8, top: 4, bottom: 4),
+          child: _controlWidget(context, candidates),
+        ),
         Padding(
           padding: const EdgeInsets.all(8),
           child: Align(
@@ -202,8 +285,9 @@ class _CharacterCardSelector extends ConsumerWidget {
               spacing: 8,
               runSpacing: 2,
               children: [
-                for (final card in charaCards)
-                  _CharaCardChip(specId: specId, card: card, selected: !rejected.contains(card.cardInfo.sid)),
+                if (candidates.isEmpty) Text("$tr_common.selector.not_found_message".tr()),
+                for (final card in candidates)
+                  _CharaCardChip(specId: widget.specId, card: card, selected: !rejected.contains(card.cardInfo.sid)),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary

The character (uma) column customization dialog previously offered only per-card toggle chips. The skill and factor selectors already provide bulk **select-all / deselect-all** controls and a **free-text search** field (via the shared `SelectorWidget`). This PR ports those affordances to the character selector so all three column types behave consistently.

## Changes

- Convert `_CharacterCardSelector` to a `ConsumerStatefulWidget` holding the text query, mirroring the skill/factor `_SelectionSelectorState` pattern.
- Add a control row with select-all / deselect-all `ActionChip`s plus a `DenseTextField`, reusing the shared `common.selector.control.*` translation keys for labels and tooltips.
- Filter the displayed cards by matching the query against `CharaCardInfo.names` (case-insensitive, trimmed); show the shared `not_found_message` when nothing matches.
- Scope the bulk actions to the **filtered candidates**: select-all removes the visible sids from `rejects`, deselect-all adds them, leaving the selection state of filtered-out cards untouched — matching how the skill/factor buttons act on the current candidates.

## Notes

- The character predicate uses a `rejects` (exclusion) set, so *selected == not rejected*; the add/remove on `rejects` is the inverse of the skill/factor query-set add/remove.
- The 30+ item collapse ("show more") behavior of `SelectorWidget` was intentionally not ported: the character chips are a bespoke widget with avatar images and cannot reuse `SelectorWidget`. The new search field covers the same need. Can be added later if desired.

## Verification

- `dart analyze lib/src/chara_detail/spec/character.dart` → No issues found.
- `dart format` → no changes (120-col compliant; pre-commit hook passes).
- Ran the Windows desktop app and manually exercised the dialog: search filters the card list, select-all/deselect-all act only on the visible subset, and the "not found" message appears on an empty result. No runtime errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
