### PR TITLE
refactor(chara_detail): update the data table incrementally instead of rebuilding

### DIFF
--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -883,16 +883,7 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   }
 
   /// Indexes [rows] by record id, skipping rows with no record (last id wins).
-  Map<String, TrinaRow> _rowsById(Iterable<TrinaRow> rows) {
-    final byId = <String, TrinaRow>{};
-    for (final row in rows) {
-      final id = recordIdOf(row);
-      if (id != null) {
-        byId[id] = row;
-      }
-    }
-    return byId;
-  }
+  Map<String, TrinaRow> _rowsById(Iterable<TrinaRow> rows) => {for (final row in rows) ?recordIdOf(row): row};
 
   /// Snapshots each row's current [TrinaRow.sortIdx] keyed by record id.
   ///

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -867,16 +867,26 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   /// The record of the currently highlighted (current) row, or null when no row
   /// is selected. Captured before a reconcile so the highlight can be restored
   /// onto the same record afterwards via [restoreCurrentRecord].
-  CharaDetailRecord? get currentRecord => currentRow?.getUserData<CharaDetailRecord>();
+  ///
+  /// Resolved from [currentCell] (the actually-selected cell's own row), not from
+  /// `currentRow` (== `refRows[currentRowIdx]`). With pinned (frozen) rows present
+  /// a tap stores a *display* index in `currentRowIdx` (frozen rows render in a
+  /// separate top block, shifting the scrollable rows' display indices) while
+  /// `refRows` keeps its own order, so `refRows[currentRowIdx]` resolves to the
+  /// wrong record. `currentCell.row` is always the tapped row — the same
+  /// unambiguous path trina's own [currentColumn]/[currentColumnField] use.
+  CharaDetailRecord? get currentRecord => currentCell?.row.getUserData<CharaDetailRecord>();
 
   /// The record id carried by [row], or null when the row has no record attached.
   String? recordIdOf(TrinaRow row) => row.getUserData<CharaDetailRecord>()?.id;
 
   /// Whether [row] is the currently highlighted row, matched by record id.
   ///
-  /// Index comparison is unsafe here: with pinned (frozen) rows present,
-  /// [currentRowIdx] indexes the full refRows while render-time row indices live
-  /// in a separate frozen block, so the two index spaces disagree.
+  /// Index comparison is unsafe here: with pinned (frozen) rows present a tap
+  /// stores a *display* index in [currentRowIdx] (frozen rows render in a
+  /// separate top block) while a reconcile recomputes it against refRows, so the
+  /// two index spaces disagree. Matching [currentRecord] (resolved from the live
+  /// [currentCell]) by id sidesteps both.
   bool isCurrentRecord(TrinaRow row) {
     final id = currentRecord?.id;
     return id != null && recordIdOf(row) == id;

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -894,10 +894,20 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     return byId;
   }
 
+  /// Snapshots each row's current [TrinaRow.sortIdx] keyed by record id.
+  ///
+  /// Captured as plain ints *before* an insert/append mutates the rows in place,
+  /// so the canonical order can be reapplied afterwards via [applyCanonicalSortIdx].
+  Map<String, int> _sortIdxById(Iterable<TrinaRow> rows) => {for (final row in rows) ?recordIdOf(row): row.sortIdx};
+
   /// Re-selects the row for [record] so the row highlight survives a rebuild that
   /// dropped the current cell (e.g. a structural column change clears it). No-op
   /// when the record is already current or no longer present (filtered out).
-  void restoreCurrentRecord(CharaDetailRecord? record, {String? ignoreField}) {
+  ///
+  /// Prefers the cell in [preferField] (the column the user had selected) so the
+  /// current cell stays in the same column; falls back to the first cell whose
+  /// key is not [ignoreField] (e.g. the checkbox) when that column is gone.
+  void restoreCurrentRecord(CharaDetailRecord? record, {String? preferField, String? ignoreField}) {
     if (record == null || currentRecord?.id == record.id) {
       return;
     }
@@ -907,10 +917,15 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
         continue;
       }
       TrinaCell? cell;
-      for (final entry in row.cells.entries) {
-        if (entry.key != ignoreField) {
-          cell = entry.value;
-          break;
+      if (preferField != null && preferField != ignoreField) {
+        cell = row.cells[preferField];
+      }
+      if (cell == null) {
+        for (final entry in row.cells.entries) {
+          if (entry.key != ignoreField) {
+            cell = entry.value;
+            break;
+          }
         }
       }
       if (cell != null) {
@@ -956,25 +971,44 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     return true;
   }
 
-  /// Realigns each live row's [TrinaRow.sortIdx] to the value carried by the
-  /// matching fresh row in [nextRows] (matched by record id).
+  /// Reapplies the canonical [TrinaRow.sortIdx] captured in [sortIdxById]
+  /// (keyed by record id) onto the live rows.
   ///
-  /// trina's insert/append paths overwrite an inserted row's sortIdx with a
+  /// trina's insert/append paths overwrite a touched row's sortIdx with a
   /// neighbour-derived sequential value, so after incremental (or appendRows)
   /// updates the app-assigned default order (`-capturedDate`, set in
   /// `_buildGrid`) drifts. trina's "reset sort" (the third sort toggle) reorders
-  /// by sortIdx, so without this the default order would come back wrong. The
-  /// fresh rows still hold the canonical sortIdx; copy it back onto the live rows
-  /// (same object identity).
-  void restoreCanonicalSortIdx(List<TrinaRow> nextRows, {Map<String, TrinaRow>? nextById}) {
-    final byId = nextById ?? _rowsById(nextRows);
+  /// by sortIdx, so without this the default order would come back wrong.
+  ///
+  /// The snapshot must be taken (via [_sortIdxById]) *before* the insert/append
+  /// runs: trina mutates `row.sortIdx` in place, and an inserted row is the very
+  /// fresh object, so reading sortIdx back off it afterwards would just echo the
+  /// already-overwritten value.
+  void applyCanonicalSortIdx(Map<String, int> sortIdxById) {
     for (final row in refRows.originalList) {
       final id = recordIdOf(row);
-      final next = id == null ? null : byId[id];
-      if (next != null) {
-        row.sortIdx = next.sortIdx;
+      final sortIdx = id == null ? null : sortIdxById[id];
+      if (sortIdx != null) {
+        row.sortIdx = sortIdx;
       }
     }
+  }
+
+  /// Replaces the whole live row set with [nextRows] in one O(n) pass, preserving
+  /// the canonical sort order and keeping the current cell position in sync.
+  ///
+  /// Shared by [reconcileRows]'s bulk-diff fallback and the widget's structural
+  /// column-change path. Snapshots the canonical sortIdx before append (see
+  /// [applyCanonicalSortIdx]) so a later "reset sort" reproduces the default order.
+  void replaceAllRows(List<TrinaRow> nextRows, {String? sortColumn, TrinaColumnSort sortOrder = TrinaColumnSort.none}) {
+    final sortIdxById = _sortIdxById(nextRows);
+    removeAllRows(notify: false);
+    appendRows(nextRows);
+    applyCanonicalSortIdx(sortIdxById);
+    if (sortColumn != null) {
+      sortColumnByField(sortColumn, sortOrder);
+    }
+    updateCurrentCellPosition(notify: false);
   }
 
   /// Applies [nextRows] to the live grid by record id, touching only the rows
@@ -990,7 +1024,10 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   /// reinsert) the per-row insert would be O(n^2), so it falls back to a
   /// wholesale replace: cheaper, at the cost of resetting scroll and selection
   /// (the caller restores the selection by record afterwards).
-  void reconcileRows(
+  ///
+  /// Returns whether any row was actually added, removed, or replaced, so the
+  /// caller can skip a column re-fit on a selection/sort-only reconcile.
+  bool reconcileRows(
     List<TrinaRow> nextRows, {
     String? sortColumn,
     TrinaColumnSort sortOrder = TrinaColumnSort.none,
@@ -1023,12 +1060,18 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     }
 
     final insertCount = nextRows.length - unchangedIds.length;
+    final changed = toRemove.isNotEmpty || insertCount > 0;
     if (insertCount > _bulkReconcileThreshold) {
       // Large diff: the incremental path buys nothing (most rows are reinserted)
       // yet pays O(n^2). Replace the whole row set in one O(n) pass instead.
-      removeAllRows(notify: false);
-      appendRows(nextRows);
+      // replaceAllRows snapshots/restores the canonical sortIdx and syncs the
+      // current cell position itself.
+      replaceAllRows(nextRows, sortColumn: sortColumn, sortOrder: sortOrder);
     } else {
+      // Snapshot the canonical sortIdx as plain ints before any insert mutates
+      // the rows in place; an inserted row is the fresh object itself, so reading
+      // its sortIdx back afterwards would echo the overwritten value.
+      final sortIdxById = _sortIdxById(nextRows);
       if (toRemove.isNotEmpty) {
         removeRows(toRemove, notify: false);
       }
@@ -1042,25 +1085,26 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
           insertRows(position, [row], notify: false);
         }
       }
+      // insert overwrote the canonical sortIdx of the touched rows; restore it
+      // from the pre-insert snapshot so a later "reset sort" reproduces the
+      // default order.
+      applyCanonicalSortIdx(sortIdxById);
+
+      if (sortColumn != null) {
+        sortColumnByField(sortColumn, sortOrder);
+      }
+      // removeRows/insertRows keep the current cell position in sync, but
+      // sortColumnByField reorders refRows without touching it — leaving the row
+      // highlight (driven by currentRowIdx) stranded on a stale index (often the
+      // top row). Recompute the position from the still-correct current cell so
+      // the highlight stays on the selected record.
+      updateCurrentCellPosition(notify: false);
     }
 
-    // insert/append overwrote the canonical sortIdx of the touched rows; restore
-    // it so a later "reset sort" reproduces the default order. Reuse the id map
-    // already built above instead of rebuilding it.
-    restoreCanonicalSortIdx(nextRows, nextById: nextById);
-
-    if (sortColumn != null) {
-      sortColumnByField(sortColumn, sortOrder);
-    }
-    // removeRows/insertRows keep the current cell position in sync, but
-    // sortColumnByField reorders refRows without touching it — leaving the row
-    // highlight (driven by currentRowIdx) stranded on a stale index (often the
-    // top row). Recompute the position from the still-correct current cell so the
-    // highlight stays on the selected record.
-    updateCurrentCellPosition(notify: false);
     if (notify) {
       notifyListeners();
     }
+    return changed;
   }
 }
 

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -855,6 +855,130 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   Iterable<CharaDetailRecord> getSortedRecords() {
     return refRows.map((e) => e.getUserData<CharaDetailRecord>()).nonNulls;
   }
+
+  /// The record of the currently highlighted (current) row, or null when no row
+  /// is selected. Captured before a reconcile so the highlight can be restored
+  /// onto the same record afterwards via [restoreCurrentRecord].
+  CharaDetailRecord? get currentRecord => currentRow?.getUserData<CharaDetailRecord>();
+
+  /// Re-selects the row for [record] so the row highlight survives a rebuild that
+  /// dropped the current cell (e.g. a structural column change clears it). No-op
+  /// when the record is already current or no longer present (filtered out).
+  void restoreCurrentRecord(CharaDetailRecord? record, {String? ignoreField}) {
+    if (record == null || currentRecord?.id == record.id) {
+      return;
+    }
+    for (var rowIdx = 0; rowIdx < refRows.length; rowIdx++) {
+      final row = refRows[rowIdx];
+      if (row.getUserData<CharaDetailRecord>()?.id != record.id) {
+        continue;
+      }
+      TrinaCell? cell;
+      for (final entry in row.cells.entries) {
+        if (entry.key != ignoreField) {
+          cell = entry.value;
+          break;
+        }
+      }
+      if (cell != null) {
+        setCurrentCell(cell, rowIdx, notify: false);
+      }
+      return;
+    }
+  }
+
+  /// Copies the renderer from each freshly built column onto the matching live
+  /// column (by field), so columns whose renderer captured a provider snapshot
+  /// (e.g. ratings) repaint with current data without a structural replace that
+  /// would drop their width and sort indicator.
+  ///
+  /// Cell-driven columns (e.g. memo, which reads the cell's user data) are
+  /// refreshed by [reconcileRows] replacing their row instead; copying their
+  /// stateless renderer here is harmless.
+  void refreshColumnRenderers(List<TrinaColumn> nextColumns) {
+    final nextByField = {for (final column in nextColumns) column.field: column};
+    for (final live in columns) {
+      final next = nextByField[live.field];
+      if (next != null) {
+        live.renderer = next.renderer;
+      }
+    }
+  }
+
+  /// Whether two rows for the same record render identically: same pinned state
+  /// and same value in every cell. Drives [reconcileRows]'s decision to leave a
+  /// row untouched (preserving scroll and identity) or replace it.
+  bool _rowContentEquals(TrinaRow a, TrinaRow b) {
+    if (a.frozen != b.frozen || a.cells.length != b.cells.length) {
+      return false;
+    }
+    for (final entry in b.cells.entries) {
+      if (a.cells[entry.key]?.value != entry.value.value) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Applies [nextRows] to the live grid by record id, touching only the rows
+  /// that actually changed.
+  ///
+  /// Rows whose record vanished or whose content/pinned state changed are
+  /// removed and the fresh row is reinserted at its position in [nextRows];
+  /// unchanged rows keep their identity so the scroll offset and current cell
+  /// survive a single cell edit. Assumes the column set is unchanged (the caller
+  /// handles structural column changes with a full rebuild).
+  void reconcileRows(List<TrinaRow> nextRows, {String? sortColumn, TrinaColumnSort sortOrder = TrinaColumnSort.none}) {
+    String? idOf(TrinaRow row) => row.getUserData<CharaDetailRecord>()?.id;
+
+    final live = refRows.originalList.toList();
+    final nextById = <String, TrinaRow>{};
+    for (final row in nextRows) {
+      final id = idOf(row);
+      if (id != null) {
+        nextById[id] = row;
+      }
+    }
+
+    // Rows to keep as-is. Everything else (gone, changed, or pinned-state
+    // changed) is removed below and reinserted fresh from nextRows.
+    final unchangedIds = <String>{};
+    final toRemove = <TrinaRow>[];
+    for (final row in live) {
+      final id = idOf(row);
+      final next = id == null ? null : nextById[id];
+      if (next != null && _rowContentEquals(row, next)) {
+        unchangedIds.add(id!);
+      } else {
+        toRemove.add(row);
+      }
+    }
+    if (toRemove.isNotEmpty) {
+      removeRows(toRemove, notify: false);
+    }
+
+    // Reinsert added/changed rows at their slot in the desired order. Processing
+    // ascending keeps each index valid: unchanged rows already sit at their
+    // final position once all earlier inserts have landed.
+    for (var position = 0; position < nextRows.length; position++) {
+      final row = nextRows[position];
+      final id = idOf(row);
+      if (id == null || !unchangedIds.contains(id)) {
+        insertRows(position, [row], notify: false);
+      }
+    }
+
+    if (sortColumn != null) {
+      sortColumnByField(sortColumn, sortOrder);
+    }
+    // removeRows/insertRows keep the current cell position in sync, but
+    // sortColumnByField reorders refRows without touching it — leaving the row
+    // highlight (driven by currentRowIdx) stranded on a stale index (often the
+    // top row). Recompute the position from the still-correct current cell so the
+    // highlight stays on the selected record.
+    updateCurrentCellPosition(notify: false);
+    notifyListeners();
+  }
 }
 
 extension TrinaCellExtension on TrinaCell {

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -869,6 +869,31 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   /// onto the same record afterwards via [restoreCurrentRecord].
   CharaDetailRecord? get currentRecord => currentRow?.getUserData<CharaDetailRecord>();
 
+  /// The record id carried by [row], or null when the row has no record attached.
+  String? recordIdOf(TrinaRow row) => row.getUserData<CharaDetailRecord>()?.id;
+
+  /// Whether [row] is the currently highlighted row, matched by record id.
+  ///
+  /// Index comparison is unsafe here: with pinned (frozen) rows present,
+  /// [currentRowIdx] indexes the full refRows while render-time row indices live
+  /// in a separate frozen block, so the two index spaces disagree.
+  bool isCurrentRecord(TrinaRow row) {
+    final id = currentRecord?.id;
+    return id != null && recordIdOf(row) == id;
+  }
+
+  /// Indexes [rows] by record id, skipping rows with no record (last id wins).
+  Map<String, TrinaRow> _rowsById(Iterable<TrinaRow> rows) {
+    final byId = <String, TrinaRow>{};
+    for (final row in rows) {
+      final id = recordIdOf(row);
+      if (id != null) {
+        byId[id] = row;
+      }
+    }
+    return byId;
+  }
+
   /// Re-selects the row for [record] so the row highlight survives a rebuild that
   /// dropped the current cell (e.g. a structural column change clears it). No-op
   /// when the record is already current or no longer present (filtered out).
@@ -878,7 +903,7 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     }
     for (var rowIdx = 0; rowIdx < refRows.length; rowIdx++) {
       final row = refRows[rowIdx];
-      if (row.getUserData<CharaDetailRecord>()?.id != record.id) {
+      if (recordIdOf(row) != record.id) {
         continue;
       }
       TrinaCell? cell;
@@ -895,10 +920,12 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     }
   }
 
-  /// Copies the renderer from each freshly built column onto the matching live
-  /// column (by field), so columns whose renderer captured a provider snapshot
-  /// (e.g. ratings) repaint with current data without a structural replace that
-  /// would drop their width and sort indicator.
+  /// Copies the renderer and title from each freshly built column onto the
+  /// matching live column (by field), so columns whose renderer captured a
+  /// provider snapshot (e.g. ratings) repaint with current data — and columns
+  /// whose title is provider-derived (e.g. a renamed rating/label set, whose
+  /// field is the stable spec id) show the new header — without a structural
+  /// replace that would drop their width and sort indicator.
   ///
   /// Cell-driven columns (e.g. memo, which reads the cell's user data) are
   /// refreshed by [reconcileRows] replacing their row instead; copying their
@@ -909,6 +936,7 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
       final next = nextByField[live.field];
       if (next != null) {
         live.renderer = next.renderer;
+        live.title = next.title;
       }
     }
   }
@@ -938,17 +966,11 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   /// by sortIdx, so without this the default order would come back wrong. The
   /// fresh rows still hold the canonical sortIdx; copy it back onto the live rows
   /// (same object identity).
-  void restoreCanonicalSortIdx(List<TrinaRow> nextRows) {
-    final nextById = <String, TrinaRow>{};
-    for (final row in nextRows) {
-      final id = row.getUserData<CharaDetailRecord>()?.id;
-      if (id != null) {
-        nextById[id] = row;
-      }
-    }
+  void restoreCanonicalSortIdx(List<TrinaRow> nextRows, {Map<String, TrinaRow>? nextById}) {
+    final byId = nextById ?? _rowsById(nextRows);
     for (final row in refRows.originalList) {
-      final id = row.getUserData<CharaDetailRecord>()?.id;
-      final next = id == null ? null : nextById[id];
+      final id = recordIdOf(row);
+      final next = id == null ? null : byId[id];
       if (next != null) {
         row.sortIdx = next.sortIdx;
       }
@@ -974,22 +996,24 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     TrinaColumnSort sortOrder = TrinaColumnSort.none,
     bool notify = true,
   }) {
-    String? idOf(TrinaRow row) => row.getUserData<CharaDetailRecord>()?.id;
+    // The incremental insert below uses indices into nextRows (the desired,
+    // unfiltered order). trina's insertRows interprets its index against the
+    // filtered refRows view, so the two only coincide while no trina-level
+    // column filter is active. The app filters upstream (in _buildGrid) and
+    // never enables trina's own filter, keeping refRows == originalList.
+    assert(
+      refRows.length == refRows.originalList.length,
+      'reconcileRows assumes no active trina-level filter (refRows == originalList).',
+    );
 
-    final nextById = <String, TrinaRow>{};
-    for (final row in nextRows) {
-      final id = idOf(row);
-      if (id != null) {
-        nextById[id] = row;
-      }
-    }
+    final nextById = _rowsById(nextRows);
 
     // Rows to keep as-is. Everything else (gone, changed, or pinned-state
     // changed) is removed below and reinserted fresh from nextRows.
     final unchangedIds = <String>{};
     final toRemove = <TrinaRow>[];
     for (final row in refRows.originalList) {
-      final id = idOf(row);
+      final id = recordIdOf(row);
       final next = id == null ? null : nextById[id];
       if (next != null && _rowContentEquals(row, next)) {
         unchangedIds.add(id!);
@@ -1013,7 +1037,7 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
       // at their final position once all earlier inserts have landed.
       for (var position = 0; position < nextRows.length; position++) {
         final row = nextRows[position];
-        final id = idOf(row);
+        final id = recordIdOf(row);
         if (id == null || !unchangedIds.contains(id)) {
           insertRows(position, [row], notify: false);
         }
@@ -1021,8 +1045,9 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     }
 
     // insert/append overwrote the canonical sortIdx of the touched rows; restore
-    // it so a later "reset sort" reproduces the default order.
-    restoreCanonicalSortIdx(nextRows);
+    // it so a later "reset sort" reproduces the default order. Reuse the id map
+    // already built above instead of rebuilding it.
+    restoreCanonicalSortIdx(nextRows, nextById: nextById);
 
     if (sortColumn != null) {
       sortColumnByField(sortColumn, sortOrder);

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -928,7 +928,12 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   /// unchanged rows keep their identity so the scroll offset and current cell
   /// survive a single cell edit. Assumes the column set is unchanged (the caller
   /// handles structural column changes with a full rebuild).
-  void reconcileRows(List<TrinaRow> nextRows, {String? sortColumn, TrinaColumnSort sortOrder = TrinaColumnSort.none}) {
+  void reconcileRows(
+    List<TrinaRow> nextRows, {
+    String? sortColumn,
+    TrinaColumnSort sortOrder = TrinaColumnSort.none,
+    bool notify = true,
+  }) {
     String? idOf(TrinaRow row) => row.getUserData<CharaDetailRecord>()?.id;
 
     final live = refRows.originalList.toList();
@@ -977,7 +982,9 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     // top row). Recompute the position from the still-correct current cell so the
     // highlight stays on the selected record.
     updateCurrentCellPosition(notify: false);
-    notifyListeners();
+    if (notify) {
+      notifyListeners();
+    }
   }
 }
 

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -768,6 +768,14 @@ final selectedColumnSpecEntryKeyProvider = Provider<String>((ref) {
   return ColumnPresetIndex.specEntryKey(index.selectedKey);
 });
 
+// Above this many rows to (re)insert, [reconcileRows] abandons the per-row diff
+// and replaces the whole row set in one pass. Each incremental insertRows is O(n)
+// in trina (it rescans the original list and rebuilds the filtered view), so a
+// large diff (e.g. a filter/search change that swaps most rows) would otherwise
+// be O(n^2); a wholesale removeAllRows + appendRows is O(n). Small edits stay
+// incremental so scroll offset and row identity are preserved.
+const _bulkReconcileThreshold = 32;
+
 extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   double _visualTextWidth(BuildContext context, String text, TextStyle style) {
     if (text.isEmpty) {
@@ -920,6 +928,33 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     return true;
   }
 
+  /// Realigns each live row's [TrinaRow.sortIdx] to the value carried by the
+  /// matching fresh row in [nextRows] (matched by record id).
+  ///
+  /// trina's insert/append paths overwrite an inserted row's sortIdx with a
+  /// neighbour-derived sequential value, so after incremental (or appendRows)
+  /// updates the app-assigned default order (`-capturedDate`, set in
+  /// `_buildGrid`) drifts. trina's "reset sort" (the third sort toggle) reorders
+  /// by sortIdx, so without this the default order would come back wrong. The
+  /// fresh rows still hold the canonical sortIdx; copy it back onto the live rows
+  /// (same object identity).
+  void restoreCanonicalSortIdx(List<TrinaRow> nextRows) {
+    final nextById = <String, TrinaRow>{};
+    for (final row in nextRows) {
+      final id = row.getUserData<CharaDetailRecord>()?.id;
+      if (id != null) {
+        nextById[id] = row;
+      }
+    }
+    for (final row in refRows.originalList) {
+      final id = row.getUserData<CharaDetailRecord>()?.id;
+      final next = id == null ? null : nextById[id];
+      if (next != null) {
+        row.sortIdx = next.sortIdx;
+      }
+    }
+  }
+
   /// Applies [nextRows] to the live grid by record id, touching only the rows
   /// that actually changed.
   ///
@@ -928,6 +963,11 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   /// unchanged rows keep their identity so the scroll offset and current cell
   /// survive a single cell edit. Assumes the column set is unchanged (the caller
   /// handles structural column changes with a full rebuild).
+  ///
+  /// When the diff is large (more than [_bulkReconcileThreshold] rows to
+  /// reinsert) the per-row insert would be O(n^2), so it falls back to a
+  /// wholesale replace: cheaper, at the cost of resetting scroll and selection
+  /// (the caller restores the selection by record afterwards).
   void reconcileRows(
     List<TrinaRow> nextRows, {
     String? sortColumn,
@@ -936,7 +976,6 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   }) {
     String? idOf(TrinaRow row) => row.getUserData<CharaDetailRecord>()?.id;
 
-    final live = refRows.originalList.toList();
     final nextById = <String, TrinaRow>{};
     for (final row in nextRows) {
       final id = idOf(row);
@@ -949,7 +988,7 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     // changed) is removed below and reinserted fresh from nextRows.
     final unchangedIds = <String>{};
     final toRemove = <TrinaRow>[];
-    for (final row in live) {
+    for (final row in refRows.originalList) {
       final id = idOf(row);
       final next = id == null ? null : nextById[id];
       if (next != null && _rowContentEquals(row, next)) {
@@ -958,20 +997,32 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
         toRemove.add(row);
       }
     }
-    if (toRemove.isNotEmpty) {
-      removeRows(toRemove, notify: false);
-    }
 
-    // Reinsert added/changed rows at their slot in the desired order. Processing
-    // ascending keeps each index valid: unchanged rows already sit at their
-    // final position once all earlier inserts have landed.
-    for (var position = 0; position < nextRows.length; position++) {
-      final row = nextRows[position];
-      final id = idOf(row);
-      if (id == null || !unchangedIds.contains(id)) {
-        insertRows(position, [row], notify: false);
+    final insertCount = nextRows.length - unchangedIds.length;
+    if (insertCount > _bulkReconcileThreshold) {
+      // Large diff: the incremental path buys nothing (most rows are reinserted)
+      // yet pays O(n^2). Replace the whole row set in one O(n) pass instead.
+      removeAllRows(notify: false);
+      appendRows(nextRows);
+    } else {
+      if (toRemove.isNotEmpty) {
+        removeRows(toRemove, notify: false);
+      }
+      // Reinsert added/changed rows at their slot in the desired order.
+      // Processing ascending keeps each index valid: unchanged rows already sit
+      // at their final position once all earlier inserts have landed.
+      for (var position = 0; position < nextRows.length; position++) {
+        final row = nextRows[position];
+        final id = idOf(row);
+        if (id == null || !unchangedIds.contains(id)) {
+          insertRows(position, [row], notify: false);
+        }
       }
     }
+
+    // insert/append overwrote the canonical sortIdx of the touched rows; restore
+    // it so a later "reset sort" reproduces the default order.
+    restoreCanonicalSortIdx(nextRows);
 
     if (sortColumn != null) {
       sortColumnByField(sortColumn, sortOrder);

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -67,6 +67,11 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
   late ThemeData _theme;
   SelectionPurpose? _purpose;
 
+  // Record id -> index within the pinned (frozen) block, rebuilt once per build
+  // from the watched grid. rowWrapper reads it O(1) per row instead of rescanning
+  // every frozen row (where().toList() + indexOf) on each row's paint.
+  Map<String, int> _pinnedIndexById = const {};
+
   void showPopup(BuildContext context, WidgetRef ref, Offset offset, CharaDetailRecord record, int initialPage) {
     final theme = Theme.of(context);
     final source = ref.read(recordSourceProvider);
@@ -259,7 +264,8 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     if (themeChanged) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         // Skip when the grid has since left the tree (empty columns): its
-        // stateManager is then disposed and notifyListeners would throw.
+        // stateManager is then disposed, so notifying it would be a wasted no-op
+        // on a stale manager.
         if (mounted && _loaded) {
           stateManager.notifyListeners();
         }
@@ -277,6 +283,14 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
       _loaded = false;
       return Container();
     }
+    // Index the pinned (frozen) rows once per build so rowWrapper can look up a
+    // row's position in the frozen block in O(1). build() re-runs on every grid
+    // change (it watches currentGridProvider), so this stays in sync with the
+    // rows _reconcile applies.
+    final pinnedRows = grid.rows.where((row) => row.frozen == TrinaRowFrozen.start).toList();
+    _pinnedIndexById = {
+      for (var i = 0; i < pinnedRows.length; i++) ?pinnedRows[i].getUserData<CharaDetailRecord>()?.id: i,
+    };
     return Expanded(
       child: Stack(
         alignment: Alignment.center,
@@ -311,9 +325,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                     // the full refRows while rowContext.rowIdx is a display index
                     // (frozen rows render in a separate block), so an index compare
                     // would highlight the wrong row.
-                    final currentId = rowContext.stateManager.currentRecord?.id;
-                    final rowId = rowContext.row.getUserData<CharaDetailRecord>()?.id;
-                    if (currentId != null && rowId == currentId) {
+                    if (rowContext.stateManager.isCurrentRecord(rowContext.row)) {
                       return theme.colorScheme.primaryContainer;
                     }
                     return rowContext.rowIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor;
@@ -334,18 +346,14 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                     // a normal-weight separator between pinned rows, and a single
                     // thick rule only at the boundary with the scrollable rows.
                     if (rowData.frozen == TrinaRowFrozen.start) {
-                      final pinned = stateManager.refRows.originalList
-                          .where((r) => r.frozen == TrinaRowFrozen.start)
-                          .toList();
-                      final pinnedIdx = pinned.indexOf(rowData);
+                      // Position within the frozen block, precomputed in build().
+                      final rowId = rowData.getUserData<CharaDetailRecord>()?.id;
+                      final pinnedIdx = rowId == null ? -1 : (_pinnedIndexById[rowId] ?? -1);
                       if (pinnedIdx >= 0) {
-                        final isLast = pinnedIdx == pinned.length - 1;
+                        final isLast = pinnedIdx == _pinnedIndexById.length - 1;
                         // Match the highlighted row by record id (see rowColorCallback):
                         // currentRowIdx and pinnedIdx live in different index spaces.
-                        final currentId = stateManager.currentRecord?.id;
-                        final isCurrent =
-                            currentId != null && rowData.getUserData<CharaDetailRecord>()?.id == currentId;
-                        final Color background = isCurrent
+                        final Color background = stateManager.isCurrentRecord(rowData)
                             ? theme.colorScheme.primaryContainer
                             : (pinnedIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor);
                         final separator = isLast
@@ -441,12 +449,13 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                     // updates itself. Nudge the grid to repaint its rows (this
                     // reuses the existing rows, so checked state is preserved).
                     WidgetsBinding.instance.addPostFrameCallback((_) {
-                      // The page may be torn down before the next frame; skip the
-                      // notify rather than poke a disposed stateManager.
-                      if (!mounted) {
-                        return;
+                      // The grid may leave the tree before the next frame (page torn
+                      // down, or columns emptied, which disposes the stateManager).
+                      // Guard on _loaded too — matching the other imperative
+                      // post-frame callbacks — so a stale manager is never poked.
+                      if (mounted && _loaded) {
+                        stateManager.notifyListeners();
                       }
-                      stateManager.notifyListeners();
                     });
                   },
                   onSelected: (TrinaGridOnSelectedEvent event) {

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -192,29 +192,32 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
 
   /// Pushes a freshly built [Grid] into the live grid instead of recreating it.
   ///
-  /// Columns are structurally replaced only when the field set/order changed
-  /// (e.g. preset/column edits, entering or leaving selection mode); otherwise
-  /// their widths and sort indicators are preserved. Rows are swapped wholesale,
-  /// then the saved sort is reapplied. The finer per-row diff that keeps scroll
-  /// and selection in place is a separate follow-up (stage B).
+  /// When the column set/order changed (preset/column edits, entering or leaving
+  /// selection mode), the columns are structurally replaced and the rows rebuilt
+  /// wholesale. Otherwise columns keep their width and sort indicator — only
+  /// their renderers are refreshed (for columns whose renderer captured provider
+  /// data, e.g. ratings) — and the rows are diffed by record id so an unchanged
+  /// row keeps its identity, preserving the scroll offset across a cell edit.
   void _reconcile(Grid next) {
     if (!_loaded) {
       _pending = next;
       return;
     }
+    // Remember the highlighted row's record so the selection survives the update.
+    // The row diff keeps an unchanged row's identity on its own, but a structural
+    // column change rebuilds every row and clears the current cell.
+    final selectedRecord = stateManager.currentRecord;
     final columnsChanged = _appliedGrid == null || !_sameColumns(_appliedGrid!.columns, next.columns);
-    // Clear rows before swapping columns so the column replace operates on an
-    // empty row set (no wasted per-row cell fill/remove, no transient mismatch).
-    stateManager.removeAllRows(notify: false);
     if (columnsChanged) {
+      // Clear rows first so the column replace operates on an empty row set (no
+      // wasted per-row cell fill/remove, no transient cell/column mismatch).
+      stateManager.removeAllRows(notify: false);
       stateManager.removeColumns(stateManager.columns.toList());
       stateManager.insertColumns(0, next.columns);
-    }
-    stateManager.appendRows(next.rows);
-    if (sortColumn != null) {
-      stateManager.sortColumnByField(sortColumn!, sortOrder);
-    }
-    if (columnsChanged) {
+      stateManager.appendRows(next.rows);
+      if (sortColumn != null) {
+        stateManager.sortColumnByField(sortColumn!, sortOrder);
+      }
       // autoFitColumns measures via gridKey.currentContext, which needs the new
       // columns laid out first, so defer it one frame.
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -222,7 +225,13 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
           stateManager.autoFitColumns();
         }
       });
+    } else {
+      stateManager.refreshColumnRenderers(next.columns);
+      stateManager.reconcileRows(next.rows, sortColumn: sortColumn, sortOrder: sortOrder);
     }
+    // Re-highlight the same record (skips the checkbox cell so the highlight
+    // lands on a data cell). No-op when it is still current or now filtered out.
+    stateManager.restoreCurrentRecord(selectedRecord, ignoreField: checkColumnField);
     _appliedGrid = next;
     stateManager.notifyListeners();
   }
@@ -334,6 +343,11 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                   },
                   configuration: TrinaGridConfiguration(
                     enterKeyAction: TrinaGridEnterKeyAction.toggleEditing,
+                    // Never auto-select the first row. In select mode TrinaGrid
+                    // otherwise highlights row 0 on (re)mount whenever no cell is
+                    // current, which would override the user's row selection and
+                    // make it appear to jump to the top.
+                    enableAutoSelectFirstRow: false,
                     scrollbar: const TrinaGridScrollbarConfig(isAlwaysShown: true, radius: 8, thickness: 12),
                     style: TrinaGridStyleConfig(
                       enableCellBorderVertical: false,
@@ -792,6 +806,12 @@ class CharaDetailDataTableLoaderLayer extends ConsumerWidget {
     final theme = Theme.of(context);
     final loader = ref.watch(charaDetailInitialDataLoader);
     return loader.when(
+      // A background reload of an upstream loader (path/module/record storage)
+      // must not tear down the whole table subtree: doing so remounts the grid,
+      // resetting its scroll offset and dropping the row selection. Keep showing
+      // the existing data across reloads; only the very first load shows the
+      // spinner (no previous value to keep).
+      skipLoadingOnReload: true,
       loading: () => loading(),
       error: (errorMessage, stackTrace) => error(errorMessage, stackTrace, theme),
       data: (_) => data(context, ref),

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -4,7 +4,6 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
 import 'package:trina_grid/trina_grid.dart';
-import 'package:uuid/uuid.dart';
 
 import '/src/chara_detail/chara_detail_record.dart';
 import '/src/chara_detail/spec/base.dart';
@@ -46,6 +45,27 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
   String? sortColumn;
   TrinaColumnSort sortOrder = TrinaColumnSort.none;
   late TrinaGridStateManager stateManager;
+
+  // The grid widget is kept alive across rebuilds (stable key); all data changes
+  // are pushed into the live stateManager imperatively via [_reconcile] instead
+  // of recreating the grid. TrinaGrid reads columns/rows only at init time
+  // (didUpdateWidget ignores them), so a fresh build's args would otherwise be
+  // dropped.
+  bool _loaded = false;
+
+  // The grid contents last pushed into stateManager. Used to detect whether the
+  // column set changed (and thus needs a structural replace) on the next update.
+  Grid? _appliedGrid;
+
+  // A grid update that arrived before onLoaded captured the stateManager. Applied
+  // once the grid is ready.
+  Grid? _pending;
+
+  // The current theme and selection purpose, mirrored here so the long-lived
+  // rowColorCallback/rowWrapper closures (captured once at grid init) read fresh
+  // values through `this` instead of stale locals captured at first build.
+  late ThemeData _theme;
+  SelectionPurpose? _purpose;
 
   void showPopup(BuildContext context, WidgetRef ref, Offset offset, CharaDetailRecord record, int initialPage) {
     final theme = Theme.of(context);
@@ -154,6 +174,59 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     );
   }
 
+  /// Whether two column lists describe the same columns in the same order.
+  ///
+  /// Compared by field id (not object identity): the provider hands back fresh
+  /// TrinaColumn objects on every rebuild, so identity would always differ.
+  bool _sameColumns(List<TrinaColumn> a, List<TrinaColumn> b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (var i = 0; i < a.length; i++) {
+      if (a[i].field != b[i].field) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Pushes a freshly built [Grid] into the live grid instead of recreating it.
+  ///
+  /// Columns are structurally replaced only when the field set/order changed
+  /// (e.g. preset/column edits, entering or leaving selection mode); otherwise
+  /// their widths and sort indicators are preserved. Rows are swapped wholesale,
+  /// then the saved sort is reapplied. The finer per-row diff that keeps scroll
+  /// and selection in place is a separate follow-up (stage B).
+  void _reconcile(Grid next) {
+    if (!_loaded) {
+      _pending = next;
+      return;
+    }
+    final columnsChanged = _appliedGrid == null || !_sameColumns(_appliedGrid!.columns, next.columns);
+    // Clear rows before swapping columns so the column replace operates on an
+    // empty row set (no wasted per-row cell fill/remove, no transient mismatch).
+    stateManager.removeAllRows(notify: false);
+    if (columnsChanged) {
+      stateManager.removeColumns(stateManager.columns.toList());
+      stateManager.insertColumns(0, next.columns);
+    }
+    stateManager.appendRows(next.rows);
+    if (sortColumn != null) {
+      stateManager.sortColumnByField(sortColumn!, sortOrder);
+    }
+    if (columnsChanged) {
+      // autoFitColumns measures via gridKey.currentContext, which needs the new
+      // columns laid out first, so defer it one frame.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          stateManager.autoFitColumns();
+        }
+      });
+    }
+    _appliedGrid = next;
+    stateManager.notifyListeners();
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -161,6 +234,24 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     // Drives the per-row overlay's color/label so a checked row reads as either
     // "archive" or "export". Non-null whenever the checkbox column is present.
     final purpose = ref.watch(selectionModeProvider);
+    // Mirror the latest theme/purpose so the grid's long-lived row callbacks read
+    // current values. A theme change won't touch currentGridProvider, so nudge the
+    // live grid to repaint the rows with the new colors.
+    final themeChanged = _loaded && _theme != theme;
+    _theme = theme;
+    _purpose = purpose;
+    if (themeChanged) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          stateManager.notifyListeners();
+        }
+      });
+    }
+    // Apply subsequent grid changes to the live stateManager rather than letting
+    // the watch above rebuild a fresh grid (TrinaGrid ignores changed columns/rows
+    // after init). The watch stays only to seed the initial grid and the empty
+    // checks below.
+    ref.listen(currentGridProvider, (_, next) => _reconcile(next));
     if (grid.columns.isEmpty) {
       return Container();
     }
@@ -179,8 +270,10 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
               return ColoredBox(
                 color: theme.colorScheme.surface,
                 child: TrinaGrid(
-                  // Since TrinaGrid have internal states, it won't rebuilt without changing the key each time.
-                  key: ValueKey(const Uuid().v4()),
+                  // Stable key keeps one grid (and its stateManager) alive across
+                  // rebuilds. Data changes are pushed in imperatively via
+                  // [_reconcile]; the columns/rows below only seed the initial grid.
+                  key: const ValueKey("chara_detail_grid"),
                   columns: grid.columns,
                   rows: grid.rows,
                   mode: TrinaGridMode.select,
@@ -190,6 +283,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                   // hasFocus, so it disappears otherwise. Setting rowColorCallback
                   // overrides the default striping, so reproduce it for other rows.
                   rowColorCallback: (rowContext) {
+                    final theme = _theme;
                     if (rowContext.stateManager.currentRowIdx == rowContext.rowIdx) {
                       return theme.colorScheme.primaryContainer;
                     }
@@ -199,6 +293,8 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                   // cells and is labeled "archive", so the destructive (lossy,
                   // irreversible) intent of the bulk selection is unmistakable.
                   rowWrapper: (context, rowWidget, rowData, stateManager) {
+                    final theme = _theme;
+                    final purpose = _purpose;
                     Widget row = rowWidget;
                     if (rowData.checked == true && purpose != null) {
                       row = _SelectionRowOverlay(purpose: purpose, child: row);
@@ -269,9 +365,18 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                   ),
                   onLoaded: (TrinaGridOnLoadedEvent event) {
                     stateManager = event.stateManager;
+                    _loaded = true;
+                    _appliedGrid = grid;
                     event.stateManager.autoFitColumns();
                     if (sortColumn != null) {
                       event.stateManager.sortColumnByField(sortColumn!, sortOrder);
+                    }
+                    // A grid change may have arrived before the stateManager was
+                    // ready; apply the latest one now.
+                    if (_pending != null) {
+                      final pending = _pending!;
+                      _pending = null;
+                      _reconcile(pending);
                     }
                   },
                   onRowSecondaryTap: (TrinaGridOnRowSecondaryTapEvent event) {

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -227,7 +227,9 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
       });
     } else {
       stateManager.refreshColumnRenderers(next.columns);
-      stateManager.reconcileRows(next.rows, sortColumn: sortColumn, sortOrder: sortOrder);
+      // _reconcile notifies once at the end (after restoreCurrentRecord), so the
+      // row diff and the restored selection land in a single repaint.
+      stateManager.reconcileRows(next.rows, sortColumn: sortColumn, sortOrder: sortOrder, notify: false);
     }
     // Re-highlight the same record (skips the checkbox cell so the highlight
     // lands on a data cell). No-op when it is still current or now filtered out.
@@ -251,7 +253,9 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     _purpose = purpose;
     if (themeChanged) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
+        // Skip when the grid has since left the tree (empty columns): its
+        // stateManager is then disposed and notifyListeners would throw.
+        if (mounted && _loaded) {
           stateManager.notifyListeners();
         }
       });
@@ -262,6 +266,10 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     // checks below.
     ref.listen(currentGridProvider, (_, next) => _reconcile(next));
     if (grid.columns.isEmpty) {
+      // The grid leaves the tree here, disposing its stateManager. Mark it
+      // unloaded so a grid update (via the listen above) or theme repaint won't
+      // touch the dead manager; onLoaded re-initializes it when columns return.
+      _loaded = false;
       return Container();
     }
     return Expanded(

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -195,6 +195,21 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     return true;
   }
 
+  /// Runs [action] after the current frame, but only while the grid is still
+  /// mounted and loaded.
+  ///
+  /// Every imperative grid poke is deferred this way: the grid may leave the tree
+  /// before the next frame (page torn down, or columns emptied — which disposes
+  /// the stateManager), so the guard keeps a stale/disposed manager from being
+  /// touched.
+  void _afterFrame(VoidCallback action) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _loaded) {
+        action();
+      }
+    });
+  }
+
   /// Pushes a freshly built [Grid] into the live grid instead of recreating it.
   ///
   /// When the column set/order changed (preset/column edits, entering or leaving
@@ -208,10 +223,12 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
       _pending = next;
       return;
     }
-    // Remember the highlighted row's record so the selection survives the update.
-    // The row diff keeps an unchanged row's identity on its own, but a structural
-    // column change rebuilds every row and clears the current cell.
+    // Remember the highlighted row's record (and which column the user had
+    // selected) so the selection survives the update. The row diff keeps an
+    // unchanged row's identity on its own, but a structural column change
+    // rebuilds every row and clears the current cell.
     final selectedRecord = stateManager.currentRecord;
+    final selectedField = stateManager.currentColumnField;
     final columnsChanged = _appliedGrid == null || !_sameColumns(_appliedGrid!.columns, next.columns);
     if (columnsChanged) {
       // Clear rows first so the column replace operates on an empty row set (no
@@ -219,31 +236,34 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
       stateManager.removeAllRows(notify: false);
       stateManager.removeColumns(stateManager.columns.toList());
       stateManager.insertColumns(0, next.columns);
-      stateManager.appendRows(next.rows);
-      // appendRows overwrites the canonical sortIdx; restore it so a later "reset
-      // sort" reproduces the default (-capturedDate) order.
-      stateManager.restoreCanonicalSortIdx(next.rows);
-      if (sortColumn != null) {
-        stateManager.sortColumnByField(sortColumn!, sortOrder);
-      }
+      // Replace the row set wholesale, restoring the canonical sortIdx and the
+      // current cell position (shared with reconcileRows' bulk fallback).
+      stateManager.replaceAllRows(next.rows, sortColumn: sortColumn, sortOrder: sortOrder);
       // autoFitColumns measures via gridKey.currentContext, which needs the new
-      // columns laid out first, so defer it one frame. Guard on _loaded too: the
-      // grid may have left the tree (empty columns) before the frame, disposing
-      // its stateManager.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && _loaded) {
-          stateManager.autoFitColumns();
-        }
-      });
+      // columns laid out first, so defer it one frame (the grid may have left the
+      // tree before the frame, disposing its stateManager — _afterFrame guards that).
+      _afterFrame(() => stateManager.autoFitColumns());
     } else {
       stateManager.refreshColumnRenderers(next.columns);
       // _reconcile notifies once at the end (after restoreCurrentRecord), so the
       // row diff and the restored selection land in a single repaint.
-      stateManager.reconcileRows(next.rows, sortColumn: sortColumn, sortOrder: sortOrder, notify: false);
+      final rowsChanged = stateManager.reconcileRows(
+        next.rows,
+        sortColumn: sortColumn,
+        sortOrder: sortOrder,
+        notify: false,
+      );
+      // Re-fit columns when the row set actually changed (e.g. a cell edited to a
+      // longer value), matching the pre-incremental behavior. Skipped on a
+      // selection/sort-only reconcile so widths don't churn needlessly.
+      if (rowsChanged) {
+        _afterFrame(() => stateManager.autoFitColumns());
+      }
     }
-    // Re-highlight the same record (skips the checkbox cell so the highlight
-    // lands on a data cell). No-op when it is still current or now filtered out.
-    stateManager.restoreCurrentRecord(selectedRecord, ignoreField: checkColumnField);
+    // Re-highlight the same record on the same column when possible (skips the
+    // checkbox cell so the highlight lands on a data cell). No-op when it is still
+    // current or now filtered out.
+    stateManager.restoreCurrentRecord(selectedRecord, preferField: selectedField, ignoreField: checkColumnField);
     _appliedGrid = next;
     stateManager.notifyListeners();
   }
@@ -262,14 +282,9 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     _theme = theme;
     _purpose = purpose;
     if (themeChanged) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        // Skip when the grid has since left the tree (empty columns): its
-        // stateManager is then disposed, so notifying it would be a wasted no-op
-        // on a stale manager.
-        if (mounted && _loaded) {
-          stateManager.notifyListeners();
-        }
-      });
+      // The grid's long-lived row callbacks read _theme; nudge them to repaint
+      // with the new colors (a theme change doesn't touch currentGridProvider).
+      _afterFrame(() => stateManager.notifyListeners());
     }
     // Apply subsequent grid changes to the live stateManager rather than letting
     // the watch above rebuild a fresh grid (TrinaGrid ignores changed columns/rows
@@ -448,15 +463,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                     // when the row list repaints — not when a single checkbox cell
                     // updates itself. Nudge the grid to repaint its rows (this
                     // reuses the existing rows, so checked state is preserved).
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      // The grid may leave the tree before the next frame (page torn
-                      // down, or columns emptied, which disposes the stateManager).
-                      // Guard on _loaded too — matching the other imperative
-                      // post-frame callbacks — so a stale manager is never poked.
-                      if (mounted && _loaded) {
-                        stateManager.notifyListeners();
-                      }
-                    });
+                    _afterFrame(() => stateManager.notifyListeners());
                   },
                   onSelected: (TrinaGridOnSelectedEvent event) {
                     try {

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -67,10 +67,13 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
   late ThemeData _theme;
   SelectionPurpose? _purpose;
 
-  // Record id -> index within the pinned (frozen) block, rebuilt once per build
-  // from the watched grid. rowWrapper reads it O(1) per row instead of rescanning
-  // every frozen row (where().toList() + indexOf) on each row's paint.
+  // Record id -> index within the pinned (frozen) block, rebuilt from the live
+  // grid by [_indexPinnedRows] after every reconcile. rowWrapper reads it O(1)
+  // per row instead of rescanning every frozen row (where().toList() + indexOf)
+  // on each row's paint. [_pinnedRowCount] is the frozen-row count (not the map
+  // size, which collapses on a duplicate/missing id) so isLast stays correct.
   Map<String, int> _pinnedIndexById = const {};
+  int _pinnedRowCount = 0;
 
   void showPopup(BuildContext context, WidgetRef ref, Offset offset, CharaDetailRecord record, int initialPage) {
     final theme = Theme.of(context);
@@ -210,6 +213,18 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     });
   }
 
+  /// Rebuilds the frozen-row index from the live grid, in the order the renderer
+  /// iterates (refRows.originalList filtered to frozen).
+  ///
+  /// Called after every reconcile (and the initial load) because a sort reorders
+  /// pinned rows among themselves, so the watched provider's row order is not a
+  /// reliable source. rowWrapper reads the resulting field at paint time.
+  void _indexPinnedRows() {
+    final pinnedRows = stateManager.refRows.originalList.where((row) => row.frozen == TrinaRowFrozen.start).toList();
+    _pinnedRowCount = pinnedRows.length;
+    _pinnedIndexById = {for (var i = 0; i < pinnedRows.length; i++) ?stateManager.recordIdOf(pinnedRows[i]): i};
+  }
+
   /// Pushes a freshly built [Grid] into the live grid instead of recreating it.
   ///
   /// When the column set/order changed (preset/column edits, entering or leaving
@@ -265,6 +280,9 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     // current or now filtered out.
     stateManager.restoreCurrentRecord(selectedRecord, preferField: selectedField, ignoreField: checkColumnField);
     _appliedGrid = next;
+    // Re-index the pinned block from the now-final live row order before the
+    // repaint so rowWrapper's O(1) lookup matches what the renderer draws.
+    _indexPinnedRows();
     stateManager.notifyListeners();
   }
 
@@ -298,14 +316,6 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
       _loaded = false;
       return Container();
     }
-    // Index the pinned (frozen) rows once per build so rowWrapper can look up a
-    // row's position in the frozen block in O(1). build() re-runs on every grid
-    // change (it watches currentGridProvider), so this stays in sync with the
-    // rows _reconcile applies.
-    final pinnedRows = grid.rows.where((row) => row.frozen == TrinaRowFrozen.start).toList();
-    _pinnedIndexById = {
-      for (var i = 0; i < pinnedRows.length; i++) ?pinnedRows[i].getUserData<CharaDetailRecord>()?.id: i,
-    };
     return Expanded(
       child: Stack(
         alignment: Alignment.center,
@@ -361,11 +371,12 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                     // a normal-weight separator between pinned rows, and a single
                     // thick rule only at the boundary with the scrollable rows.
                     if (rowData.frozen == TrinaRowFrozen.start) {
-                      // Position within the frozen block, precomputed in build().
-                      final rowId = rowData.getUserData<CharaDetailRecord>()?.id;
+                      // Position within the frozen block, precomputed by
+                      // [_indexPinnedRows] from the live row order.
+                      final rowId = stateManager.recordIdOf(rowData);
                       final pinnedIdx = rowId == null ? -1 : (_pinnedIndexById[rowId] ?? -1);
                       if (pinnedIdx >= 0) {
-                        final isLast = pinnedIdx == _pinnedIndexById.length - 1;
+                        final isLast = pinnedIdx == _pinnedRowCount - 1;
                         // Match the highlighted row by record id (see rowColorCallback):
                         // currentRowIdx and pinnedIdx live in different index spaces.
                         final Color background = stateManager.isCurrentRecord(rowData)
@@ -433,6 +444,9 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                     if (sortColumn != null) {
                       event.stateManager.sortColumnByField(sortColumn!, sortOrder);
                     }
+                    // Index the pinned block so frozen rows are styled on first
+                    // load; a later _pending reconcile reindexes (harmlessly).
+                    _indexPinnedRows();
                     // A grid change may have arrived before the stateManager was
                     // ready; apply the latest one now.
                     if (_pending != null) {

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -215,13 +215,18 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
       stateManager.removeColumns(stateManager.columns.toList());
       stateManager.insertColumns(0, next.columns);
       stateManager.appendRows(next.rows);
+      // appendRows overwrites the canonical sortIdx; restore it so a later "reset
+      // sort" reproduces the default (-capturedDate) order.
+      stateManager.restoreCanonicalSortIdx(next.rows);
       if (sortColumn != null) {
         stateManager.sortColumnByField(sortColumn!, sortOrder);
       }
       // autoFitColumns measures via gridKey.currentContext, which needs the new
-      // columns laid out first, so defer it one frame.
+      // columns laid out first, so defer it one frame. Guard on _loaded too: the
+      // grid may have left the tree (empty columns) before the frame, disposing
+      // its stateManager.
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
+        if (mounted && _loaded) {
           stateManager.autoFitColumns();
         }
       });
@@ -301,7 +306,14 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                   // overrides the default striping, so reproduce it for other rows.
                   rowColorCallback: (rowContext) {
                     final theme = _theme;
-                    if (rowContext.stateManager.currentRowIdx == rowContext.rowIdx) {
+                    // Detect the highlighted row by record id, not row index. With
+                    // pinned (frozen) rows present, currentRowIdx is an index into
+                    // the full refRows while rowContext.rowIdx is a display index
+                    // (frozen rows render in a separate block), so an index compare
+                    // would highlight the wrong row.
+                    final currentId = rowContext.stateManager.currentRecord?.id;
+                    final rowId = rowContext.row.getUserData<CharaDetailRecord>()?.id;
+                    if (currentId != null && rowId == currentId) {
                       return theme.colorScheme.primaryContainer;
                     }
                     return rowContext.rowIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor;
@@ -328,7 +340,12 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                       final pinnedIdx = pinned.indexOf(rowData);
                       if (pinnedIdx >= 0) {
                         final isLast = pinnedIdx == pinned.length - 1;
-                        final Color background = stateManager.currentRowIdx == pinnedIdx
+                        // Match the highlighted row by record id (see rowColorCallback):
+                        // currentRowIdx and pinnedIdx live in different index spaces.
+                        final currentId = stateManager.currentRecord?.id;
+                        final isCurrent =
+                            currentId != null && rowData.getUserData<CharaDetailRecord>()?.id == currentId;
+                        final Color background = isCurrent
                             ? theme.colorScheme.primaryContainer
                             : (pinnedIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor);
                         final separator = isLast

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -377,24 +377,43 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                       final pinnedIdx = rowId == null ? -1 : (_pinnedIndexById[rowId] ?? -1);
                       if (pinnedIdx >= 0) {
                         final isLast = pinnedIdx == _pinnedRowCount - 1;
-                        // Match the highlighted row by record id (see rowColorCallback):
-                        // currentRowIdx and pinnedIdx live in different index spaces.
-                        final Color background = stateManager.isCurrentRecord(rowData)
-                            ? theme.colorScheme.primaryContainer
-                            : (pinnedIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor);
+                        // The stripe and separator don't depend on the selection, so
+                        // compute them once; only the current-row highlight below is
+                        // recomputed per notify.
+                        final stripe = pinnedIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor;
                         final separator = isLast
                             ? BorderSide(color: theme.colorScheme.primary, width: 3)
                             : BorderSide(
                                 color: theme.focusColor,
                                 width: stateManager.configuration.style.cellHorizontalBorderWidth,
                               );
-                        row = DecoratedBox(
-                          decoration: BoxDecoration(color: background),
-                          child: DecoratedBox(
-                            position: DecorationPosition.foreground,
-                            decoration: BoxDecoration(border: Border(bottom: separator)),
-                            child: row,
-                          ),
+                        final bordered = DecoratedBox(
+                          position: DecorationPosition.foreground,
+                          decoration: BoxDecoration(border: Border(bottom: separator)),
+                          child: row,
+                        );
+                        // The current-row highlight must track currentCell changes.
+                        // Scrollable rows get this for free: their highlight is
+                        // painted inside TrinaBaseRow (via rowColorCallback), which
+                        // listens to the stateManager and rebuilds on every notify.
+                        // Frozen rows render with a transparent frozenRowColor and
+                        // bypass rowColorCallback, so this outer wrapper paints their
+                        // highlight — but it only re-runs on a body rebuild, leaving a
+                        // stale highlight when the selection moves to another row.
+                        // Listen to the stateManager here so the background repaints by
+                        // record id whenever the current row changes.
+                        row = ListenableBuilder(
+                          listenable: stateManager,
+                          builder: (context, child) {
+                            final background = stateManager.isCurrentRecord(rowData)
+                                ? theme.colorScheme.primaryContainer
+                                : stripe;
+                            return DecoratedBox(
+                              decoration: BoxDecoration(color: background),
+                              child: child,
+                            );
+                          },
+                          child: bordered,
                         );
                       }
                     }
@@ -419,7 +438,17 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                       // Keep the checked-row background neutral; the amber cue is
                       // drawn as an overlay via rowWrapper instead (see below).
                       rowCheckedColor: Colors.transparent,
-                      activatedColor: theme.colorScheme.primaryContainer,
+                      // Disable trina's built-in current-row fill. It highlights
+                      // the row where `currentRowIdx == widget.rowIdx`, comparing
+                      // a (tap-set) display index against each row's display
+                      // index. With pinned (frozen) rows that index space drifts
+                      // out of sync with refRows after a reconcile, so the
+                      // built-in fill lands on the wrong row — a second highlight
+                      // on top of the record-id one we paint in rowColorCallback/
+                      // rowWrapper. A transparent color fails trina's
+                      // `activatedColor.a > 0` guard, leaving our callback's color
+                      // in place, so the highlight is driven solely by record id.
+                      activatedColor: Colors.transparent,
                       // TrinaGrid paints frozen (pinned) rows from these and
                       // bypasses rowColorCallback for them, so its single
                       // frozenRowColor can't reproduce the normal alternating


### PR DESCRIPTION
## Summary

Reworks the chara_detail data table so data changes are pushed into the live
`TrinaGridStateManager` imperatively, instead of recreating the whole `TrinaGrid`
on every rebuild (previously keyed with `ValueKey(Uuid().v4())`). This preserves
scroll offset and the row selection across cell edits, pin toggles, ratings/memo
changes, and background reloads.

## What changed

- **Drive the grid via the stateManager.** A stable key keeps one grid (and its
  stateManager) alive; `_reconcile` diffs the incoming `Grid` by record id and
  applies only what changed. Structural column changes (preset/column edits,
  entering/leaving selection mode) still do a full column replace.
- **Diff rows by record id** (`reconcileRows`) so an unchanged row keeps its
  identity, and re-highlight the same record after an update
  (`restoreCurrentRecord`).
- **`skipLoadingOnReload`** keeps the table on screen across upstream loader
  reloads rather than tearing the subtree down.

## Follow-up fixes

- **Drive the row highlight by the current cell, not a row index.** With pinned
  (frozen) rows present, two index spaces collide: a tap stores a *display* index
  in `currentCellPosition.rowIdx` (frozen rows render in a separate top block,
  shifting the scrollable rows' display indices), while a reconcile recomputes it
  against `refRows`. `currentRecord` resolved the selected record via `currentRow`
  (`== refRows[currentRowIdx]`), so after a tap it pointed at the wrong record and
  the highlight stuck on (or duplicated onto) the wrong row. Now `currentRecord`
  resolves from `currentCell.row` — the same unambiguous path trina's own
  `currentColumn`/`currentColumnField` use. trina's built-in `activatedColor` is
  also made transparent so its index-based current-row fill can't double-paint
  over the record-id highlight we draw ourselves, and the frozen-row highlight is
  wrapped in a `ListenableBuilder` on the stateManager so it repaints on every
  selection change (scrollable rows get this for free inside `TrinaBaseRow`).
- **Bulk fallback in `reconcileRows`.** For large diffs (more than the threshold
  of rows to reinsert, e.g. a filter/search swap), fall back to
  `removeAllRows` + `appendRows` to avoid O(n^2) per-row inserts.
- **Restore the canonical `sortIdx` (`-capturedDate`)** after incremental /
  `appendRows` updates, since trina overwrites it on insert; otherwise trina's
  "reset sort" (third toggle) reproduced a drifted default order.
- **Guard the deferred `autoFitColumns` on `_loaded`** as well as `mounted` so it
  never touches a disposed stateManager.

## Verification

- `dart format` + `flutter analyze` clean on the changed files.
- Manually verified on Windows desktop: with rows pinned, the current-row
  highlight follows the selected record (no stuck/duplicated highlight on either
  scrollable or frozen rows).
- Manual checks recommended: large filter/search swaps render without jank; the
  third sort toggle restores newest-first order; light/dark theme toggle restyles
  the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
