### PR TITLE
feat(icons): migrate to Material Symbols (Rounded) and refine logic-slot UI

### DIFF
--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -632,7 +632,8 @@
                             "strategy": "脚質",
                             "weather": "天候",
                             "record_type": "レコード種別",
-                            "support_rank": "サポカランク"
+                            "support_rank": "サポカランク",
+                            "icon": "アイコン"
                         }
                     }
                 },

--- a/lib/src/app/pages.dart
+++ b/lib/src/app/pages.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 
 import '/src/app/route.dart';
 
@@ -18,32 +19,32 @@ class Pages {
     PageLabel(
       route: const DashboardRoute(),
       label: "pages.dashboard.title".tr(),
-      selectedIcon: const Icon(Icons.dashboard),
-      unselectedIcon: const Icon(Icons.dashboard_outlined),
+      selectedIcon: const Icon(Symbols.dashboard_rounded, fill: 1),
+      unselectedIcon: const Icon(Symbols.dashboard_rounded),
     ),
     PageLabel(
       route: const CaptureRoute(),
       label: "pages.capture.title".tr(),
-      selectedIcon: const Icon(Icons.videocam),
-      unselectedIcon: const Icon(Icons.videocam_outlined),
+      selectedIcon: const Icon(Symbols.videocam_rounded, fill: 1),
+      unselectedIcon: const Icon(Symbols.videocam_rounded),
     ),
     PageLabel(
       route: const CharaDetailRoute(),
       label: "pages.chara_detail.title".tr(),
-      selectedIcon: const Icon(Icons.manage_search),
-      unselectedIcon: const Icon(Icons.manage_search_outlined),
+      selectedIcon: const Icon(Symbols.database_search_rounded, fill: 1),
+      unselectedIcon: const Icon(Symbols.database_search_rounded),
     ),
     PageLabel(
       route: const AddonRoute(),
       label: "pages.addon.title".tr(),
-      selectedIcon: const Icon(Icons.extension),
-      unselectedIcon: const Icon(Icons.extension_outlined),
+      selectedIcon: const Icon(Symbols.extension_rounded, fill: 1),
+      unselectedIcon: const Icon(Symbols.extension_rounded),
     ),
     PageLabel(
       route: const SettingsRoute(),
       label: "pages.settings.title".tr(),
-      selectedIcon: const Icon(Icons.settings),
-      unselectedIcon: const Icon(Icons.settings_outlined),
+      selectedIcon: const Icon(Symbols.settings_rounded, fill: 1),
+      unselectedIcon: const Icon(Symbols.settings_rounded),
     ),
   ];
 

--- a/lib/src/chara_detail/spec/character.dart
+++ b/lib/src/chara_detail/spec/character.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:trina_grid/trina_grid.dart';
 import 'package:uuid/uuid.dart';
@@ -273,7 +274,7 @@ class _CharacterCardSelectorState extends ConsumerState<_CharacterCardSelector> 
         children: [
           ActionChip(
             padding: padding,
-            avatar: const Icon(Icons.select_all, size: 20),
+            avatar: const Icon(Symbols.select_all_rounded, size: 20),
             label: Text("$tr_common.selector.control.select_all.label".tr()),
             tooltip: "$tr_common.selector.control.select_all.tooltip".tr(),
             side: BorderSide.none,
@@ -291,7 +292,7 @@ class _CharacterCardSelectorState extends ConsumerState<_CharacterCardSelector> 
           ),
           ActionChip(
             padding: padding,
-            avatar: const Icon(Icons.deselect, size: 20),
+            avatar: const Icon(Symbols.deselect_rounded, size: 20),
             label: Text("$tr_common.selector.control.deselect_all.label".tr()),
             tooltip: "$tr_common.selector.control.deselect_all.tooltip".tr(),
             side: BorderSide.none,

--- a/lib/src/chara_detail/spec/logic.dart
+++ b/lib/src/chara_detail/spec/logic.dart
@@ -1,6 +1,7 @@
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:trina_grid/trina_grid.dart';
 import 'package:uuid/uuid.dart';
@@ -164,7 +165,11 @@ class LogicColumnSpec extends ColumnSpec<bool> with LogicColumnSpecMappable, Con
       readOnly: true,
       renderer: (TrinaColumnRendererContext context) {
         final data = context.cell.getUserData<LogicCellData>()!;
-        return Icon(data.passed ? Icons.check : Icons.close, color: data.passed ? Colors.green : Colors.red, size: 18);
+        return Icon(
+          data.passed ? Symbols.check_rounded : Symbols.close_rounded,
+          color: data.passed ? Colors.green : Colors.red,
+          size: 18,
+        );
       },
     )..setUserData(this);
   }

--- a/lib/src/chara_detail/spec/memo.dart
+++ b/lib/src/chara_detail/spec/memo.dart
@@ -1,6 +1,7 @@
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:trina_grid/trina_grid.dart';
 import 'package:uuid/uuid.dart';
@@ -244,7 +245,7 @@ class _RecordMemoDialogState extends ConsumerState<_RecordMemoDialog> {
             Tooltip(
               message: "$tr_memo.dialog.ok_button.tooltip".tr(),
               child: FilledButton.icon(
-                icon: const Icon(Icons.check_circle),
+                icon: const Icon(Symbols.check_circle_rounded),
                 label: Text("$tr_memo.dialog.ok_button.label".tr()),
                 onPressed: () {
                   memoStorage.update(recordId: record.id, memo: controller.text);

--- a/lib/src/chara_detail/spec/rating.dart
+++ b/lib/src/chara_detail/spec/rating.dart
@@ -1,6 +1,7 @@
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:trina_grid/trina_grid.dart';
@@ -254,7 +255,7 @@ class _RecordRatingDialogState extends ConsumerState<_RecordRatingDialog> {
                   });
                 },
                 itemBuilder: (BuildContext context, int index) {
-                  return const Icon(Icons.star, color: Colors.amber);
+                  return const Icon(Symbols.star_rate_rounded, color: Colors.amber, weight: 400, fill: 1);
                 },
               ),
               const SizedBox(height: 8),
@@ -268,7 +269,7 @@ class _RecordRatingDialogState extends ConsumerState<_RecordRatingDialog> {
             Tooltip(
               message: "$tr_rating.dialog.ok_button.tooltip".tr(),
               child: FilledButton.icon(
-                icon: const Icon(Icons.check_circle),
+                icon: const Icon(Symbols.check_circle_rounded),
                 label: Text("$tr_rating.dialog.ok_button.label".tr()),
                 onPressed: () {
                   widget.onRatingUpdate(rating);
@@ -350,7 +351,7 @@ class _RecordRatingWidgetState extends ConsumerState<_RecordRatingWidget> {
               }
             },
             itemBuilder: (BuildContext context, int index) {
-              return const Icon(Icons.star, color: Colors.amber);
+              return const Icon(Symbols.star_rate_rounded, color: Colors.amber, weight: 400, fill: 1);
             },
           ),
         ),

--- a/lib/src/chara_detail/spec/script.dart
+++ b/lib/src/chara_detail/spec/script.dart
@@ -7,6 +7,7 @@ import 'package:dart_eval/dart_eval_bridge.dart';
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -464,15 +465,15 @@ Color? _resolveColor(String? source) {
 const _iconWidthReserve = 'MM';
 
 const Map<String, IconData> _iconMap = {
-  'cross': Icons.close, // ×
-  'circle': Icons.circle_outlined, // ○
-  'double_circle': Icons.radio_button_checked, // ◎
-  'check': Icons.check, // ✓
-  'star': Icons.star_border, // ☆ (outline)
-  'favorite': Icons.favorite_border, // ♡ (outline)
-  'flag': Icons.flag_outlined, // ⚑ (outline)
-  'arrow_upward': Icons.arrow_upward, // ↑
-  'arrow_downward': Icons.arrow_downward, // ↓
+  'cross': Symbols.close_rounded, // ×
+  'circle': Symbols.circle_rounded, // ○
+  'double_circle': Symbols.radio_button_checked_rounded, // ◎
+  'check': Symbols.check_rounded, // ✓
+  'star': Symbols.star_rounded, // ☆ (outline)
+  'favorite': Symbols.favorite_rounded, // ♡ (outline)
+  'flag': Symbols.flag_rounded, // ⚑ (outline)
+  'arrow_upward': Symbols.arrow_upward_rounded, // ↑
+  'arrow_downward': Symbols.arrow_downward_rounded, // ↓
 };
 
 // --- Spec -------------------------------------------------------------------
@@ -671,7 +672,7 @@ class _ScriptCell extends StatelessWidget {
     if (result.error != null) {
       return Tooltip(
         message: result.error!,
-        child: const Icon(Icons.error_outline, size: 18, color: Colors.orange),
+        child: const Icon(Symbols.error_rounded, size: 18, color: Colors.orange),
       );
     }
     final iconData = result.icon == null ? null : _iconMap[result.icon!];
@@ -822,7 +823,7 @@ class _CopyButton extends StatelessWidget {
     return Tooltip(
       message: "$tr_script.copy.tooltip".tr(),
       child: IconButton(
-        icon: Icon(Icons.copy, size: 18, color: color),
+        icon: Icon(Symbols.content_copy_rounded, size: 18, color: color),
         visualDensity: VisualDensity.compact,
         onPressed: () => _copyToClipboard(text()),
       ),
@@ -1067,7 +1068,7 @@ class _NameLookupState extends ConsumerState<_NameLookup> {
                     ),
                   if (needCollapse)
                     ActionChip(
-                      avatar: const Icon(Icons.expand_more),
+                      avatar: const Icon(Symbols.expand_more_rounded),
                       label: Text("$_trCommonSelector.expand_button".tr()),
                       side: BorderSide.none,
                       backgroundColor: theme.colorScheme.primaryContainer,
@@ -1264,7 +1265,7 @@ class _ScriptColumnSelectorState extends ConsumerState<ScriptColumnSelector> {
                   onPressed: _running ? null : _evaluate,
                   icon: _running
                       ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))
-                      : const Icon(Icons.play_arrow),
+                      : const Icon(Symbols.play_arrow_rounded),
                   label: Text("$tr_script.preview.button".tr()),
                 ),
               ),

--- a/lib/src/chara_detail/spec/script.dart
+++ b/lib/src/chara_detail/spec/script.dart
@@ -467,7 +467,7 @@ const _iconWidthReserve = 'MM';
 const Map<String, IconData> _iconMap = {
   'cross': Symbols.close_rounded, // ×
   'circle': Symbols.circle_rounded, // ○
-  'double_circle': Symbols.radio_button_checked_rounded, // ◎
+  'double_circle': Symbols.circle_circle_rounded, // ◎
   'check': Symbols.check_rounded, // ✓
   'star': Symbols.star_rounded, // ☆ (outline)
   'favorite': Symbols.favorite_rounded, // ♡ (outline)
@@ -853,7 +853,18 @@ class _LookupCategory {
   final String? category;
   final Map<String, int> codeByName;
 
-  const _LookupCategory(this.path, this.hintKey, this.names, {this.category, this.codeByName = const {}});
+  /// When true, [names] are [_iconMap] keys: the picker renders each chip with
+  /// its glyph as the avatar so the user can match a Cell `icon` key to its look.
+  final bool showIcon;
+
+  const _LookupCategory(
+    this.path,
+    this.hintKey,
+    this.names, {
+    this.category,
+    this.codeByName = const {},
+    this.showIcon = false,
+  });
 }
 
 /// Drops blanks and removes duplicates while preserving first-seen order.
@@ -926,6 +937,8 @@ List<_LookupCategory> _buildLookupCategories(LabelMap labels, List<String> chara
     coded('r.races[].weather.name', 'weather', 'weather', label('race_weather.name')),
     coded('r.metadata.recordType.name', 'record_type', 'record_type', label(LabelKeys.recordType)),
     coded('r.supportCards[].rank.name', 'support_rank', 'support_rank', _supportCardRanks),
+    // Not an accessor: the keys a Cell's `icon` field accepts (see [_iconMap]).
+    _LookupCategory('icon', 'icon', _iconMap.keys.toList(), showIcon: true),
   ];
 }
 
@@ -1062,6 +1075,7 @@ class _NameLookupState extends ConsumerState<_NameLookup> {
                   if (matched.isEmpty) Text("$_trCommonSelector.not_found_message".tr()),
                   for (final name in reduced)
                     ActionChip(
+                      avatar: category.showIcon ? Icon(_iconMap[name], size: 18) : null,
                       label: Text(name),
                       backgroundColor: theme.colorScheme.surfaceContainerLow,
                       onPressed: () => _copyName(name),

--- a/lib/src/gui/addon.dart
+++ b/lib/src/gui/addon.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:percent_indicator/percent_indicator.dart';
 import 'package:uuid/uuid.dart';
@@ -48,7 +49,7 @@ class _TaskListCard extends ConsumerWidget {
       title: "$tr_addon.card.tasks".tr(),
       crossAxisAlignment: CrossAxisAlignment.stretch,
       trailing: IconButton(
-        icon: const Icon(Icons.add),
+        icon: const Icon(Symbols.add_rounded),
         tooltip: "$tr_addon.task.add".tr(),
         onPressed: () => TaskEditDialog.show(ref.base, _newTask(), isNew: true),
       ),
@@ -86,7 +87,7 @@ class _TaskRow extends ConsumerWidget {
         overflow: TextOverflow.ellipsis,
       ),
       trailing: IconButton(
-        icon: const Icon(Icons.play_arrow),
+        icon: const Icon(Symbols.play_arrow_rounded),
         tooltip: "$tr_addon.task.run".tr(),
         onPressed: isRunning ? null : () => ref.read(addonExecutionControllerProvider.notifier).runManual(task),
       ),
@@ -120,7 +121,7 @@ class _RunningTasksCard extends ConsumerWidget {
             title: Text(exec.taskName),
             subtitle: exec.progress.message == null ? null : Text(exec.progress.message!),
             trailing: IconButton(
-              icon: const Icon(Icons.stop_circle_outlined),
+              icon: const Icon(Symbols.stop_circle_rounded),
               tooltip: "$tr_addon.running.cancel".tr(),
               onPressed: () => ref.read(addonExecutionControllerProvider.notifier).cancel(exec.executionId),
             ),
@@ -135,11 +136,11 @@ class _HistoryCard extends ConsumerWidget {
 
   IconData _statusIcon(ExecutionStatus status) {
     return switch (status) {
-      ExecutionStatus.success => Icons.check_circle,
-      ExecutionStatus.failure => Icons.error,
-      ExecutionStatus.cancelled => Icons.cancel,
-      ExecutionStatus.timeout => Icons.timer_off,
-      ExecutionStatus.running => Icons.hourglass_empty,
+      ExecutionStatus.success => Symbols.check_circle_rounded,
+      ExecutionStatus.failure => Symbols.error_rounded,
+      ExecutionStatus.cancelled => Symbols.cancel_rounded,
+      ExecutionStatus.timeout => Symbols.timer_off_rounded,
+      ExecutionStatus.running => Symbols.hourglass_empty_rounded,
     };
   }
 
@@ -168,7 +169,7 @@ class _HistoryCard extends ConsumerWidget {
       trailing: history.isEmpty
           ? null
           : IconButton(
-              icon: const Icon(Icons.delete_sweep),
+              icon: const Icon(Symbols.delete_sweep_rounded),
               tooltip: "$tr_addon.history.clear".tr(),
               onPressed: () => ref.read(addonExecutionControllerProvider.notifier).clearHistory(),
             ),
@@ -190,7 +191,7 @@ class _HistoryCard extends ConsumerWidget {
                 "${entry.exitCode == null ? '' : ' · exit ${entry.exitCode}'}",
                 style: theme.textTheme.bodySmall,
               ),
-              trailing: _hasDetail(entry) ? const Icon(Icons.chevron_right) : null,
+              trailing: _hasDetail(entry) ? const Icon(Symbols.chevron_right_rounded) : null,
               onTap: _hasDetail(entry) ? () => _showDetail(context, ref, entry) : null,
             ),
       ],

--- a/lib/src/gui/addon/task_dialog.dart
+++ b/lib/src/gui/addon/task_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -305,7 +306,7 @@ class _TaskEditDialogState extends ConsumerState<TaskEditDialog> {
             Tooltip(
               message: "$tr_addon.dialog.delete_confirm".tr(),
               child: OutlinedButton.icon(
-                icon: const Icon(Icons.delete_forever),
+                icon: const Icon(Symbols.delete_forever_rounded),
                 label: Text("$tr_addon.dialog.delete".tr()),
                 // Require a long-press so a single misclick cannot discard a
                 // carefully configured task (mirrors DeleteRecordDialog).
@@ -316,7 +317,7 @@ class _TaskEditDialogState extends ConsumerState<TaskEditDialog> {
           else
             const SizedBox.shrink(),
           FilledButton.icon(
-            icon: const Icon(Icons.check_circle),
+            icon: const Icon(Symbols.check_circle_rounded),
             label: Text("$tr_addon.dialog.save".tr()),
             onPressed: _canSave ? _save : null,
           ),
@@ -387,7 +388,7 @@ List<Widget> _externalFields(_ActionFields f, TriggerEvent trigger, VoidCallback
       controller: f.program,
       decoration: InputDecoration(
         labelText: "$tr_addon.dialog.program.label".tr(),
-        suffixIcon: IconButton(icon: const Icon(Icons.folder_open), onPressed: pickProgram),
+        suffixIcon: IconButton(icon: const Icon(Symbols.folder_open_rounded), onPressed: pickProgram),
       ),
       onChanged: (_) => onChanged(),
     ),
@@ -407,7 +408,7 @@ List<Widget> _externalFields(_ActionFields f, TriggerEvent trigger, VoidCallback
       decoration: InputDecoration(
         labelText: "$tr_addon.dialog.working_dir.label".tr(),
         helperText: "$tr_addon.dialog.working_dir.helper".tr(),
-        suffixIcon: IconButton(icon: const Icon(Icons.folder_open), onPressed: pickWorkingDir),
+        suffixIcon: IconButton(icon: const Icon(Symbols.folder_open_rounded), onPressed: pickWorkingDir),
       ),
     ),
     const SizedBox(height: 16),
@@ -639,7 +640,7 @@ class _BuiltinRecordWarning extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(Icons.warning_amber, size: 18, color: theme.colorScheme.error),
+          Icon(Symbols.warning_rounded, size: 18, color: theme.colorScheme.error),
           const SizedBox(width: 8),
           Expanded(
             child: Text(

--- a/lib/src/gui/app_widget.dart
+++ b/lib/src/gui/app_widget.dart
@@ -5,6 +5,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:window_manager/window_manager.dart';
@@ -77,7 +78,7 @@ class _Sidebar extends ConsumerWidget {
           right: 0,
           child: TextButton(
             style: ButtonStyle(shape: WidgetStateProperty.all(const RoundedRectangleBorder())),
-            child: Icon(isExtended ? Icons.chevron_left : Icons.chevron_right),
+            child: Icon(isExtended ? Symbols.chevron_left_rounded : Symbols.chevron_right_rounded),
             onPressed: () => ref.read(sidebarExtendedStateProvider.notifier).toggle(),
           ),
         ),
@@ -289,6 +290,17 @@ class ApplicationWidgetState extends ConsumerState<ApplicationWidget> {
         labelLarge: modifyFontWeight(base.textTheme.labelLarge, offset),
         labelMedium: modifyFontWeight(base.textTheme.labelMedium, offset),
         labelSmall: modifyFontWeight(base.textTheme.labelSmall, offset),
+      ),
+      iconTheme: base.iconTheme.copyWith(weight: 600),
+      // NavigationRail replaces (does not merge) the ambient IconTheme for its
+      // destinations, so the global iconTheme weight above never reaches the
+      // sidebar icons. Re-apply the weight on the rail's own icon themes while
+      // preserving the size/color FlexColorScheme set.
+      navigationRailTheme: base.navigationRailTheme.copyWith(
+        selectedIconTheme: (base.navigationRailTheme.selectedIconTheme ?? const IconThemeData()).copyWith(weight: 600),
+        unselectedIconTheme: (base.navigationRailTheme.unselectedIconTheme ?? const IconThemeData()).copyWith(
+          weight: 600,
+        ),
       ),
     );
   }

--- a/lib/src/gui/capture.dart
+++ b/lib/src/gui/capture.dart
@@ -4,6 +4,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
 
 import '/src/app/route.dart';
@@ -340,9 +341,9 @@ class _CapturingPlatformInfoWidget extends ConsumerWidget {
     _Requirement.insufficient: Colors.red.shade500,
   };
   final iconMap = {
-    _Requirement.good: Icons.check,
-    _Requirement.unsure: Icons.warning_amber,
-    _Requirement.insufficient: Icons.block,
+    _Requirement.good: Symbols.check_rounded,
+    _Requirement.unsure: Symbols.warning_rounded,
+    _Requirement.insufficient: Symbols.block_rounded,
   };
 
   Widget chip({

--- a/lib/src/gui/chara_detail/column_builder_dialog.dart
+++ b/lib/src/gui/chara_detail/column_builder_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:recase/recase.dart';
 
@@ -23,7 +24,7 @@ class ColumnBuilderDialog extends ConsumerWidget {
 
   Widget addAllChipWidget(BuildContext context, WidgetRef ref, List<ColumnBuilder> targets) {
     return ActionChip(
-      avatar: const Icon(Icons.auto_awesome_motion_outlined, size: 16),
+      avatar: const Icon(Symbols.auto_awesome_motion_rounded, size: 16),
       labelPadding: const EdgeInsets.only(right: 8),
       label: Text("$tr_chara_detail.column_spec.dialog.add_all_button.label".tr()),
       tooltip: "$tr_chara_detail.column_spec.dialog.add_all_button.tooltip".tr(),

--- a/lib/src/gui/chara_detail/column_preset_bar_widget.dart
+++ b/lib/src/gui/chara_detail/column_preset_bar_widget.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/chara_detail/spec/base.dart';
@@ -65,7 +66,7 @@ class ColumnPresetBarWidget extends ConsumerWidget {
               ),
               const SizedBox(width: 4),
               _PresetActionButton(
-                icon: Icons.add,
+                icon: Symbols.add_rounded,
                 tooltip: "$tr_preset.create.tooltip".tr(),
                 onPressed: () => _PresetNameDialog.show(
                   ref.base,
@@ -75,7 +76,7 @@ class ColumnPresetBarWidget extends ConsumerWidget {
                 ),
               ),
               _PresetActionButton(
-                icon: Icons.copy,
+                icon: Symbols.content_copy_rounded,
                 tooltip: "$tr_preset.duplicate.tooltip".tr(),
                 onPressed: selected == null
                     ? null
@@ -88,7 +89,7 @@ class ColumnPresetBarWidget extends ConsumerWidget {
                       ),
               ),
               _PresetActionButton(
-                icon: Icons.edit,
+                icon: Symbols.edit_rounded,
                 tooltip: "$tr_preset.rename.tooltip".tr(),
                 onPressed: selected == null
                     ? null
@@ -101,7 +102,7 @@ class ColumnPresetBarWidget extends ConsumerWidget {
                       ),
               ),
               _PresetActionButton(
-                icon: Icons.delete_outline,
+                icon: Symbols.delete_rounded,
                 tooltip: canDelete ? "$tr_preset.delete.tooltip".tr() : "$tr_preset.delete.disabled_tooltip".tr(),
                 onPressed: (!canDelete || selected == null) ? null : () => _PresetDeleteDialog.show(ref.base, selected),
               ),
@@ -222,7 +223,7 @@ class _PresetNameDialogState extends ConsumerState<_PresetNameDialog> {
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             OutlinedButton.icon(
-              icon: const Icon(Icons.cancel),
+              icon: const Icon(Symbols.cancel_rounded),
               label: Text("$tr_preset.dialog.cancel_button".tr()),
               onPressed: () => CardDialog.dismiss(ref.base),
             ),
@@ -234,7 +235,7 @@ class _PresetNameDialogState extends ConsumerState<_PresetNameDialog> {
               valueListenable: _controller,
               builder: (context, value, _) {
                 return FilledButton.icon(
-                  icon: const Icon(Icons.check_circle),
+                  icon: const Icon(Symbols.check_circle_rounded),
                   label: Text("$tr_preset.dialog.ok_button".tr()),
                   onPressed: value.text.trim().isEmpty ? null : _submit,
                 );
@@ -278,7 +279,7 @@ class _PresetDeleteDialog extends ConsumerWidget {
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             OutlinedButton.icon(
-              icon: const Icon(Icons.cancel),
+              icon: const Icon(Symbols.cancel_rounded),
               label: Text("$tr_preset.dialog.cancel_button".tr()),
               onPressed: () => CardDialog.dismiss(ref.base),
             ),
@@ -288,7 +289,7 @@ class _PresetDeleteDialog extends ConsumerWidget {
                 backgroundColor: theme.colorScheme.error,
                 foregroundColor: theme.colorScheme.onError,
               ),
-              icon: const Icon(Icons.delete),
+              icon: const Icon(Symbols.delete_rounded),
               label: Text("$tr_preset.dialog.delete_button".tr()),
               onPressed: () {
                 ref.read(columnPresetIndexProvider.notifier).delete(target.key);

--- a/lib/src/gui/chara_detail/column_spec_dialog.dart
+++ b/lib/src/gui/chara_detail/column_spec_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/chara_detail/spec/base.dart';
@@ -151,7 +152,7 @@ class ColumnSpecDialog extends ConsumerWidget {
           Tooltip(
             message: "$tr_chara_detail.column_predicate.dialog.delete_button.tooltip".tr(),
             child: OutlinedButton.icon(
-              icon: const Icon(Icons.delete_forever),
+              icon: const Icon(Symbols.delete_forever_rounded),
               label: Text("$tr_chara_detail.column_predicate.dialog.delete_button.label".tr()),
               onPressed: () {
                 ref.read(currentColumnSpecsLoaderProvider.notifier).removeIfExists(specId);
@@ -164,7 +165,7 @@ class ColumnSpecDialog extends ConsumerWidget {
                 ? "$tr_chara_detail.column_predicate.dialog.ok_button.tooltip".tr()
                 : "$tr_chara_detail.column_predicate.dialog.ok_button.disabled_tooltip".tr(),
             child: FilledButton.icon(
-              icon: const Icon(Icons.check_circle),
+              icon: const Icon(Symbols.check_circle_rounded),
               label: Text("$tr_chara_detail.column_predicate.dialog.ok_button.label".tr()),
               onPressed: !saveEnabled
                   ? null

--- a/lib/src/gui/chara_detail/column_spec_tag_widget.dart
+++ b/lib/src/gui/chara_detail/column_spec_tag_widget.dart
@@ -312,13 +312,29 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
     final selected = active && _currentSlot == slot;
     return _slot(
       key,
-      CustomPaint(
-        painter: _DashedRRectPainter(color: theme.colorScheme.primary),
-        child: selected
-            ? IgnorePointer(child: _staticContent(context, _draggedSpec!, highlight: true))
-            : const SizedBox(width: 40, height: 32),
-      ),
+      selected
+          ? CustomPaint(
+              painter: _DashedRRectPainter(color: theme.colorScheme.primary),
+              child: IgnorePointer(child: _staticContent(context, _draggedSpec!, highlight: true)),
+            )
+          : _emptySlotBox(context),
       gap: false,
+    );
+  }
+
+  // The resting look of an empty logic container's inner slot: a dashed, rounded
+  // box with the `place_item` glyph. Shared by [_emptyDropSlot] and by
+  // [_staticContent] so a dragged empty container's placeholder keeps this look
+  // instead of collapsing to a bare label.
+  Widget _emptySlotBox(BuildContext context) {
+    final theme = Theme.of(context);
+    return CustomPaint(
+      painter: _DashedRRectPainter(color: theme.colorScheme.primary),
+      child: SizedBox(
+        width: 40,
+        height: 32,
+        child: Center(child: Icon(Symbols.place_item_rounded, size: 18, color: theme.colorScheme.primary)),
+      ),
     );
   }
 
@@ -331,6 +347,9 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
     }
     return _logicContainer(context, [
       _spaced(_logicLabel(context, spec, highlight: highlight)),
+      // No trailing gap: matches the live empty slot ([_emptyDropSlot] uses
+      // gap: false) so a dragged empty container's placeholder is the same width.
+      if (spec.children.isEmpty) _emptySlotBox(context),
       for (final child in spec.children) _spaced(_staticContent(context, child, highlight: highlight)),
     ], highlight: highlight);
   }

--- a/lib/src/gui/chara_detail/column_spec_tag_widget.dart
+++ b/lib/src/gui/chara_detail/column_spec_tag_widget.dart
@@ -1,6 +1,7 @@
 import 'package:badges/badges.dart' as badges;
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/chara_detail/spec/base.dart';
@@ -170,7 +171,7 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
         GestureDetector(
           onSecondaryTap: () => ref.read(currentColumnSpecsLoaderProvider.notifier).removeIfExists(spec.id),
           child: ActionChip(
-            avatar: broken ? Icon(Icons.warning_amber_rounded, color: theme.colorScheme.onErrorContainer) : null,
+            avatar: broken ? Icon(Symbols.warning_rounded, color: theme.colorScheme.onErrorContainer) : null,
             label: spec.label(),
             tooltip: _tooltipFor(spec),
             backgroundColor: highlight
@@ -235,10 +236,7 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (broken) ...[
-                      Icon(Icons.warning_amber_rounded, size: 16, color: color),
-                      const SizedBox(width: 2),
-                    ],
+                    if (broken) ...[Icon(Symbols.warning_rounded, size: 16, color: color), const SizedBox(width: 2)],
                     DefaultTextStyle.merge(
                       style: theme.textTheme.labelLarge!.copyWith(color: color, fontWeight: FontWeight.w600),
                       child: spec.label(),
@@ -546,7 +544,7 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
 
   Widget addButton(ThemeData theme) {
     return ActionChip(
-      avatar: Icon(Icons.add, color: theme.colorScheme.onPrimary),
+      avatar: Icon(Symbols.add_rounded, color: theme.colorScheme.onPrimary),
       label: const Text(""),
       tooltip: "$tr_chara_detail.add_column_button.tooltip".tr(),
       backgroundColor: theme.colorScheme.primary,
@@ -561,7 +559,7 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
 
   Widget addButtonWithLabel(ThemeData theme) {
     return ActionChip(
-      avatar: Icon(Icons.add, color: theme.colorScheme.onPrimary),
+      avatar: Icon(Symbols.add_rounded, color: theme.colorScheme.onPrimary),
       label: Text(
         "$tr_chara_detail.add_column_button.label".tr(),
         style: theme.textTheme.labelLarge!.copyWith(color: theme.colorScheme.onPrimary),

--- a/lib/src/gui/chara_detail/column_spec_tag_widget.dart
+++ b/lib/src/gui/chara_detail/column_spec_tag_widget.dart
@@ -325,7 +325,9 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
               child: IgnorePointer(child: _staticContent(context, _draggedSpec!, highlight: true)),
             )
           : _emptySlotBox(context, spec),
-      gap: false,
+      // Same trailing gap as a populated child slot, so an empty container's inner
+      // right margin matches a non-empty one (and doesn't shrink the moment its
+      // only child is picked up).
     );
   }
 
@@ -357,9 +359,9 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
     }
     return _logicContainer(context, [
       _spaced(_logicLabel(context, spec, highlight: highlight)),
-      // No trailing gap: matches the live empty slot ([_emptyDropSlot] uses
-      // gap: false) so a dragged empty container's placeholder is the same width.
-      if (spec.children.isEmpty) _emptySlotBox(context, spec),
+      // Trailing gap matches the live empty slot ([_emptyDropSlot]) so a dragged
+      // empty container's placeholder is the same width as the container at rest.
+      if (spec.children.isEmpty) _spaced(_emptySlotBox(context, spec)),
       for (final child in spec.children) _spaced(_staticContent(context, child, highlight: highlight)),
     ], highlight: highlight);
   }

--- a/lib/src/gui/chara_detail/column_spec_tag_widget.dart
+++ b/lib/src/gui/chara_detail/column_spec_tag_widget.dart
@@ -21,6 +21,10 @@ const tr_chara_detail = "pages.chara_detail";
 // no stray gap behind in the flow.
 const double _chipGap = 4;
 
+// Approximate height of an ActionChip in this view. The plain-text logic-operator
+// label and the empty-slot box are sized to it so they line up with sibling chips.
+const double _chipHeight = 32;
+
 // Deadband (in pixels) around a chip's centre within which the placeholder does
 // not switch sides, so it doesn't flicker when the pointer hovers right on the
 // boundary.
@@ -231,17 +235,20 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
             child: GestureDetector(
               onTap: () => ColumnSpecDialog.show(ref.base, spec),
               onSecondaryTap: () => ref.read(currentColumnSpecsLoaderProvider.notifier).removeIfExists(spec.id),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (broken) ...[Icon(Symbols.warning_rounded, size: 16, color: color), const SizedBox(width: 2)],
-                    DefaultTextStyle.merge(
-                      style: theme.textTheme.labelLarge!.copyWith(color: color, fontWeight: FontWeight.w600),
-                      child: spec.label(),
-                    ),
-                  ],
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: _chipHeight),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (broken) ...[Icon(Symbols.warning_rounded, size: 16, color: color), const SizedBox(width: 2)],
+                      DefaultTextStyle.merge(
+                        style: theme.textTheme.labelLarge!.copyWith(color: color, fontWeight: FontWeight.w600),
+                        child: spec.label(),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -317,7 +324,7 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
               painter: _DashedRRectPainter(color: theme.colorScheme.primary),
               child: IgnorePointer(child: _staticContent(context, _draggedSpec!, highlight: true)),
             )
-          : _emptySlotBox(context),
+          : _emptySlotBox(context, spec),
       gap: false,
     );
   }
@@ -326,14 +333,17 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
   // box with the `place_item` glyph. Shared by [_emptyDropSlot] and by
   // [_staticContent] so a dragged empty container's placeholder keeps this look
   // instead of collapsing to a bare label.
-  Widget _emptySlotBox(BuildContext context) {
+  Widget _emptySlotBox(BuildContext context, ColumnSpec spec) {
     final theme = Theme.of(context);
-    return CustomPaint(
-      painter: _DashedRRectPainter(color: theme.colorScheme.primary),
-      child: SizedBox(
-        width: 40,
-        height: 32,
-        child: Center(child: Icon(Symbols.place_item_rounded, size: 18, color: theme.colorScheme.primary)),
+    return Tooltip(
+      message: _tooltipFor(spec),
+      child: CustomPaint(
+        painter: _DashedRRectPainter(color: theme.colorScheme.primary),
+        child: SizedBox(
+          width: 40,
+          height: _chipHeight,
+          child: Center(child: Icon(Symbols.place_item_rounded, size: 18, color: theme.colorScheme.primary)),
+        ),
       ),
     );
   }
@@ -349,7 +359,7 @@ class _ColumnSpecTagWidgetState extends ConsumerState<ColumnSpecTagWidget> {
       _spaced(_logicLabel(context, spec, highlight: highlight)),
       // No trailing gap: matches the live empty slot ([_emptyDropSlot] uses
       // gap: false) so a dragged empty container's placeholder is the same width.
-      if (spec.children.isEmpty) _emptySlotBox(context),
+      if (spec.children.isEmpty) _emptySlotBox(context, spec),
       for (final child in spec.children) _spaced(_staticContent(context, child, highlight: highlight)),
     ], highlight: highlight);
   }

--- a/lib/src/gui/chara_detail/common.dart
+++ b/lib/src/gui/chara_detail/common.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 // riverpod 3 moved ProviderListenable out of the default export surface.
 import 'package:flutter_riverpod/misc.dart';
@@ -282,7 +283,7 @@ class _SelectorExpandButton extends ConsumerWidget {
         padding: const EdgeInsets.only(top: 8),
         child: ActionChip(
           padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-          avatar: const Icon(Icons.expand_more),
+          avatar: const Icon(Symbols.expand_more_rounded),
           label: Text("$tr_common.selector.expand_button".tr()),
           side: BorderSide.none,
           backgroundColor: theme.colorScheme.primaryContainer,
@@ -343,7 +344,7 @@ class _SelectorWidgetState extends ConsumerState<SelectorWidget> {
         children: [
           ActionChip(
             padding: padding,
-            avatar: const Icon(Icons.select_all, size: 20),
+            avatar: const Icon(Symbols.select_all_rounded, size: 20),
             label: Text("$tr_common.selector.control.select_all.label".tr()),
             tooltip: "$tr_common.selector.control.select_all.tooltip".tr(),
             side: BorderSide.none,
@@ -355,7 +356,7 @@ class _SelectorWidgetState extends ConsumerState<SelectorWidget> {
           ),
           ActionChip(
             padding: padding,
-            avatar: const Icon(Icons.deselect, size: 20),
+            avatar: const Icon(Symbols.deselect_rounded, size: 20),
             label: Text("$tr_common.selector.control.deselect_all.label".tr()),
             tooltip: "$tr_common.selector.control.deselect_all.tooltip".tr(),
             side: BorderSide.none,

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
 import 'package:trina_grid/trina_grid.dart';
@@ -297,7 +298,7 @@ class _QuarantineBannerWidget extends ConsumerWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           child: Row(
             children: [
-              Icon(Icons.warning_amber_rounded, color: theme.colorScheme.onErrorContainer),
+              Icon(Symbols.warning_rounded, color: theme.colorScheme.onErrorContainer),
               const SizedBox(width: 12),
               Expanded(
                 child: Text(
@@ -308,14 +309,14 @@ class _QuarantineBannerWidget extends ConsumerWidget {
               const SizedBox(width: 8),
               TextButton.icon(
                 onPressed: () => ref.invalidate(charaDetailQuarantineCountProvider),
-                icon: const Icon(Icons.refresh),
+                icon: const Icon(Symbols.refresh_rounded),
                 label: Text("$tr_chara_detail.quarantine_banner.refresh".tr()),
                 style: buttonStyle,
               ),
               const SizedBox(width: 8),
               TextButton.icon(
                 onPressed: () => quarantineDir.launch(),
-                icon: const Icon(Icons.folder_open),
+                icon: const Icon(Symbols.folder_open_rounded),
                 label: Text("$tr_chara_detail.quarantine_banner.open".tr()),
                 style: buttonStyle,
               ),

--- a/lib/src/gui/chara_detail/delete_record_dialog.dart
+++ b/lib/src/gui/chara_detail/delete_record_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/chara_detail/storage.dart';
@@ -50,7 +51,7 @@ class DeleteRecordDialog extends ConsumerWidget {
             Tooltip(
               message: "$tr_delete_record.dialog.cancel_button.tooltip".tr(),
               child: OutlinedButton.icon(
-                icon: const Icon(Icons.cancel),
+                icon: const Icon(Symbols.cancel_rounded),
                 label: Text("$tr_delete_record.dialog.cancel_button.label".tr()),
                 onPressed: () {
                   CardDialog.dismiss(ref.base);
@@ -65,7 +66,7 @@ class DeleteRecordDialog extends ConsumerWidget {
                   backgroundColor: theme.colorScheme.error,
                   foregroundColor: theme.colorScheme.onError,
                 ),
-                icon: const Icon(Icons.delete),
+                icon: const Icon(Symbols.delete_rounded),
                 label: Text("$tr_delete_record.dialog.ok_button.label".tr()),
                 onPressed: () {},
                 onLongPress: () {

--- a/lib/src/gui/chara_detail/export_button.dart
+++ b/lib/src/gui/chara_detail/export_button.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/chara_detail/exporter.dart';
@@ -51,7 +52,7 @@ class CharaDetailExportButton extends ConsumerWidget {
             child: PopupMenuButton<int>(
               enabled: ref.watch(charaDetailRecordStorageProvider).isNotEmpty,
               padding: EdgeInsets.zero,
-              icon: const Icon(Icons.download),
+              icon: const Icon(Symbols.download_rounded),
               tooltip: "$tr_chara_detail.export.button_tooltip".tr(),
               splashRadius: 24,
               position: PopupMenuPosition.under,

--- a/lib/src/gui/chara_detail/preview_dialog.dart
+++ b/lib/src/gui/chara_detail/preview_dialog.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/chara_detail/spec/base.dart';
@@ -323,7 +324,7 @@ class _CharaDetailPreviewDialogState extends ConsumerState<CharaDetailPreviewDia
             Tooltip(
               message: "$tr_preview.dialog.visualize_prediction.$overlay.tooltip".tr(),
               child: OutlinedButton.icon(
-                icon: Icon(overlay ? Icons.subtitles_off_outlined : Icons.subtitles_outlined),
+                icon: Icon(overlay ? Symbols.subtitles_off_rounded : Symbols.subtitles_rounded),
                 label: Text("$tr_preview.dialog.visualize_prediction.$overlay.label".tr()),
                 onPressed: () {
                   setState(() {
@@ -337,7 +338,7 @@ class _CharaDetailPreviewDialogState extends ConsumerState<CharaDetailPreviewDia
               Tooltip(
                 message: "$tr_preview.dialog.report_button.tooltip".tr(),
                 child: OutlinedButton.icon(
-                  icon: const Icon(Icons.report_outlined),
+                  icon: const Icon(Symbols.report_rounded),
                   label: Text("$tr_preview.dialog.report_button.label".tr()),
                   onPressed: () {
                     CardDialog.dismiss(ref.base);
@@ -352,7 +353,7 @@ class _CharaDetailPreviewDialogState extends ConsumerState<CharaDetailPreviewDia
               child: Tooltip(
                 message: "$tr_preview.dialog.up_button.tooltip".tr(),
                 child: OutlinedButton(
-                  child: const Icon(Icons.arrow_upward),
+                  child: const Icon(Symbols.arrow_upward_rounded),
                   onPressed: () {
                     setState(() {
                       currentIdx = Math.clamp(0, currentIdx - 1, widget.recordDirs.length - 1);
@@ -367,7 +368,7 @@ class _CharaDetailPreviewDialogState extends ConsumerState<CharaDetailPreviewDia
               child: Tooltip(
                 message: "$tr_preview.dialog.down_button.tooltip".tr(),
                 child: OutlinedButton(
-                  child: const Icon(Icons.arrow_downward),
+                  child: const Icon(Symbols.arrow_downward_rounded),
                   onPressed: () {
                     setState(() {
                       currentIdx = Math.clamp(0, currentIdx + 1, widget.recordDirs.length - 1);
@@ -380,7 +381,7 @@ class _CharaDetailPreviewDialogState extends ConsumerState<CharaDetailPreviewDia
             Tooltip(
               message: "$tr_preview.dialog.close_button.tooltip".tr(),
               child: FilledButton.icon(
-                icon: const Icon(Icons.close),
+                icon: const Icon(Symbols.close_rounded),
                 label: Text("$tr_preview.dialog.close_button.label".tr()),
                 onPressed: () {
                   CardDialog.dismiss(ref.base);

--- a/lib/src/gui/chara_detail/regenerate_record_dialog.dart
+++ b/lib/src/gui/chara_detail/regenerate_record_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/chara_detail/storage.dart';
@@ -53,7 +54,7 @@ class RegenerateRecordDialog extends ConsumerWidget {
             Tooltip(
               message: "$tr_regenerate_record.dialog.cancel_button.tooltip".tr(),
               child: OutlinedButton.icon(
-                icon: const Icon(Icons.cancel),
+                icon: const Icon(Symbols.cancel_rounded),
                 label: Text("$tr_regenerate_record.dialog.cancel_button.label".tr()),
                 onPressed: () {
                   CardDialog.dismiss(ref.base);
@@ -68,7 +69,7 @@ class RegenerateRecordDialog extends ConsumerWidget {
                   backgroundColor: theme.colorScheme.error,
                   foregroundColor: theme.colorScheme.onError,
                 ),
-                icon: const Icon(Icons.refresh),
+                icon: const Icon(Symbols.refresh_rounded),
                 label: Text("$tr_regenerate_record.dialog.ok_button.label".tr()),
                 onPressed: () {},
                 onLongPress: () {

--- a/lib/src/gui/chara_detail/report_record_dialog.dart
+++ b/lib/src/gui/chara_detail/report_record_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/core/path_entity.dart';
@@ -49,7 +50,7 @@ class ReportRecordDialog extends ConsumerWidget {
           Tooltip(
             message: "$tr_report_record.dialog.close_button.tooltip".tr(),
             child: FilledButton.icon(
-              icon: const Icon(Icons.check_circle),
+              icon: const Icon(Symbols.check_circle_rounded),
               label: Text("$tr_report_record.dialog.close_button.label".tr()),
               onPressed: () {
                 CardDialog.dismiss(ref.base);
@@ -76,7 +77,7 @@ class ReportRecordDialog extends ConsumerWidget {
           Tooltip(
             message: "$tr_report_record.dialog.close_button.tooltip".tr(),
             child: FilledButton.icon(
-              icon: const Icon(Icons.check_circle),
+              icon: const Icon(Symbols.check_circle_rounded),
               label: Text("$tr_report_record.dialog.close_button.label".tr()),
               onPressed: () {
                 CardDialog.dismiss(ref.base);
@@ -143,7 +144,7 @@ class ReportRecordDialog extends ConsumerWidget {
           Tooltip(
             message: "$tr_report_record.dialog.cancel_button.tooltip".tr(),
             child: OutlinedButton.icon(
-              icon: const Icon(Icons.cancel),
+              icon: const Icon(Symbols.cancel_rounded),
               label: Text("$tr_report_record.dialog.cancel_button.label".tr()),
               onPressed: () {
                 CardDialog.dismiss(ref.base);
@@ -154,7 +155,7 @@ class ReportRecordDialog extends ConsumerWidget {
           Tooltip(
             message: "$tr_report_record.dialog.ok_button.tooltip".tr(),
             child: FilledButton.icon(
-              icon: const Icon(Icons.check_circle),
+              icon: const Icon(Symbols.check_circle_rounded),
               label: Text("$tr_report_record.dialog.ok_button.label".tr()),
               onPressed: () {
                 captureCharaDetailRecord(controller.text, directory);

--- a/lib/src/gui/chara_detail/report_screen_dialog.dart
+++ b/lib/src/gui/chara_detail/report_screen_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/core/sentry_util.dart';
@@ -45,7 +46,7 @@ class ReportScreenDialog extends ConsumerWidget {
           Tooltip(
             message: "$tr_report_screen.dialog.close_button.tooltip".tr(),
             child: FilledButton.icon(
-              icon: const Icon(Icons.check_circle),
+              icon: const Icon(Symbols.check_circle_rounded),
               label: Text("$tr_report_screen.dialog.close_button.label".tr()),
               onPressed: () {
                 CardDialog.dismiss(ref.base);
@@ -72,7 +73,7 @@ class ReportScreenDialog extends ConsumerWidget {
           Tooltip(
             message: "$tr_report_screen.dialog.close_button.tooltip".tr(),
             child: FilledButton.icon(
-              icon: const Icon(Icons.check_circle),
+              icon: const Icon(Symbols.check_circle_rounded),
               label: Text("$tr_report_screen.dialog.close_button.label".tr()),
               onPressed: () {
                 CardDialog.dismiss(ref.base);
@@ -126,7 +127,7 @@ class ReportScreenDialog extends ConsumerWidget {
           Tooltip(
             message: "$tr_report_screen.dialog.cancel_button.tooltip".tr(),
             child: OutlinedButton.icon(
-              icon: const Icon(Icons.cancel),
+              icon: const Icon(Symbols.cancel_rounded),
               label: Text("$tr_report_screen.dialog.cancel_button.label".tr()),
               onPressed: () {
                 data?.path.deleteSync(emptyOk: true);
@@ -140,7 +141,7 @@ class ReportScreenDialog extends ConsumerWidget {
             child: Tooltip(
               message: "$tr_report_screen.dialog.ok_button.tooltip".tr(),
               child: FilledButton.icon(
-                icon: const Icon(Icons.check_circle),
+                icon: const Icon(Symbols.check_circle_rounded),
                 label: Text("$tr_report_screen.dialog.ok_button.label".tr()),
                 onPressed: () {
                   captureScreen(controller.text, data!.path);

--- a/lib/src/gui/common.dart
+++ b/lib/src/gui/common.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:feedback_sentry/feedback_sentry.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/core/sentry_util.dart';
@@ -340,7 +341,7 @@ class CardDialog extends ConsumerWidget {
                 : Tooltip(
                     message: closeButtonTooltip,
                     child: IconButton(
-                      icon: Icon(Icons.close, color: theme.colorScheme.onPrimary),
+                      icon: Icon(Symbols.close_rounded, color: theme.colorScheme.onPrimary),
                       splashRadius: 24,
                       onPressed: () {
                         CardDialog.dismiss(ref.base);

--- a/lib/src/gui/module_update_dialog.dart
+++ b/lib/src/gui/module_update_dialog.dart
@@ -3,6 +3,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:pasteboard/pasteboard.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -139,7 +140,7 @@ class _ModuleManualUpdateDialogState extends ConsumerState<ModuleManualUpdateDia
               child: Tooltip(
                 message: "$tr_module_update.dialog.pick_button.tooltip".tr(),
                 child: FilledButton.icon(
-                  icon: const Icon(Icons.folder_open),
+                  icon: const Icon(Symbols.folder_open_rounded),
                   label: Text("$tr_module_update.dialog.pick_button.label".tr()),
                   onPressed: _installing ? null : _pickFile,
                 ),
@@ -198,12 +199,12 @@ class _DownloadSource extends StatelessWidget {
           ),
           const SizedBox(width: 8),
           IconButton(
-            icon: const Icon(Icons.content_copy),
+            icon: const Icon(Symbols.content_copy_rounded),
             tooltip: "$tr_module_update.dialog.copy_tooltip".tr(),
             onPressed: _copy,
           ),
           IconButton(
-            icon: const Icon(Icons.open_in_browser),
+            icon: const Icon(Symbols.open_in_browser_rounded),
             tooltip: "$tr_module_update.dialog.open_tooltip".tr(),
             onPressed: _open,
           ),
@@ -229,7 +230,7 @@ class _WarningCard extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(Icons.warning_amber, color: theme.colorScheme.onErrorContainer),
+          Icon(Symbols.warning_rounded, color: theme.colorScheme.onErrorContainer),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
@@ -283,7 +284,7 @@ class _DropZone extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.file_upload_outlined, size: 36, color: theme.colorScheme.primary),
+            Icon(Symbols.file_upload_rounded, size: 36, color: theme.colorScheme.primary),
             const SizedBox(height: 8),
             Text(
               "$tr_module_update.dialog.drop_zone".tr(),

--- a/lib/src/gui/settings.dart
+++ b/lib/src/gui/settings.dart
@@ -3,6 +3,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pasteboard/pasteboard.dart';
 import 'package:recase/recase.dart';
@@ -132,15 +133,15 @@ class _BrightnessWidget extends ConsumerWidget {
   static final _iconMap = <ThemeMode, Widget>{
     ThemeMode.light: Tooltip(
       message: "$tr_settings.style.brightness.choice.light".tr(),
-      child: const Icon(Icons.wb_sunny),
+      child: const Icon(Symbols.wb_sunny_rounded),
     ),
     ThemeMode.dark: Tooltip(
       message: "$tr_settings.style.brightness.choice.dark".tr(),
-      child: const Icon(Icons.brightness_3),
+      child: const Icon(Symbols.brightness_3_rounded),
     ),
     ThemeMode.system: Tooltip(
       message: "$tr_settings.style.brightness.choice.system".tr(),
-      child: const Icon(Icons.brightness_auto),
+      child: const Icon(Symbols.brightness_auto_rounded),
     ),
   };
 
@@ -365,7 +366,7 @@ class AboutGroup extends ConsumerWidget {
           subtitle: Text(versionString(ref)),
           trailing: const Align(
             widthFactor: 1,
-            child: Padding(padding: EdgeInsets.only(right: 16), child: Icon(Icons.paste)),
+            child: Padding(padding: EdgeInsets.only(right: 16), child: Icon(Symbols.content_paste_rounded)),
           ),
           onTap: () => Pasteboard.writeText(versionString(ref)),
         ),
@@ -374,7 +375,7 @@ class AboutGroup extends ConsumerWidget {
           child: ListTile(
             title: Text("$tr_settings.about.regenerate.title".tr()),
             subtitle: Text("$tr_settings.about.regenerate.description".tr()),
-            trailing: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Icons.refresh)),
+            trailing: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Symbols.refresh_rounded)),
             onTap: () {
               final storage = ref.read(charaDetailRecordStorageLoaderProvider.notifier);
               storage.checkRecordVersion(includeCurrentVersion: true);
@@ -382,10 +383,9 @@ class AboutGroup extends ConsumerWidget {
           ),
         ),
         ListTile(
-          isThreeLine: true,
           title: Text("$tr_settings.about.resolve_inheritance.title".tr()),
           subtitle: Text("$tr_settings.about.resolve_inheritance.description".tr()),
-          trailing: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Icons.account_tree)),
+          trailing: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Symbols.refresh_rounded)),
           onTap: () {
             ref.read(charaDetailRecordStorageLoaderProvider.notifier).resolveAllInheritance();
           },
@@ -393,7 +393,7 @@ class AboutGroup extends ConsumerWidget {
         ListTile(
           title: Text("$tr_settings.module_update.entry.title".tr()),
           subtitle: Text("$tr_settings.module_update.entry.description".tr()),
-          trailing: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Icons.upload_file)),
+          trailing: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Symbols.download_rounded)),
           onTap: () => ModuleManualUpdateDialog.show(ref.base),
         ),
       ],

--- a/lib/src/gui/statistics.dart
+++ b/lib/src/gui/statistics.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
@@ -263,7 +264,7 @@ class _MonthlyFansStatisticWidgetState extends ConsumerState<MonthlyFansStatisti
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(),
               splashRadius: 16,
-              icon: const Icon(Icons.keyboard_arrow_left),
+              icon: const Icon(Symbols.keyboard_arrow_left_rounded),
               onPressed: () {
                 setState(() {
                   targetMonth = DateTimeExtension.later(targetMonth.lastMonth(), widget.start);
@@ -278,7 +279,7 @@ class _MonthlyFansStatisticWidgetState extends ConsumerState<MonthlyFansStatisti
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(),
               splashRadius: 16,
-              icon: const Icon(Icons.keyboard_arrow_right),
+              icon: const Icon(Symbols.keyboard_arrow_right_rounded),
               onPressed: () {
                 setState(() {
                   targetMonth = DateTimeExtension.earlier(targetMonth.nextMonth(), widget.end);

--- a/lib/src/gui/toast.dart
+++ b/lib/src/gui/toast.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/core/utils.dart';
@@ -52,10 +53,10 @@ class Toaster {
     ToastType.error: const Duration(seconds: 15),
   };
   final Map<ToastType, IconData> iconMap = {
-    ToastType.success: Icons.check_circle,
-    ToastType.info: Icons.info,
-    ToastType.warning: Icons.warning,
-    ToastType.error: Icons.dangerous,
+    ToastType.success: Symbols.check_circle_rounded,
+    ToastType.info: Symbols.info_rounded,
+    ToastType.warning: Symbols.warning_rounded,
+    ToastType.error: Symbols.dangerous_rounded,
   };
   final Map<ToastType, Color> colorMap = {
     ToastType.success: Colors.green.shade500,

--- a/lib/src/gui/window_manager_alt.dart
+++ b/lib/src/gui/window_manager_alt.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -100,7 +101,7 @@ class _WindowCaptionAltState extends ConsumerState<WindowCaptionAlt> with Window
           ),
           if (isFeedbackAvailable(ref))
             WindowCaptionButtonAlt(
-              icon: Icon(Icons.feedback_outlined, size: 20, color: theme.colorScheme.onSurface),
+              icon: Icon(Symbols.feedback_rounded, size: 20, color: theme.colorScheme.onSurface),
               tooltip: "app.feedback.tooltip".tr(),
               onPressed: () {
                 showFeedbackDialog(context);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -956,6 +956,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_symbols_icons:
+    dependency: "direct main"
+    description:
+      name: material_symbols_icons
+      sha256: "10a74aaa9e566c92f8aa14809d2dd78156fb93743348ebffec0345c38eb35706"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2928.1"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   version: ^3.0.2
   window_manager: ^0.5.1
   yaml: ^3.1.1
+  material_symbols_icons: ^4.2928.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Migrate the app's iconography from Material Icons to Material Symbols (Rounded)
and refine a few chara_detail UI details along the way.

- Swap every `Icons.*` usage for the matching `Symbols.*_rounded` glyph across
  the navigation rail, dialogs, chips, toasts, and the script-cell icon map.
  Material Symbols default to `fill: 0` (outline), so the script `_iconMap`
  comments that note "(outline)" stay accurate; the rating stars opt into
  `fill: 1` explicitly.
- Re-apply icon `weight` on the `NavigationRailTheme`'s own icon themes, since
  `NavigationRail` replaces (does not merge) the ambient `IconTheme` for its
  destinations.
- Refine the empty logic-container slot: render a dashed, rounded box with a
  `place_item` glyph, share that box between the live drop slot and the dragged
  placeholder, align the logic-operator label height to sibling chips, and keep
  the empty slot's trailing margin.
- List the Cell `icon` keys in the script name lookup so a user can match an
  `icon` key to its glyph (rendered as the chip avatar).

## Notes

- All referenced `Symbols.*` names were verified to exist in
  `material_symbols_icons` 4.2928.1.
- In the About settings group, `resolve_inheritance` intentionally shares the
  `refresh` glyph, and dropping `isThreeLine` aligns it with its sibling rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
