### PR TITLE
docs(skill): add native-cli-dev skill for the C++ CLI backend

### DIFF
--- a/.claude/skills/native-cli-dev/SKILL.md
+++ b/.claude/skills/native-cli-dev/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: native-cli-dev
+description: >-
+  Build, run, log, and debug the C++ capture/recognition backend in native/ as a
+  standalone CLI (umacapture_cli) from the command line, without CLion. Sets up
+  the MSVC toolchain via vcvars64, configures CMake with Ninja (Debug/Release),
+  runs the build / capture / video / stitch / recognize subcommands, explains the
+  spdlog output and the event-loop subcommands that never self-exit, and steps
+  through the binary with the cdb command-line debugger. Use when the user wants
+  to build, rebuild, run, inspect logs from, or debug the native CLI, regenerate
+  the assets/config/*.json scene definitions, or test capture/recognition logic
+  outside the Flutter app.
+---
+
+# Build, run, and debug the native C++ CLI (umacapture_cli)
+
+`native/` holds the C++ capture + recognition backend. It is normally built into
+the Flutter Windows app, but `native/CMakeLists.txt` also defines a standalone
+executable target, `umacapture_cli`, so the backend can be exercised in
+isolation. This was historically driven from CLion; this skill reproduces the
+same build from the command line.
+
+The build is **Windows + MSVC only** (it links `windowsapp.lib`, `dwmapi.lib`,
+and uses WinRT screen capture). Generator is **Ninja**, compiler is **MSVC
+`cl.exe`**, matching the original CLion "Visual Studio" toolchain.
+
+## Prerequisites (already present on this machine)
+
+- **Visual Studio 2022 or newer** with the C++ workload. `vcvars64.bat` provides
+  `cl.exe`, and VS ships both `cmake` and `ninja` under
+  `Common7\IDE\CommonExtensions\Microsoft\CMake\`. (A system CMake at
+  `C:\Program Files\CMake` also works once `cl`/`ninja` are on PATH.)
+- **OpenCV 4.5.5** prebuilt at `windows/opencv/build` (referenced absolutely by
+  `CMakeLists.txt` via `OpenCV_DIR`).
+- **ONNX Runtime 1.11.1** at `windows/onnxruntime` (headers in `include/`,
+  `onnxruntime.lib`/`.dll` in `lib/`).
+
+These dependency dirs are checked into the repo, so no download step is needed.
+
+## Key fact: the MSVC environment is mandatory
+
+`cl.exe` and the bundled `ninja` are **not on PATH by default**. Every cmake
+command must run inside a shell where `vcvars64.bat` has been sourced first.
+Locate the latest VS install with `vswhere` rather than hard-coding a version:
+
+```
+"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+```
+
+then call `"<installationPath>\VC\Auxiliary\Build\vcvars64.bat"`.
+
+Because the Bash/PowerShell tools do not persist a sourced batch environment
+across calls, the reliable pattern is a **single `.cmd` script** that sources
+vcvars and then runs cmake in the same process. PowerShell cannot `call` a
+`.bat`, so drive it through `cmd /c`.
+
+## Build steps
+
+Write a temporary build script — e.g. `native/build.cmd` (adjust the VS path from
+`vswhere` if needed). Note a stray `.cmd` under `native/` is **not** covered by
+`.gitignore` (only `cmake-build-*/` is), so it shows up as untracked — delete it
+when done, or write it inside the build dir:
+
+```bat
+@echo off
+call "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat" >nul
+cd /d C:\Projects\umacapture\native
+cmake -G Ninja -S . -B cmake-build-release -DCMAKE_BUILD_TYPE=Release
+cmake --build cmake-build-release
+```
+
+The `...\18\Community\...` path is this machine's current VS install; on a VS 2022
+box it would read `...\2022\Community\...`. Resolve it with `vswhere` (above)
+rather than copying the literal path.
+
+Run it:
+
+```
+cmd /c C:\Projects\umacapture\native\build.cmd
+```
+
+Notes:
+- Use a build dir named `cmake-build-*` — `native/.gitignore` ignores
+  `cmake-build-*/`, so it won't pollute git. The original CLion dirs are
+  `cmake-build-debug-visual-studio` / `cmake-build-release-visual-studio`; you
+  can reuse them or create your own. For a debug build pass
+  `-DCMAKE_BUILD_TYPE=Debug` (see **Debugging** for what that changes).
+- A `POST_BUILD` step auto-copies the matching `opencv_world455[d].dll` and
+  `onnxruntime.dll` next to the exe, so the exe runs from its own build dir
+  without PATH changes.
+- Incremental rebuilds: re-run only `cmake --build <dir>` (still inside vcvars).
+- Cleanup gotcha: after a build, `mspdbsrv.exe` / `vctip.exe` linger and lock
+  the build dir. Kill them (or just wait) before deleting a build directory.
+
+## Running the CLI
+
+The exe lives at `native/<build-dir>/umacapture_cli.exe`. **Run it with the
+build dir as the working directory** — the code reads/writes paths relative to
+cwd (`../../assets/config`, `../../sandbox/modules`, `./temp`, `./storage`), and
+those `../../` paths resolve to the repo root only from inside `native/<build-dir>/`.
+
+Subcommands (see `src/core/cli.cpp`):
+
+| Subcommand  | Purpose | Example args |
+|-------------|---------|--------------|
+| `build`     | Regenerate the scene-definition JSONs from the C++ builders, round-trip-verifying each. | `build --assets_dir C:\Projects\umacapture\assets\config` |
+| `capture`   | Live capture from the game window on screen (WinRT recorder). | `capture` |
+| `video`     | Run capture against recorded video files. | `video --video_path_list "C:\Projects\umacapture\sandbox\inheritance_only_1.mp4"` |
+| `stitch`    | Stitch previously scraped images for one record id. | `stitch --id <uuid>` |
+| `recognize` | Run the recognizer over stitched images. | `recognize --id <uuid> [<uuid> ...]` |
+
+Example (a harmless smoke test — `--help`, plus `build` into a throwaway dir):
+
+```
+cd C:\Projects\umacapture\native\cmake-build-release
+umacapture_cli.exe --help
+umacapture_cli.exe build --assets_dir .\smoke_assets
+```
+
+> **Caution:** pointing `build --assets_dir` at the real
+> `C:\Projects\umacapture\assets\config` **overwrites the tracked scene JSONs in
+> place.** Only do that when you intend to regenerate them (see the `build`
+> section below); for a smoke test write to a throwaway dir as shown.
+
+### Only `build` self-terminates; the rest run an event loop forever
+
+`capture` / `video` / `stitch` / `recognize` all start `NativeApi`'s event loop
+and then spin in `while (api.isRunning()) sleep(...)`, which does **not** exit on
+its own even after the work is done. Run them in the background, watch for the
+output artifact (below), then kill the process (`Stop-Process -Name
+umacapture_cli -Force`). Only `build` returns on completion.
+
+### `build` subcommand — regenerating scene config
+
+`build` is the most useful target for non-capture work: it runs the
+`tool/builder/*` C++ builders to emit
+`assets/config/chara_detail/{scene_context,scene_scraper,scene_stitcher,recognizer}.json`,
+then parses each back and asserts the round-trip is identical (data-loss guard).
+Use it after editing any `tool/builder/*_builder.h`, pointing `--assets_dir` at
+`C:\Projects\umacapture\assets\config` to overwrite the tracked JSONs, then
+commit them as the build artifact. (The round-trip `assert_` is only active in a
+Debug build — see Debugging.) With an absolute `--assets_dir`, `build` does not
+depend on the working directory, unlike the event-loop subcommands.
+
+### `video` subcommand needs the FFmpeg DLL
+
+OpenCV decodes video via `opencv_videoio_ffmpeg455_64.dll`, which the POST_BUILD
+step does **not** copy. For the `video` subcommand, copy it manually from
+`windows/opencv/build/x64/vc15/bin/opencv_videoio_ffmpeg455_64.dll` into the
+build dir (alongside the exe). The other subcommands don't need it.
+
+### Test inputs (from the old CLion run configurations)
+
+The CLion run configs in `native/.idea/workspace.xml` recorded working inputs
+that still exist in the repo:
+
+- **`video`** — `sandbox/inheritance_only_1.mp4` (and many other `sandbox/*.mp4`
+  clips). Needs the FFmpeg DLL (see the `video` note above). Verified: it decodes
+  the clip and writes scraped scene dirs under
+  `<build-dir>/temp/chara_detail/<uuid>/`.
+- **`recognize`** / **`stitch`** — operate on record ids under
+  `<build-dir>/storage/chara_detail/active/<uuid>/`. The committed CLion **debug**
+  build dir (`cmake-build-debug-visual-studio`) already contains stitched data
+  for these ids: `4bbc9295-567b-4068-8850-d3e963e638af`,
+  `84050aec-0088-4f27-900d-814716ac3ebe`,
+  `4404be29-3fc0-4ff3-9565-f7884f623399`,
+  `9fc47f24-16f7-479d-bece-05cce428549f`. So the simplest way to exercise
+  `recognize` is to run from that debug dir (it also already has the exe + all
+  runtime DLLs including FFmpeg). Verified: `recognize --id <one of those>`
+  rewrites `prediction.json` / `prediction_*.png` in the id's dir.
+
+The data lives only in those gitignored build dirs — there is no fresh-checkout
+fixture. To test `recognize` from a clean build dir, first produce stitched data
+with `video` → `stitch`, or copy a `storage/chara_detail/active/<uuid>/` folder
+from the debug build dir.
+
+## Logs
+
+Logging is spdlog, configured in `src/util/logger_util.cpp` /
+`logger_util.h::init()`. This applies to every run; the buffering note below is
+what bites when you kill an event-loop subcommand. On Windows:
+
+- **Logs go to stdout**, colored, with pattern `%^%L%$ %T.%f [%t] [%!:%#] %v` —
+  i.e. `<level-char> HH:MM:SS.microseconds [thread-id] [function:line] message`.
+  There is **no file sink** by default (the `basic_file_sink` line is commented
+  out). To capture a run, redirect stdout: `umacapture_cli.exe recognize --id
+  <uuid> > run.log 2>&1` (ANSI color codes land in the file too).
+- **Log macros:** `log_debug/info/warning/error/fatal(...)` and the `vlog_*`
+  variants, which auto-print each argument as `name=value` (used in `main()` as a
+  smoke test of all six levels at startup).
+- **Compile-time level floor:** `logger_util.h` line 4 sets
+  `SPDLOG_ACTIVE_LEVEL = SPDLOG_LEVEL_DEBUG`, so `log_trace` / `vlog_trace` are
+  **compiled out**. To see TRACE, change that line to `SPDLOG_LEVEL_TRACE` and
+  rebuild — the comment on line 3 marks the intended toggle. The runtime level
+  (`set_level(trace)`) is already permissive, so the macro is the only gate.
+- **Buffering gotcha:** `flush_on(warn)` + `flush_every(5s)`. WARN and above
+  flush immediately; DEBUG/INFO can sit in the buffer up to 5 seconds. Since the
+  event-loop subcommands are killed rather than exited, **the last few seconds of
+  buffered DEBUG/INFO can be lost** when you `Stop-Process`. If you need the tail,
+  log at WARN or wait for a flush before killing.
+
+## Debugging
+
+### Build a Debug configuration first
+
+For any real debugging, configure a separate Debug build dir — inside the same
+vcvars `.cmd` wrapper as the release build above (the `call vcvars64.bat` + `cd`
+lines are still required; only the cmake flags change):
+
+```bat
+cmake -G Ninja -S . -B cmake-build-debug -DCMAKE_BUILD_TYPE=Debug
+cmake --build cmake-build-debug
+```
+
+A Debug build differs from Release in three ways that matter:
+
+- **PDBs are generated**, so debuggers can map to source and show locals.
+- **`assert_` becomes live.** `assert_` (`src/util/misc.h`) is compiled to
+  `((void)0)` whenever `NDEBUG` is defined — i.e. in Release. So the `build`
+  subcommand's round-trip assertion, and every internal `assert_` in the
+  pipeline, **only fire in a Debug build**. A failed `assert_` calls `_wassert`,
+  which pops the abort/retry/ignore dialog and breaks into an attached debugger.
+- POST_BUILD copies the debug OpenCV DLL (`opencv_world455d.dll`) instead of the
+  release one. (FFmpeg DLL is still not copied — see the `video` note above.)
+
+(The compile-time log level floor is independent of build type — see **Logs**.)
+
+### Debugging with cdb (command-line debugger)
+
+Use **`cdb`** from the Windows SDK Debugging Tools:
+`C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe`. It is fully
+scriptable (`-c "commands"`), so it works from a non-interactive shell — no GUI
+IDE needed. The Debug build's PDB sits next to the exe, so symbols auto-load.
+
+Two things to get right:
+
+- **Working directory must be the build dir.** cdb launches the child with cdb's
+  own cwd, and the CLI resolves `../../assets/config`, `./storage`, etc. relative
+  to it. `cd` into the build dir before launching.
+- **Pass the exe by absolute path.** A bare relative `umacapture_cli.exe` fails
+  with `Win32 error 0n2` (file not found); give cdb the full path. Subcommand args
+  follow the exe path normally.
+
+Scripted example — set a breakpoint, run to it, dump a source-line stack, then
+quit. Targets the self-terminating `build` subcommand (the event-loop subcommands
+never exit, so under cdb you just break, inspect, and `q` to stop):
+
+```bat
+cd /d C:\Projects\umacapture\native\cmake-build-debug
+"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe" -lines ^
+  -c "bm umacapture_cli!uma::cli::buildJson*; g; kn; x umacapture_cli!uma::cli::createConfig*; q" ^
+  "C:\Projects\umacapture\native\cmake-build-debug\umacapture_cli.exe" build --assets_dir cdb_out
+```
+
+- `-lines` enables source line info in stacks.
+- `bm <pattern>` sets breakpoints by mangled-name pattern (one per template
+  instantiation, e.g. each `buildJson<...Builder, lambda, lambda>`); the fact that
+  it resolves confirms the PDB loaded.
+- `g` runs to the breakpoint; `kn` prints the call stack with `file @ line`
+  (e.g. `cli.cpp @ 24` ← `main ... cli.cpp @ 187`).
+- `x <pattern>` lists matching symbols with signatures.
+
+Common interactive commands once stopped: `g` (go), `p`/`t` (step over/into),
+`bp <func>` (breakpoint), `dv` (locals), `?? <expr>` (evaluate C++ expression),
+`q` (quit and kill the child). A failed `assert_` (Debug only) calls `_wassert`,
+which breaks straight into cdb.
+
+## Source layout (for reference)
+
+- `src/core/cli.cpp` — `main()` + CLI11 subcommand wiring (CLI entry point).
+- `src/core/native_api.{h,cpp}` — `NativeApi` event loop shared with the Flutter app.
+- `src/chara_detail/`, `src/condition/`, `src/cv/` — recognition pipeline.
+- `tool/builder/*_builder.h` — programmatic builders for the scene JSONs.
+- `vendor/` — header-only deps (CLI11, spdlog, nlohmann/json, eventpp, nameof,
+  minimal_uuid4). Also includes `../windows` (for `runner/window_recorder.h`,
+  `runner/windows_config.h`) and `tool/` on the include path.


### PR DESCRIPTION
## Summary

Adds a project skill, `.claude/skills/native-cli-dev/`, documenting how to build, run, log, and debug the standalone `umacapture_cli` target in `native/` from the command line — the workflow that was previously only driven from CLion.

## What it covers

- **Toolchain:** MSVC setup via `vcvars64` + Ninja (Debug/Release), and why a single `.cmd` wrapper is needed (the sourced env doesn't persist across tool calls).
- **Subcommands:** `build` / `capture` / `video` / `stitch` / `recognize`, including that only `build` self-terminates while the rest spin in `NativeApi`'s event loop and must be killed.
- **Runtime gotchas:** cwd must be the build dir for the relative paths to resolve; the FFmpeg DLL is not auto-copied for `video`; `build --assets_dir` pointed at the tracked `assets/config` overwrites it in place.
- **Logs:** spdlog to stdout, the message pattern, TRACE being compiled out, and the `flush_every(5s)` buffering that can drop the tail when you kill an event-loop subcommand.
- **Debugging:** the `cdb` command-line debugger with a verified scripted breakpoint/stack example, plus how a Debug build turns on `assert_` and PDBs.

## Verification

Performed on this machine and reflected in the doc:
- Configure + build succeed for both Release and Debug (Ninja + MSVC, OpenCV/ONNX resolved).
- `build` (round-trip JSON regen), `video` (FFmpeg decode → scraped scene dirs), and `recognize` (rewrites `prediction.json`) all run.
- `cdb` loads PDB symbols, hits a breakpoint, and prints a source-line stack.

## Notes

- Documentation only — no code or build changes.
- The skill content is in English per the repo language policy; this PR description and the in-skill prose follow that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
