### PR TITLE
style(theme): pin chip theme to a stadium shape

### DIFF
--- a/lib/src/gui/app_widget.dart
+++ b/lib/src/gui/app_widget.dart
@@ -260,7 +260,10 @@ class ApplicationWidgetState extends ConsumerState<ApplicationWidget> {
         waitDuration: const Duration(milliseconds: 100),
         showDuration: Duration.zero,
       ),
-      chipTheme: base.chipTheme.copyWith(labelStyle: modifyFontWeight(base.chipTheme.labelStyle, offset)),
+      chipTheme: base.chipTheme.copyWith(
+        labelStyle: modifyFontWeight(base.chipTheme.labelStyle, offset),
+        shape: StadiumBorder(side: base.chipTheme.shape?.side ?? BorderSide.none),
+      ),
       textTheme: base.textTheme.copyWith(
         displayLarge: modifyFontWeight(base.textTheme.displayLarge, offset),
         displayMedium: modifyFontWeight(base.textTheme.displayMedium, offset),


### PR DESCRIPTION
## Summary

Set an explicit `StadiumBorder` on the global `chipTheme` so chips render with a consistent pill shape across the app. The configured border side from the base theme is preserved (falling back to `BorderSide.none`).

Previously the `chipTheme` override only adjusted the label style and inherited the shape implicitly, leaving the chip outline dependent on the base `ThemeData` defaults.

## Changes

- `lib/src/gui/app_widget.dart`: add `shape: StadiumBorder(side: base.chipTheme.shape?.side ?? BorderSide.none)` to the `chipTheme.copyWith(...)`.

## Verification

- `dart analyze lib/src/gui/app_widget.dart` → No issues found.
- `dart format` → no changes (120-col compliant).

## Note

This change predates and is independent of the character-column work in #86; it is split out here as its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
