### PR TITLE
feat(skills): add sentry-issues skill for triaging error reports

### DIFF
--- a/.claude/skills/sentry-issues/SKILL.md
+++ b/.claude/skills/sentry-issues/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: sentry-issues
+description: >-
+  Fetch and inspect this app's Sentry error reports from the command line via
+  the Sentry REST API. Use whenever the user wants to check, look at, triage, or
+  pull umacapture's Sentry issues, crash reports, or error logs — e.g. "check
+  Sentry", "what errors are users hitting", "show the latest crashes", "is there
+  anything new on release X", or when they want the full stack trace / tags /
+  context of a specific issue. Covers the production and debug projects, the
+  release-version filter, and the difference between readable Dart exceptions and
+  unsymbolicated native crashes.
+---
+
+# Inspecting umacapture's Sentry issues
+
+The app reports errors to Sentry (configured in `lib/src/core/sentry_util.dart`).
+This skill pulls those reports over the REST API so you can triage them here
+instead of opening the web UI. There is no Sentry MCP connector installed; the
+REST API plus an auth token is the supported path.
+
+## Project coordinates
+
+These are baked into the helper script, but keep them visible for ad-hoc calls:
+
+| What | Value |
+|---|---|
+| Region | `sentry.io` (US) |
+| Org id | `1367286` |
+| **release** project (production, `kReleaseMode`) | `6670477` |
+| **debug** project (`kDebugMode`) | `6668087` |
+
+The numeric ids work directly in API paths, so no org/project *slug* lookup is
+needed. Default to the **release** project — that's where real users' errors land.
+
+## Default scope: latest release build only
+
+Unless the user asks otherwise, **only fetch issues for the latest release
+build**. Old versions accumulate stale issues that users on the current build can
+no longer hit, so an unscoped list is mostly noise and misleads triage. The helper
+script does this automatically: `list` resolves the newest release from Sentry's
+releases endpoint (newest-first by creation date) and applies `release:<version>`,
+switching to an all-time window so a fresh build isn't hidden by the 14d default.
+
+Widen the scope only when the user explicitly wants it:
+
+- `--all-releases` — every version (the raw, unscoped list).
+- `--release <version>` — pin one specific version.
+- an explicit `release:` token inside `--query` — treated as the user's choice and
+  left untouched.
+
+## Auth token
+
+Every call needs a Sentry auth token. It is **not** in the repo. By convention it
+lives at `~/.sentry_token` (a single line, outside the repository, gitignored by
+virtue of being in `$HOME`). Reading it from a file keeps the secret out of the
+command line and shell history.
+
+- If the file is missing or empty, ask the user to create one: Sentry → Settings →
+  Auth Tokens, scopes `event:read` + `project:read` (add `org:read` only if you
+  need org-wide queries). Read-only is enough for everything in this skill.
+- Uploading debug symbols (see below) needs a *different*, write-capable token —
+  out of scope here.
+
+## Quick start — use the helper script
+
+The script is stdlib-only and runs under `uv run --no-project` (this repo's
+convention is to invoke Python through `uv`, never bare `python`). From the repo
+root:
+
+```bash
+# Default: most-frequent unresolved issues on the LATEST release build only
+uv run --no-project .claude/skills/sentry-issues/scripts/sentry_issues.py list
+
+# Newest issues (latest release), with permalinks + numeric ids to drill in
+uv run --no-project .claude/skills/sentry-issues/scripts/sentry_issues.py \
+  list --sort new --links
+
+# Widen to every release version (the raw, unscoped list)
+uv run --no-project .claude/skills/sentry-issues/scripts/sentry_issues.py \
+  list --all-releases
+
+# Pin a specific older release
+uv run --no-project .claude/skills/sentry-issues/scripts/sentry_issues.py \
+  list --release 0.0.10
+
+# Drill into one issue: latest event's meta, tags, contexts, and stack trace
+uv run --no-project .claude/skills/sentry-issues/scripts/sentry_issues.py \
+  event 7569943159 --top 30
+```
+
+Pass `--json` to either subcommand when you need the raw payload to extract
+fields the table view omits. Run with `-h` for all options.
+
+## Useful search queries
+
+The `--query` value is standard Sentry issue search:
+
+- `is:unresolved` — open issues (the default).
+- `is:unresolved release:0.1.0` — open issues seen in a given app version. Pair
+  with `--stats-period ""` so a brand-new release isn't hidden by the 14d window.
+- `is:unhandled` — crashes/uncaught errors only.
+- `level:fatal` — fatal-level events.
+- `firstSeen:-7d` — regressions/new issues from the last week.
+
+`--sort` accepts `freq` (most events), `date` (most recent), `new`, `user`.
+
+## Reading the results
+
+**Two kinds of events, and they read very differently:**
+
+- **Dart exceptions** (most issues) arrive with a real Dart stack trace —
+  `package:umacapture/.../file.dart:line`. These are directly actionable; map the
+  frame to the source file and investigate. This app does **not** obfuscate, so no
+  symbol step is needed.
+- **Native crashes** (`platform: native`, `mechanism: minidump`, e.g. an
+  `EXCEPTION_ACCESS_VIOLATION`) arrive as raw addresses. Only OS modules
+  (`ntdll`, `USER32`, `dxgi`, …) resolve to names automatically via Microsoft's
+  public symbol server; `umacapture.exe` and `flutter_windows.dll` frames stay as
+  `?` because **their debug symbols (PDBs) were never uploaded to Sentry**. You
+  can still read the surrounding OS frames to infer *what* the app was doing
+  (e.g. window teardown, graphics release), but not the exact app function.
+  Symbolicating app frames would require uploading the matching build's PDBs via
+  `sentry-cli debug-files upload` — there is currently no such step in the release
+  pipeline, and it's only worth setting up if native crashes become frequent.
+
+**Version tagging is consistent.** Both the Dart side (`assets/version_info.json`)
+and the native side (`windows/runner/Runner.rc` `FLUTTER_VERSION`) derive from the
+pubspec `version` at build time, so a given build reports the same release on both
+paths. If you see two events with different release strings, that's two different
+app builds/users — not a tagging bug.
+
+## Ad-hoc curl (when the script doesn't cover it)
+
+```bash
+TOKEN=$(tr -d ' \t\r\n' < ~/.sentry_token)
+# Resolve the latest release (newest-first), then scope issues to it (all-time):
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://sentry.io/api/0/projects/1367286/6670477/releases/?per_page=1"
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://sentry.io/api/0/projects/1367286/6670477/issues/?query=is:unresolved%20release:0.1.0&statsPeriod=&sort=freq"
+# latest event of an issue:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://sentry.io/api/0/issues/<ISSUE_ID>/events/latest/"
+```
+
+Gotchas worth remembering when going manual:
+
+- **`statsPeriod` only accepts `""`, `"24h"`, `"14d"`.** Anything else (e.g.
+  `90d`) returns HTTP 400. For longer ranges, filter by `release:` / `firstSeen:`
+  with an empty period instead.
+- **`jq` is not installed on this machine.** Parse JSON with
+  `uv run --no-project python` (write the response to a file first, then read it
+  with a *relative* path — Windows-native Python resolves a Git-Bash `/tmp/...`
+  absolute path to the wrong place).
+- Event payloads for native crashes are large (~0.5 MB with debug images). Save to
+  a file and extract fields rather than dumping inline.

--- a/.claude/skills/sentry-issues/scripts/sentry_issues.py
+++ b/.claude/skills/sentry-issues/scripts/sentry_issues.py
@@ -1,0 +1,206 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Fetch and inspect umacapture Sentry issues via the REST API.
+
+Stdlib-only (urllib) so it runs under `uv run --no-project` with no install
+step. The auth token is read from a file outside the repo so it never lands in
+the command line, shell history, or the repository.
+
+Subcommands:
+  list    List issues for a project (filtered by a Sentry search query).
+  event   Dump the latest event of an issue: meta, tags, contexts, stack.
+
+Run `python sentry_issues.py <subcommand> -h` for per-command options.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+# umacapture Sentry coordinates (US region, sentry.io). The numeric IDs work
+# directly in the API path, so no org/project *slug* lookup is needed.
+ORG_ID = "1367286"
+PROJECTS = {
+    "release": "6670477",  # production build (kReleaseMode)
+    "debug": "6668087",  # kDebugMode build
+}
+DEFAULT_TOKEN_PATH = "~/.sentry_token"
+BASE = "https://sentry.io/api/0"
+
+# The issues endpoint only accepts these statsPeriod values; anything else is a
+# 400. Use "" (empty) to search across all time, which is what you want when
+# filtering by release: a fresh release has little history inside a 14d window.
+VALID_PERIODS = {"", "24h", "14d"}
+
+
+def read_token(path: str) -> str:
+    token_file = Path(os.path.expanduser(path))
+    if not token_file.exists():
+        sys.exit(f"Token file not found: {token_file}\nCreate it and paste a Sentry auth token inside.")
+    token = token_file.read_text(encoding="utf-8").strip()
+    if not token:
+        sys.exit(f"Token file is empty: {token_file}")
+    return token
+
+
+def api_get(url: str, token: str) -> object:
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        sys.exit(f"HTTP {exc.code} from {url}\n{body}")
+    except urllib.error.URLError as exc:
+        sys.exit(f"Network error for {url}: {exc.reason}")
+
+
+def latest_release(project: str, token: str) -> str | None:
+    """Return the newest release version for a project, or None if it has none.
+
+    Sentry's releases endpoint is ordered newest-first by creation date, so the
+    first entry is the latest build that has reported events.
+    """
+    url = f"{BASE}/projects/{ORG_ID}/{project}/releases/?per_page=1"
+    releases = api_get(url, token)
+    if isinstance(releases, list) and releases:
+        return releases[0].get("version")
+    return None
+
+
+def cmd_list(args: argparse.Namespace, token: str) -> None:
+    project = PROJECTS[args.project]
+
+    # By default we scope to the latest release build only: old versions
+    # accumulate stale issues that users on the current build can't hit, so an
+    # unscoped list is mostly noise. The user can widen this with --all-releases
+    # or pin a version with --release. An explicit release: token in --query also
+    # counts as "the user chose", so we don't override it.
+    query = args.query
+    release = None
+    if not args.all_releases and "release:" not in query:
+        release = args.release or latest_release(project, token)
+        if release:
+            query = f"{query} release:{release}".strip()
+
+    # A release filter needs an all-time window ("") — a fresh build has little
+    # history inside 14d. Only force this when the user didn't pick a period.
+    period = args.stats_period
+    if period is None:
+        period = "" if (release or "release:" in query) else "14d"
+    if period not in VALID_PERIODS:
+        sys.exit(f"--stats-period must be one of {sorted(VALID_PERIODS)!r} (Sentry constraint).")
+
+    url = (
+        f"{BASE}/projects/{ORG_ID}/{project}/issues/"
+        f"?query={urllib.parse.quote(query, safe='')}"
+        f"&statsPeriod={urllib.parse.quote(period, safe='')}&sort={args.sort}&limit={args.limit}"
+    )
+    issues = api_get(url, token)
+    if isinstance(issues, dict):
+        sys.exit(f"Unexpected response: {json.dumps(issues)[:300]}")
+    if args.json:
+        print(json.dumps(issues, ensure_ascii=False, indent=2))
+        return
+    scope = f"release {release}" if release else ("all releases" if args.all_releases else "query as given")
+    print(f"{len(issues)} issue(s) for project={args.project} [{scope}] query={query!r}\n")
+    for i in issues:
+        print(
+            f'{i["shortId"]:22} | {i["level"]:6} | n={i["count"]:>5} '
+            f'| first={i["firstSeen"][:10]} last={i["lastSeen"][:10]} '
+            f'| {i["title"][:70]}'
+        )
+    if issues and args.links:
+        print("\nLinks:")
+        for i in issues:
+            print(f'  {i["shortId"]:22} {i["permalink"]}  (id={i["id"]})')
+
+
+def _frames_table(frames: list, top: int) -> None:
+    # Sentry orders frames oldest-first, so the crash site is last. Show the
+    # innermost `top` frames; mark in-app frames with `*`.
+    for f in frames[-top:]:
+        pkg = (f.get("package") or "").replace("\\", "/").rsplit("/", 1)[-1]
+        name = f.get("function") or f.get("symbol") or "?"
+        line = f.get("lineNo")
+        mark = "*" if f.get("inApp") else " "
+        addr = f.get("instructionAddr") or ""
+        print(f'  {mark} {pkg:26} {name}  {("L" + str(line)) if line else ""} {addr}')
+
+
+def cmd_event(args: argparse.Namespace, token: str) -> None:
+    ref = args.event_id or "latest"
+    url = f"{BASE}/issues/{args.issue_id}/events/{ref}/"
+    d = api_get(url, token)
+    if args.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2))
+        return
+
+    print("=== meta ===")
+    for k in ("eventID", "dateCreated", "platform"):
+        print(f"{k}: {d.get(k)}")
+    rel = d.get("release")
+    print("release:", rel.get("version") if isinstance(rel, dict) else rel)
+    print("title:", d.get("title"))
+
+    print("\n=== tags ===")
+    for t in d.get("tags", []) or []:
+        print(f'{t.get("key")} = {t.get("value")}')
+
+    print("\n=== contexts ===")
+    for k, v in (d.get("contexts", {}) or {}).items():
+        print(f"{k}: {json.dumps(v, ensure_ascii=False)[:400]}")
+
+    print("\n=== stack (innermost last) ===")
+    for entry in d.get("entries", []) or []:
+        if entry.get("type") == "exception":
+            for v in entry["data"]["values"]:
+                st = v.get("stacktrace") or {}
+                frames = st.get("frames") or []
+                print(f'\n# EXC {v.get("type")} | {v.get("value")} | frames={len(frames)}')
+                _frames_table(frames, args.top)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--token-path", default=DEFAULT_TOKEN_PATH, help=f"auth token file (default: {DEFAULT_TOKEN_PATH})")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    pl = sub.add_parser("list", help="list issues for a project")
+    pl.add_argument("--project", choices=PROJECTS, default="release")
+    pl.add_argument("--query", default="is:unresolved", help='Sentry search, e.g. "is:unresolved release:0.1.0"')
+    pl.add_argument("--release", help="pin a specific release version (default: auto-detect the latest)")
+    pl.add_argument("--all-releases", action="store_true", help="do not scope to a release; list every version")
+    pl.add_argument("--stats-period", default=None, help='"", "24h", or "14d" (default: 14d, or "" when release-scoped)')
+    pl.add_argument("--sort", default="freq", choices=["date", "new", "freq", "user"])
+    pl.add_argument("--limit", type=int, default=25)
+    pl.add_argument("--links", action="store_true", help="also print permalinks and numeric ids")
+    pl.add_argument("--json", action="store_true", help="raw JSON instead of a table")
+    pl.set_defaults(func=cmd_list)
+
+    pe = sub.add_parser("event", help="dump an issue's latest (or specific) event")
+    pe.add_argument("issue_id", help="numeric issue id (from `list --links`)")
+    pe.add_argument("--event-id", help="specific event id (default: latest)")
+    pe.add_argument("--top", type=int, default=25, help="number of innermost stack frames to show")
+    pe.add_argument("--json", action="store_true", help="raw JSON instead of a summary")
+    pe.set_defaults(func=cmd_event)
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    token = read_token(args.token_path)
+    args.func(args, token)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a `sentry-issues` skill that documents and tools the workflow for fetching umacapture's Sentry error reports over the REST API (no MCP connector is installed).

- **`scripts/sentry_issues.py`** — a stdlib-only helper runnable via `uv run --no-project`, with two subcommands:
  - `list`: issues for a project, scoped by default to the latest release build (auto-resolved from the releases endpoint) so stale issues from old versions don't drown out what current users actually hit; `--all-releases` / `--release` override the scope.
  - `event`: dump an issue's latest event (meta, tags, contexts, stack).
- **`SKILL.md`** — records the project coordinates, the auth-token convention (`~/.sentry_token`, read-only scopes), the `statsPeriod` constraint, the lack of `jq`, and how native minidump crashes differ from Dart exceptions.

## Notes

- Rebased onto current `develop` (includes #100).
- Documentation/tooling only — no app code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
