### PR TITLE
fix(notification): play repeated capture sounds by avoiding AsyncValue dedup

### DIFF
--- a/lib/src/chara_detail/storage.dart
+++ b/lib/src/chara_detail/storage.dart
@@ -19,8 +19,13 @@ import '/src/gui/toast.dart';
 
 part 'storage.mapper.dart';
 
-StreamController<String> _duplicatedCharaEventController = StreamController();
-final duplicatedCharaEventProvider = StreamProvider<String>((ref) {
+// Monotonic id so each duplicated-chara event yields a distinct StreamProvider value; the sound
+// listener uses ref.listen(), which would otherwise dedupe equal consecutive AsyncData and skip
+// repeated duplicate detections. See _soundEventSequence in platform_controller.dart.
+int _duplicatedCharaEventSequence = 0;
+
+StreamController<int> _duplicatedCharaEventController = StreamController();
+final duplicatedCharaEventProvider = StreamProvider<int>((ref) {
   if (_duplicatedCharaEventController.hasListener) {
     _duplicatedCharaEventController = StreamController();
   }
@@ -143,7 +148,7 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> {
     final duplicated = records.firstWhereOrNull((e) => record.isSameChara(e));
     if (duplicated != null && duplicated.id != record.id) {
       (rootDirectory / record.id).deleteSyncWithCheck(recursive: true);
-      _duplicatedCharaEventController.sink.add(record.id);
+      _duplicatedCharaEventController.sink.add(_duplicatedCharaEventSequence++);
       ref.read(charaDetailCaptureStateProvider.notifier).fail("duplicated_character");
       return;
     }

--- a/lib/src/core/platform_controller.dart
+++ b/lib/src/core/platform_controller.dart
@@ -36,8 +36,14 @@ final capturingFrameSizeProvider = settableNotifierProvider<Size?>(null);
 
 final capturingFrameRateProvider = settableNotifierProvider<double?>(null);
 
-StreamController<String> _errorEventController = StreamController();
-final errorEventProvider = StreamProvider<String>((ref) {
+// Monotonic id so every sound-trigger event yields a distinct StreamProvider value. The sound
+// listeners use ref.listen(), which skips equal consecutive AsyncData; without a changing payload a
+// repeated event (same scroll index, same error message) would be deduplicated and play no sound
+// (e.g. retrying a capture quickly, or opening/closing the same tab repeatedly).
+int _soundEventSequence = 0;
+
+StreamController<int> _errorEventController = StreamController();
+final errorEventProvider = StreamProvider<int>((ref) {
   if (_errorEventController.hasListener) {
     _errorEventController = StreamController();
   }
@@ -279,7 +285,7 @@ class PlatformController {
     final captureState = _ref.read(charaDetailCaptureStateProvider.notifier);
     switch (dataType) {
       case 'onError':
-        _errorEventController.sink.add(data['message']);
+        _errorEventController.sink.add(_soundEventSequence++);
         captureState.fail(data['message']);
         break;
       case 'onCaptureStarted':
@@ -293,13 +299,13 @@ class PlatformController {
         _ref.read(capturingFrameRateProvider.notifier).set(null);
         break;
       case 'onScrollReady':
-        _scrollReadyEventController.sink.add(data['index']);
+        _scrollReadyEventController.sink.add(_soundEventSequence++);
         break;
       case 'onScrollUpdated':
         captureState.progress(data['index'], data['progress']);
         break;
       case 'onPageReady':
-        _pageReadyEventController.sink.add(data['index']);
+        _pageReadyEventController.sink.add(_soundEventSequence++);
         captureState.progress(data['index'], 1);
         break;
       case 'onCharaDetailStarted':

--- a/lib/src/core/sound_player.dart
+++ b/lib/src/core/sound_player.dart
@@ -76,8 +76,11 @@ class SoundEffect {
     return SoundEffect._(player);
   }
 
-  void play() {
-    _player.stop();
-    _player.resume();
+  Future<void> play() async {
+    // The player instance is cached and reused, so a previous take may still be playing or already
+    // completed. Await stop() to bring it back to a clean stopped state (position reset to 0) before
+    // resume(), which restarts playback from the beginning on every call.
+    await _player.stop();
+    await _player.resume();
   }
 }


### PR DESCRIPTION
## Problem

During capture, the notification sounds went silent after the first occurrence
when events repeated quickly. Reported symptom: opening and closing the same
chara-detail tab repeatedly should alternate the scroll-ready sound and the
interruption-error sound, but both stayed silent after the first one. Waiting a
few seconds, or moving to a different tab, made them play again.

## Root cause

Sound triggers (`scrollReadyEventProvider`, `pageReadyEventProvider`,
`errorEventProvider`, `duplicatedCharaEventProvider`) are delivered via
`StreamProvider` + `ref.listen`. Riverpod does not invoke the listener when the
new `AsyncData` equals the previous one. Repeated events carried the same
payload (the same scroll index, the same `"closed_before_completed"` message),
so consecutive emissions produced equal `AsyncData` values and were
deduplicated — the sound callback never ran. This matches every observation:

- a different tab plays (different scroll index → different value),
- waiting changes the last emitted value, so the next one differs,
- the capture itself was unaffected (only the sound path goes through these
  providers).

The pre-existing `hasListener` controller-recreation guard did not help: those
providers are never invalidated, so their create function runs only once and the
guard never fires.

## Fix

- Emit a monotonic id per event so each emission is a distinct `StreamProvider`
  value and always fires the listener. The error message and tab progress still
  flow through `CharaDetailCaptureState`, so no information is lost.
- Harden `SoundEffect.play` to `await stop()` before `resume()` for a clean
  restart of the reused, cached `AudioPlayer`.

## Verification

Release build (`flutter run --release`). With temporary diagnostic logging,
confirmed that rapidly opening/closing a tab now fires `_playSound` on every
event, alternating `attentionWeak` ↔ `error`, each reaching
`PlayerState.playing`. Audibly verified the sounds now alternate as expected.
`dart analyze` clean; `dart format` no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
