### PR TITLE
style: general GUI adjustments for chara_detail and storage settings

### DIFF
--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -944,7 +944,8 @@
                 "unpin": "固定解除",
                 "regenerate_record": "再認識する",
                 "delete_record": "データを削除する",
-                "report_record": "誤認識を報告する"
+                "report_record": "誤認識を報告する",
+                "others": "その他"
             },
             "preview": {
                 "rental": "レンタル",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -1279,7 +1279,7 @@
             "storage": {
                 "data_root": {
                     "title": "データの保存先",
-                    "default_label": "既定の場所",
+                    "default_label": "現在はデフォルト設定です。",
                     "records_label": "レコード",
                     "modules_label": "認識モジュール",
                     "settings_label": "設定"
@@ -1296,6 +1296,12 @@
                     "copy_path_tooltip": "パスをコピー",
                     "open_in_explorer_tooltip": "エクスプローラーで開く",
                     "path_copied": "パスをコピーしました。",
+                    "bootstrap_heading": "保存先設定の設定ファイル",
+                    "bootstrap_hint": "保存先の設定は次のパスに記録されます。アプリから変更できない場合は、このファイルを新規作成・直接編集して指定してください。",
+                    "bootstrap_sample_label": "記入例",
+                    "bootstrap_sample_notes": "・data_root の値を新しい保存先に置き換えてください。\n・パス区切り「\\」は「\\\\」と2つ重ねるか、代わりに「/」を使用してください。",
+                    "copy_sample_tooltip": "サンプルをコピー",
+                    "sample_copied": "サンプルをコピーしました。",
                     "change_button": "保存先を変更",
                     "reset_button": "デフォルトに戻す",
                     "back_button": "戻る",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -942,10 +942,11 @@
                 "open_in_explorer": "フォルダを開く",
                 "pin_to_top": "上部に固定",
                 "unpin": "固定解除",
-                "regenerate_record": "再認識する",
-                "delete_record": "データを削除する",
-                "report_record": "誤認識を報告する",
-                "others": "その他"
+                "regenerate_record": "再認識",
+                "delete_record": "データを削除",
+                "report_record": "誤認識を報告",
+                "archive_record": "データをアーカイブ",
+                "group_file": "ファイル"
             },
             "preview": {
                 "rental": "レンタル",

--- a/lib/src/core/bootstrap.dart
+++ b/lib/src/core/bootstrap.dart
@@ -20,10 +20,14 @@ import 'package:path_provider/path_provider.dart';
 
 import '/src/core/app_logger.dart';
 
-/// Current on-disk schema version of [_bootstrapFileName].
+/// Current on-disk schema version of [bootstrapFileName].
 const int _bootstrapVersion = 1;
 
-const String _bootstrapFileName = "data_root.json";
+/// Name of the fixed bootstrap file that records the data root override.
+///
+/// Public so the settings UI can show its location, letting a user hand-edit the
+/// data root if the in-app change ever fails to write it.
+const String bootstrapFileName = "data_root.json";
 
 const String _versionKey = "version";
 
@@ -55,10 +59,19 @@ bool dataRootDegraded = false;
 /// offer to clear the stale pointer. `null` means no override is recorded.
 String? configuredDataRoot;
 
+/// Returns a sample `data_root.json` body pointing at [examplePath].
+///
+/// Built with the same encoder, schema version, and keys the app itself writes
+/// (see [writeDataRootOverride]), so the sample shown in the settings UI can
+/// never drift from the real format. The encoder escapes backslashes, so a
+/// Windows [examplePath] comes out correctly JSON-escaped for the user to copy.
+String sampleBootstrapContent(String examplePath) =>
+    const JsonEncoder.withIndent("  ").convert({_versionKey: _bootstrapVersion, _dataRootKey: examplePath});
+
 /// Returns the fixed bootstrap file, independent of any override.
 Future<File> _bootstrapFile() async {
   final supportDir = await getApplicationSupportDirectory();
-  return File(p.join(supportDir.path, _bootstrapFileName));
+  return File(p.join(supportDir.path, bootstrapFileName));
 }
 
 /// Reads the configured data root and caches it in [resolvedDataRoot].

--- a/lib/src/gui/chara_detail/archive_record_dialog.dart
+++ b/lib/src/gui/chara_detail/archive_record_dialog.dart
@@ -4,6 +4,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/chara_detail/storage.dart';
+import '/src/core/providers.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/common.dart';
 import '/src/gui/common.dart';
@@ -11,26 +12,27 @@ import '/src/gui/common.dart';
 // ignore: constant_identifier_names
 const tr_archive_record = "pages.chara_detail.archive_records";
 
-/// Bulk-archive confirmation dialog.
+/// Bulk-archive confirmation dialog, the selection-flow counterpart of
+/// [ArchiveRecordDialog].
 ///
 /// Shows how many records will be archived and lets the user pick the image
 /// disposition ([ArchiveImageOption]) for the whole batch. Archiving is
 /// destructive (re-recognition is lost), so confirmation is a long-press, like
-/// the delete dialog.
-class ArchiveRecordDialog extends ConsumerStatefulWidget {
+/// the bulk delete dialog. Reports a count rather than a single record's icon.
+class BulkArchiveRecordDialog extends ConsumerStatefulWidget {
   final List<String> recordIds;
 
-  const ArchiveRecordDialog({super.key, required this.recordIds});
+  const BulkArchiveRecordDialog({super.key, required this.recordIds});
 
   static void show(RefBase ref, {required List<String> recordIds}) {
-    CardDialog.show(ref, (_) => ArchiveRecordDialog(recordIds: recordIds));
+    CardDialog.show(ref, (_) => BulkArchiveRecordDialog(recordIds: recordIds));
   }
 
   @override
-  ConsumerState<ArchiveRecordDialog> createState() => _ArchiveRecordDialogState();
+  ConsumerState<BulkArchiveRecordDialog> createState() => _BulkArchiveRecordDialogState();
 }
 
-class _ArchiveRecordDialogState extends ConsumerState<ArchiveRecordDialog> {
+class _BulkArchiveRecordDialogState extends ConsumerState<BulkArchiveRecordDialog> {
   ArchiveImageOption _option = ArchiveImageOption.resizedJpeg;
 
   void _confirm() {
@@ -83,6 +85,105 @@ class _ArchiveRecordDialogState extends ConsumerState<ArchiveRecordDialog> {
       confirmIcon: Symbols.archive_rounded,
       destructive: true,
       onConfirm: _confirm,
+    );
+  }
+}
+
+/// Single-record archive confirmation dialog, the context-menu counterpart of
+/// [BulkArchiveRecordDialog].
+///
+/// Mirrors [DeleteRecordDialog]'s layout — the trainee icon and evaluation value
+/// of the target record — so archiving one record from the row context menu
+/// looks and reads like deleting one. It still exposes the image disposition
+/// ([ArchiveImageOption]) that archiving requires.
+class ArchiveRecordDialog extends ConsumerStatefulWidget {
+  final String recordId;
+  final RecordSource source;
+
+  const ArchiveRecordDialog({super.key, required this.recordId, this.source = RecordSource.active});
+
+  static void show(RefBase ref, {required String recordId, RecordSource source = RecordSource.active}) {
+    CardDialog.show(ref, (_) => ArchiveRecordDialog(recordId: recordId, source: source));
+  }
+
+  @override
+  ConsumerState<ArchiveRecordDialog> createState() => _ArchiveRecordDialogState();
+}
+
+class _ArchiveRecordDialogState extends ConsumerState<ArchiveRecordDialog> {
+  ArchiveImageOption _option = ArchiveImageOption.resizedJpeg;
+
+  void _confirm() {
+    ref.read(charaArchiveControllerProvider.notifier).archive([widget.recordId], _option);
+    CardDialog.dismiss(ref.base);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final record = recordStorageFor(ref, widget.source).getBy(id: widget.recordId);
+    if (record == null) {
+      return dismissForMissingRecord(ref.base);
+    }
+    final iconPath = traineeIconPathIn(recordDirOf(ref.read(pathInfoProvider), widget.source, record));
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 500, maxHeight: 560),
+      child: CardDialog(
+        dialogTitle: "$tr_archive_record.dialog.title".tr(),
+        closeButtonTooltip: "$tr_archive_record.dialog.cancel_button.tooltip".tr(),
+        usePageView: false,
+        content: Expanded(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 140),
+                child: Image.file(
+                  iconPath.toFile(),
+                  // The trainee icon is normally always present, but guard against a
+                  // missing/corrupt file (e.g. a hand-edited archive) so the dialog
+                  // shows a placeholder instead of a red error box.
+                  errorBuilder: (context, error, stackTrace) =>
+                      Icon(Symbols.hide_image_rounded, size: 64, color: theme.colorScheme.onSurfaceVariant),
+                ),
+              ),
+              Text(record.evaluationValue.toNumberString(), style: theme.textTheme.titleMedium),
+              const SizedBox(height: 8),
+              RadioGroup<ArchiveImageOption>(
+                groupValue: _option,
+                onChanged: (value) => setState(() => _option = value!),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    RadioListTile<ArchiveImageOption>(
+                      value: ArchiveImageOption.resizedJpeg,
+                      title: Text("$tr_archive_record.dialog.option.resized_jpeg.label".tr()),
+                      subtitle: Text("$tr_archive_record.dialog.option.resized_jpeg.description".tr()),
+                    ),
+                    RadioListTile<ArchiveImageOption>(
+                      value: ArchiveImageOption.none,
+                      title: Text("$tr_archive_record.dialog.option.none.label".tr()),
+                      subtitle: Text("$tr_archive_record.dialog.option.none.description".tr()),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 8),
+              Center(child: WarningCard(message: "$tr_archive_record.dialog.description".tr())),
+            ],
+          ),
+        ),
+        bottom: ConfirmActionRow(
+          dismissRef: ref.base,
+          cancelLabel: "$tr_archive_record.dialog.cancel_button.label".tr(),
+          cancelTooltip: "$tr_archive_record.dialog.cancel_button.tooltip".tr(),
+          confirmLabel: "$tr_archive_record.dialog.ok_button.label".tr(),
+          confirmTooltip: "$tr_archive_record.dialog.ok_button.tooltip".tr(),
+          confirmIcon: Symbols.archive_rounded,
+          destructive: true,
+          onConfirm: _confirm,
+        ),
+      ),
     );
   }
 }

--- a/lib/src/gui/chara_detail/archive_record_dialog.dart
+++ b/lib/src/gui/chara_detail/archive_record_dialog.dart
@@ -33,10 +33,12 @@ class BulkArchiveRecordDialog extends ConsumerStatefulWidget {
 }
 
 class _BulkArchiveRecordDialogState extends ConsumerState<BulkArchiveRecordDialog> {
-  ArchiveImageOption _option = ArchiveImageOption.resizedJpeg;
+  // Starts unselected so the user must deliberately pick an image disposition;
+  // the confirm button stays disabled until then.
+  ArchiveImageOption? _option;
 
   void _confirm() {
-    ref.read(charaArchiveControllerProvider.notifier).archive(widget.recordIds, _option);
+    ref.read(charaArchiveControllerProvider.notifier).archive(widget.recordIds, _option!);
     // The grid rebuilds without these rows; leave selection mode so the
     // checkbox column disappears and stale checks are dropped.
     exitSelection(ref);
@@ -85,6 +87,7 @@ class _BulkArchiveRecordDialogState extends ConsumerState<BulkArchiveRecordDialo
       confirmIcon: Symbols.archive_rounded,
       destructive: true,
       onConfirm: _confirm,
+      confirmEnabled: _option != null,
     );
   }
 }
@@ -111,10 +114,12 @@ class ArchiveRecordDialog extends ConsumerStatefulWidget {
 }
 
 class _ArchiveRecordDialogState extends ConsumerState<ArchiveRecordDialog> {
-  ArchiveImageOption _option = ArchiveImageOption.resizedJpeg;
+  // Starts unselected so the user must deliberately pick an image disposition;
+  // the confirm button stays disabled until then.
+  ArchiveImageOption? _option;
 
   void _confirm() {
-    ref.read(charaArchiveControllerProvider.notifier).archive([widget.recordId], _option);
+    ref.read(charaArchiveControllerProvider.notifier).archive([widget.recordId], _option!);
     CardDialog.dismiss(ref.base);
   }
 
@@ -182,6 +187,7 @@ class _ArchiveRecordDialogState extends ConsumerState<ArchiveRecordDialog> {
           confirmIcon: Symbols.archive_rounded,
           destructive: true,
           onConfirm: _confirm,
+          enabled: _option != null,
         ),
       ),
     );

--- a/lib/src/gui/chara_detail/column_preset_bar_widget.dart
+++ b/lib/src/gui/chara_detail/column_preset_bar_widget.dart
@@ -49,7 +49,7 @@ class ColumnPresetBarWidget extends ConsumerWidget {
         color: theme.colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
           child: Row(
             children: [
               _GroupLabel("$tr_toolbar.preset_group".tr()),

--- a/lib/src/gui/chara_detail/common.dart
+++ b/lib/src/gui/chara_detail/common.dart
@@ -256,6 +256,11 @@ class ConfirmActionRow extends StatelessWidget {
   final bool destructive;
   final VoidCallback onConfirm;
 
+  /// Whether the confirm button accepts input. When false the button is greyed
+  /// and both tap and long-press are no-ops, e.g. until a required choice (an
+  /// archive image option) has been made.
+  final bool enabled;
+
   const ConfirmActionRow({
     super.key,
     required this.dismissRef,
@@ -266,6 +271,7 @@ class ConfirmActionRow extends StatelessWidget {
     required this.confirmIcon,
     required this.destructive,
     required this.onConfirm,
+    this.enabled = true,
   });
 
   @override
@@ -295,9 +301,14 @@ class ConfirmActionRow extends StatelessWidget {
             icon: Icon(confirmIcon),
             label: Text(confirmLabel),
             // Destructive actions require a deliberate long-press; a plain press
-            // is a no-op so an accidental tap cannot delete/archive.
-            onPressed: destructive ? () {} : onConfirm,
-            onLongPress: destructive ? onConfirm : null,
+            // is a no-op so an accidental tap cannot delete/archive. When
+            // disabled, both are null so the button greys out entirely.
+            onPressed: !enabled
+                ? null
+                : destructive
+                ? () {}
+                : onConfirm,
+            onLongPress: enabled && destructive ? onConfirm : null,
           ),
         ),
       ],
@@ -327,6 +338,10 @@ class BulkConfirmDialog extends StatelessWidget {
   final bool destructive;
   final VoidCallback onConfirm;
 
+  /// Forwarded to [ConfirmActionRow.enabled]; greys out the confirm button until
+  /// a required choice has been made.
+  final bool confirmEnabled;
+
   const BulkConfirmDialog({
     super.key,
     required this.dismissRef,
@@ -343,6 +358,7 @@ class BulkConfirmDialog extends StatelessWidget {
     required this.confirmIcon,
     required this.destructive,
     required this.onConfirm,
+    this.confirmEnabled = true,
   });
 
   @override
@@ -377,6 +393,7 @@ class BulkConfirmDialog extends StatelessWidget {
           confirmIcon: confirmIcon,
           destructive: destructive,
           onConfirm: onConfirm,
+          enabled: confirmEnabled,
         ),
       ),
     );

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -87,9 +87,14 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     DirectoryPath dirOf(CharaDetailRecord r) => recordDirOf(pathInfo, source, r);
     const constraints = BoxConstraints(minHeight: 40);
     final style = theme.textTheme.labelMedium;
-    // The per-item Text overrides the menu's built-in disabled coloring, so grey
-    // the label ourselves for items disabled during selection.
+    // The per-item Text/Icon overrides MenuItem's built-in disabled coloring, so
+    // grey both the label and the leading icon ourselves for items disabled
+    // during selection.
     final disabledStyle = style?.copyWith(color: theme.disabledColor);
+    final disabledIconColor = selecting ? theme.disabledColor : null;
+    // Material Symbols are a variable font; bump the wght axis so the thin
+    // default strokes read clearly at the 16px menu icon size.
+    const iconWeight = 700.0;
     final menu = ContextMenu(
       position: offset,
       entries: <ContextMenuEntry>[
@@ -99,6 +104,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
         MenuItem(
           constraints: constraints,
           enabled: !selecting,
+          icon: Icon(isPinned ? Symbols.keep_off : Symbols.keep, weight: iconWeight, color: disabledIconColor),
           onSelected: (_) {
             final next = {...ref.read(pinnedRecordIdsProvider)};
             isPinned ? next.remove(record.id) : next.add(record.id);
@@ -111,6 +117,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
         ),
         MenuItem(
           constraints: constraints,
+          icon: const Icon(Symbols.visibility, weight: iconWeight),
           onSelected: (_) {
             final records = stateManager.getSortedRecords().toList();
             final index = records.indexOf(record);
@@ -119,17 +126,62 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
           },
           label: Text("$tr_chara_detail.context_menu.preview".tr(), style: style),
         ),
-        MenuItem(
+        // File group: open the record's folder and copy the recognition images.
+        MenuItem.submenu(
           constraints: constraints,
-          onSelected: (_) => dirOf(record).launch(),
-          label: Text("$tr_chara_detail.context_menu.open_in_explorer".tr(), style: style),
+          icon: const Icon(Symbols.folder, weight: iconWeight),
+          label: Text("$tr_chara_detail.context_menu.group_file".tr(), style: style),
+          items: [
+            MenuItem(
+              constraints: constraints,
+              icon: const Icon(Symbols.content_copy, weight: iconWeight),
+              onSelected: (_) =>
+                  copyRecordImageToClipboard(ref.base, dirOf(record), CharaDetailRecordImageMode.skillPlain),
+              label: Text("$tr_chara_detail.context_menu.copy_skill".tr(), style: style),
+            ),
+            MenuItem(
+              constraints: constraints,
+              icon: const Icon(Symbols.content_copy, weight: iconWeight),
+              onSelected: (_) =>
+                  copyRecordImageToClipboard(ref.base, dirOf(record), CharaDetailRecordImageMode.factorPlain),
+              label: Text("$tr_chara_detail.context_menu.copy_factor".tr(), style: style),
+            ),
+            MenuItem(
+              constraints: constraints,
+              icon: const Icon(Symbols.folder_open, weight: iconWeight),
+              onSelected: (_) => dirOf(record).launch(),
+              label: Text("$tr_chara_detail.context_menu.open_in_explorer".tr(), style: style),
+            ),
+          ],
         ),
-        // Re-recognition only applies to active records; archived ones have lossy
-        // or no images and are intentionally excluded.
+        // Destructive record actions, set off by a divider: archive (active-only;
+        // archived records cannot be archived again) then delete (both sources).
+        const MenuDivider(),
         if (source == RecordSource.active)
           MenuItem(
             constraints: constraints,
             enabled: !selecting,
+            icon: Icon(Symbols.archive, weight: iconWeight, color: disabledIconColor),
+            onSelected: (_) => ArchiveRecordDialog.show(ref.base, recordId: record.id, source: source),
+            label: Text("$tr_chara_detail.context_menu.archive_record".tr(), style: selecting ? disabledStyle : style),
+          ),
+        MenuItem(
+          constraints: constraints,
+          enabled: !selecting,
+          icon: Icon(Symbols.delete, weight: iconWeight, color: disabledIconColor),
+          onSelected: (_) => DeleteRecordDialog.show(ref.base, recordId: record.id, source: source),
+          label: Text("$tr_chara_detail.context_menu.delete_record".tr(), style: selecting ? disabledStyle : style),
+        ),
+        // Recognition actions, listed inline (active records only), so the
+        // trailing divider that sets them off is active-only too — otherwise an
+        // archived record would end on a dangling separator. Re-recognize, then
+        // report a misrecognition (Sentry builds only).
+        if (source == RecordSource.active) const MenuDivider(),
+        if (source == RecordSource.active)
+          MenuItem(
+            constraints: constraints,
+            enabled: !selecting,
+            icon: Icon(Symbols.autorenew, weight: iconWeight, color: disabledIconColor),
             onSelected: (_) async {
               final moduleVersion = await ref.read(moduleVersionLoader.future);
               if (moduleVersion == null) {
@@ -147,43 +199,13 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
               style: selecting ? disabledStyle : style,
             ),
           ),
-        const MenuDivider(),
-        MenuItem(
-          constraints: constraints,
-          enabled: !selecting,
-          onSelected: (_) => DeleteRecordDialog.show(ref.base, recordId: record.id, source: source),
-          label: Text("$tr_chara_detail.context_menu.delete_record".tr(), style: selecting ? disabledStyle : style),
-        ),
-        // Reports attach the recognition images for a bug repro; archived records
-        // only keep lossy/no images, so the report is diagnostically useless there.
-        // Active-only, like regenerate above.
         if (source == RecordSource.active && isSentryAvailable())
           MenuItem(
             constraints: constraints,
+            icon: const Icon(Symbols.flag, weight: iconWeight),
             onSelected: (_) => ReportRecordDialog.show(ref.base, dirOf(record)),
             label: Text("$tr_chara_detail.context_menu.report_record".tr(), style: style),
           ),
-        // Secondary actions (image copies) grouped into a submenu at the bottom,
-        // separated from the destructive actions above.
-        const MenuDivider(),
-        MenuItem.submenu(
-          constraints: constraints,
-          label: Text("$tr_chara_detail.context_menu.others".tr(), style: style),
-          items: [
-            MenuItem(
-              constraints: constraints,
-              onSelected: (_) =>
-                  copyRecordImageToClipboard(ref.base, dirOf(record), CharaDetailRecordImageMode.skillPlain),
-              label: Text("$tr_chara_detail.context_menu.copy_skill".tr(), style: style),
-            ),
-            MenuItem(
-              constraints: constraints,
-              onSelected: (_) =>
-                  copyRecordImageToClipboard(ref.base, dirOf(record), CharaDetailRecordImageMode.factorPlain),
-              label: Text("$tr_chara_detail.context_menu.copy_factor".tr(), style: style),
-            ),
-          ],
-        ),
       ],
     );
     showContextMenu(
@@ -712,8 +734,8 @@ class _TopControlsLayer extends ConsumerWidget {
 }
 
 /// The scrim's primary action, which opens the purpose's confirmation dialog
-/// ([ArchiveRecordDialog] or [ExportRecordDialog]) for the checked rows. Disabled
-/// until at least one row is checked.
+/// ([BulkArchiveRecordDialog] or [ExportRecordDialog]) for the checked rows.
+/// Disabled until at least one row is checked.
 class _SelectionConfirmButton extends ConsumerWidget {
   final SelectionPurpose purpose;
   final int selectedCount;
@@ -732,7 +754,7 @@ class _SelectionConfirmButton extends ConsumerWidget {
               final recordIds = ref.read(selectedRecordIdsProvider).toList();
               switch (purpose) {
                 case SelectionPurpose.archive:
-                  ArchiveRecordDialog.show(ref.base, recordIds: recordIds);
+                  BulkArchiveRecordDialog.show(ref.base, recordIds: recordIds);
                 case SelectionPurpose.export:
                   ExportRecordDialog.show(ref.base, recordIds: recordIds);
                 case SelectionPurpose.delete:

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -418,7 +418,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                         // recomputed per notify.
                         final stripe = pinnedIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor;
                         final separator = isLast
-                            ? BorderSide(color: theme.colorScheme.primary, width: 3)
+                            ? BorderSide(color: theme.colorScheme.outline, width: 3)
                             : BorderSide(
                                 color: theme.focusColor,
                                 width: stateManager.configuration.style.cellHorizontalBorderWidth,
@@ -581,6 +581,13 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                       sortColumn = event.column.field;
                       sortOrder = event.column.sort;
                     }
+                    // A header-click sort reorders the frozen rows in place
+                    // (FilteredList.sort works on originalList), but unlike
+                    // _reconcile/onLoaded it doesn't rebuild the pinned index, so
+                    // rowWrapper's stripe/boundary would read stale positions.
+                    // toggleSortColumn fires this before its own notifyListeners,
+                    // so re-indexing here lands in the very next repaint.
+                    _indexPinnedRows();
                   },
                 ),
               );

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_context_menu/flutter_context_menu.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
@@ -84,68 +85,52 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     final selecting = ref.read(selectionModeProvider) != null;
     final isPinned = ref.read(pinnedRecordIdsProvider).contains(record.id);
     DirectoryPath dirOf(CharaDetailRecord r) => recordDirOf(pathInfo, source, r);
-    final rect = offset & const Size(1, 1);
-    const height = 40.0;
+    const constraints = BoxConstraints(minHeight: 40);
     final style = theme.textTheme.labelMedium;
-    // The per-item Text overrides PopupMenuItem's built-in disabled coloring, so
-    // grey the label ourselves for items disabled during selection.
+    // The per-item Text overrides the menu's built-in disabled coloring, so grey
+    // the label ourselves for items disabled during selection.
     final disabledStyle = style?.copyWith(color: theme.disabledColor);
-    showMenu<int>(
-      context: context,
-      position: RelativeRect.fromLTRB(rect.left, rect.top, rect.right, rect.bottom),
-      shape: RoundedRectangleBorder(
-        side: BorderSide(color: theme.colorScheme.outline),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      items: [
-        PopupMenuItem(
-          height: height,
-          onTap: () {
+    final menu = ContextMenu(
+      position: offset,
+      entries: <ContextMenuEntry>[
+        // Pin/unpin the row to the top of the table. Disabled while selecting,
+        // since toggling rebuilds the grid and would drop the in-progress
+        // checkbox selection.
+        MenuItem(
+          constraints: constraints,
+          enabled: !selecting,
+          onSelected: (_) {
+            final next = {...ref.read(pinnedRecordIdsProvider)};
+            isPinned ? next.remove(record.id) : next.add(record.id);
+            ref.read(pinnedRecordIdsProvider.notifier).set(next);
+          },
+          label: Text(
+            "$tr_chara_detail.context_menu.${isPinned ? "unpin" : "pin_to_top"}".tr(),
+            style: selecting ? disabledStyle : style,
+          ),
+        ),
+        MenuItem(
+          constraints: constraints,
+          onSelected: (_) {
             final records = stateManager.getSortedRecords().toList();
             final index = records.indexOf(record);
             final directories = records.map(dirOf).toList();
             return CharaDetailPreviewDialog.show(ref.base, directories, index);
           },
-          child: Text("$tr_chara_detail.context_menu.preview".tr(), style: style),
+          label: Text("$tr_chara_detail.context_menu.preview".tr(), style: style),
         ),
-        PopupMenuItem(
-          height: height,
-          onTap: () => copyRecordImageToClipboard(ref.base, dirOf(record), CharaDetailRecordImageMode.skillPlain),
-          child: Text("$tr_chara_detail.context_menu.copy_skill".tr(), style: style),
-        ),
-        PopupMenuItem(
-          height: height,
-          onTap: () => copyRecordImageToClipboard(ref.base, dirOf(record), CharaDetailRecordImageMode.factorPlain),
-          child: Text("$tr_chara_detail.context_menu.copy_factor".tr(), style: style),
-        ),
-        PopupMenuItem(
-          height: height,
-          onTap: () => dirOf(record).launch(),
-          child: Text("$tr_chara_detail.context_menu.open_in_explorer".tr(), style: style),
-        ),
-        // Pin/unpin the row to the top of the table. Disabled while selecting,
-        // since toggling rebuilds the grid and would drop the in-progress
-        // checkbox selection.
-        PopupMenuItem(
-          height: height,
-          enabled: !selecting,
-          onTap: () {
-            final next = {...ref.read(pinnedRecordIdsProvider)};
-            isPinned ? next.remove(record.id) : next.add(record.id);
-            ref.read(pinnedRecordIdsProvider.notifier).set(next);
-          },
-          child: Text(
-            "$tr_chara_detail.context_menu.${isPinned ? "unpin" : "pin_to_top"}".tr(),
-            style: selecting ? disabledStyle : style,
-          ),
+        MenuItem(
+          constraints: constraints,
+          onSelected: (_) => dirOf(record).launch(),
+          label: Text("$tr_chara_detail.context_menu.open_in_explorer".tr(), style: style),
         ),
         // Re-recognition only applies to active records; archived ones have lossy
         // or no images and are intentionally excluded.
         if (source == RecordSource.active)
-          PopupMenuItem(
-            height: height,
+          MenuItem(
+            constraints: constraints,
             enabled: !selecting,
-            onTap: () async {
+            onSelected: (_) async {
               final moduleVersion = await ref.read(moduleVersionLoader.future);
               if (moduleVersion == null) {
                 sendModuleVersionCheckToast(ToastType.error, ModuleVersionCheckResultCode.noVersionAvailable);
@@ -157,28 +142,57 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
               }
               ref.read(charaDetailRecordRegenerationControllerProvider.notifier).start([record]);
             },
-            child: Text(
+            label: Text(
               "$tr_chara_detail.context_menu.regenerate_record".tr(),
               style: selecting ? disabledStyle : style,
             ),
           ),
-        const PopupMenuDivider(),
-        PopupMenuItem(
-          height: height,
+        const MenuDivider(),
+        MenuItem(
+          constraints: constraints,
           enabled: !selecting,
-          onTap: () => DeleteRecordDialog.show(ref.base, recordId: record.id, source: source),
-          child: Text("$tr_chara_detail.context_menu.delete_record".tr(), style: selecting ? disabledStyle : style),
+          onSelected: (_) => DeleteRecordDialog.show(ref.base, recordId: record.id, source: source),
+          label: Text("$tr_chara_detail.context_menu.delete_record".tr(), style: selecting ? disabledStyle : style),
         ),
         // Reports attach the recognition images for a bug repro; archived records
         // only keep lossy/no images, so the report is diagnostically useless there.
         // Active-only, like regenerate above.
         if (source == RecordSource.active && isSentryAvailable())
-          PopupMenuItem(
-            height: height,
-            onTap: () => ReportRecordDialog.show(ref.base, dirOf(record)),
-            child: Text("$tr_chara_detail.context_menu.report_record".tr(), style: style),
+          MenuItem(
+            constraints: constraints,
+            onSelected: (_) => ReportRecordDialog.show(ref.base, dirOf(record)),
+            label: Text("$tr_chara_detail.context_menu.report_record".tr(), style: style),
           ),
+        // Secondary actions (image copies) grouped into a submenu at the bottom,
+        // separated from the destructive actions above.
+        const MenuDivider(),
+        MenuItem.submenu(
+          constraints: constraints,
+          label: Text("$tr_chara_detail.context_menu.others".tr(), style: style),
+          items: [
+            MenuItem(
+              constraints: constraints,
+              onSelected: (_) =>
+                  copyRecordImageToClipboard(ref.base, dirOf(record), CharaDetailRecordImageMode.skillPlain),
+              label: Text("$tr_chara_detail.context_menu.copy_skill".tr(), style: style),
+            ),
+            MenuItem(
+              constraints: constraints,
+              onSelected: (_) =>
+                  copyRecordImageToClipboard(ref.base, dirOf(record), CharaDetailRecordImageMode.factorPlain),
+              label: Text("$tr_chara_detail.context_menu.copy_factor".tr(), style: style),
+            ),
+          ],
+        ),
       ],
+    );
+    showContextMenu(
+      context,
+      contextMenu: menu,
+      routeOptions: const MenuRouteOptions(
+        transitionDuration: Duration(milliseconds: 120),
+        reverseTransitionDuration: Duration(milliseconds: 120),
+      ),
     );
   }
 

--- a/lib/src/gui/chara_detail/export_button.dart
+++ b/lib/src/gui/chara_detail/export_button.dart
@@ -73,7 +73,7 @@ class CharaDetailExportButton extends ConsumerWidget {
 
 /// Format picker shown after rows are selected for export.
 ///
-/// Mirrors [ArchiveRecordDialog]: it runs from its own [WidgetRef] (so the
+/// Mirrors [BulkArchiveRecordDialog]: it runs from its own [WidgetRef] (so the
 /// asynchronous export survives the scrim being torn down), reports how many
 /// records are involved, and lets the user pick one disposition for the whole
 /// batch. Export is non-destructive, so a plain confirm replaces the archive

--- a/lib/src/gui/common.dart
+++ b/lib/src/gui/common.dart
@@ -393,7 +393,18 @@ class _CardDialogState extends ConsumerState<CardDialog> {
                 ),
               ),
             ),
-          if (!widget.usePageView) widget.content,
+          if (!widget.usePageView)
+            // Bound the content to the space left between the title and bottom
+            // bars and let it scroll past that, instead of overflowing the card.
+            // `Flexible` (loose) keeps short content at its natural size, so
+            // dialogs that already fit are visually unchanged; the inner scroll
+            // view still hands the content unbounded height as before.
+            Flexible(
+              child: Scrollbar(
+                controller: _controller,
+                child: SingleChildScrollView(controller: _controller, child: widget.content),
+              ),
+            ),
           if (widget.bottom != null)
             Container(
               decoration: BoxDecoration(

--- a/lib/src/gui/common.dart
+++ b/lib/src/gui/common.dart
@@ -331,6 +331,12 @@ class CardDialog extends ConsumerStatefulWidget {
   final Widget? bottom;
   final bool usePageView;
 
+  /// Opt-in scroll/clip for tall, self-sizing content when [usePageView] is
+  /// false. Leave false for content that uses `Expanded`/`Flexible` (the common
+  /// case): such content must be placed directly under the dialog's `Column`, as
+  /// a `SingleChildScrollView` cannot host an `Expanded` child.
+  final bool scrollableContent;
+
   const CardDialog({
     super.key,
     required this.dialogTitle,
@@ -338,6 +344,7 @@ class CardDialog extends ConsumerStatefulWidget {
     required this.content,
     this.bottom,
     this.usePageView = true,
+    this.scrollableContent = false,
   });
 
   @override
@@ -393,18 +400,23 @@ class _CardDialogState extends ConsumerState<CardDialog> {
                 ),
               ),
             ),
-          if (!widget.usePageView)
+          if (!widget.usePageView && widget.scrollableContent)
             // Bound the content to the space left between the title and bottom
             // bars and let it scroll past that, instead of overflowing the card.
             // `Flexible` (loose) keeps short content at its natural size, so
             // dialogs that already fit are visually unchanged; the inner scroll
             // view still hands the content unbounded height as before.
+            //
+            // Only for content that sizes itself; `Expanded`/`Flexible` content
+            // cannot live inside a `SingleChildScrollView`, so it uses the
+            // direct-placement branch below.
             Flexible(
               child: Scrollbar(
                 controller: _controller,
                 child: SingleChildScrollView(controller: _controller, child: widget.content),
               ),
             ),
+          if (!widget.usePageView && !widget.scrollableContent) widget.content,
           if (widget.bottom != null)
             Container(
               decoration: BoxDecoration(

--- a/lib/src/gui/storage_settings.dart
+++ b/lib/src/gui/storage_settings.dart
@@ -422,6 +422,9 @@ class _DataRootMigrationDialogState extends ConsumerState<_DataRootMigrationDial
           ? null
           : "$tr_storage.dialog.close_button".tr(),
       usePageView: false,
+      // The overview can grow taller than the card (per-directory breakdown plus
+      // the bootstrap-file hint), so let it scroll instead of overflowing.
+      scrollableContent: true,
       // Fill the dialog width instead of a fixed 480: the title bar and bottom
       // button row already stretch to the card width, so a narrower fixed
       // content was being centered with empty side gutters.

--- a/lib/src/gui/storage_settings.dart
+++ b/lib/src/gui/storage_settings.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
+import '/const.dart';
 import '/src/core/bootstrap.dart';
 import '/src/core/data_root_migration.dart';
 import '/src/core/path_entity.dart';
@@ -153,6 +154,116 @@ class _LabeledPath extends StatelessWidget {
         ),
         child,
       ],
+    );
+  }
+}
+
+/// A footnote pointing at the bootstrap file (`data_root.json`) that records the
+/// data root, with copy-path and reveal-in-explorer actions.
+///
+/// The in-app change writes this file, but if that ever fails (e.g. a read-only
+/// support directory), the user can edit the file by hand to set the location.
+/// The file may not exist yet in the native-default layout; the reveal action
+/// opens its parent folder so the user can create it there.
+class _BootstrapFileHint extends StatelessWidget {
+  final FilePath file;
+
+  const _BootstrapFileHint({required this.file});
+
+  /// A platform-appropriate example data root for the sample file body. It is
+  /// illustrative only; the user is expected to replace it with a real path.
+  static String get _examplePath {
+    if (CurrentPlatform.isWindows()) return r"D:\ExamplePath\umacapture";
+    if (CurrentPlatform.isMacOS()) return "/Users/you/umacapture";
+    return "/home/you/umacapture";
+  }
+
+  void _copy() {
+    Clipboard.setData(ClipboardData(text: file.path));
+    Toaster.show(ToastData.success(description: "$tr_storage.dialog.path_copied".tr()));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text("$tr_storage.dialog.bootstrap_hint".tr(), style: theme.textTheme.bodyMedium),
+        const SizedBox(height: 16),
+        _PathBox(
+          path: file.path,
+          trailing: [
+            const SizedBox(width: 8),
+            IconButton(
+              icon: const Icon(Symbols.content_copy_rounded),
+              tooltip: "$tr_storage.dialog.copy_path_tooltip".tr(),
+              onPressed: _copy,
+            ),
+            IconButton(
+              icon: const Icon(Symbols.folder_open_rounded),
+              tooltip: "$tr_storage.dialog.open_in_explorer_tooltip".tr(),
+              onPressed: () => file.parent.launch(),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        _LabeledPath(
+          label: "$tr_storage.dialog.bootstrap_sample_label".tr(),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text("$tr_storage.dialog.bootstrap_sample_notes".tr(), style: theme.textTheme.bodyMedium),
+              const SizedBox(height: 8),
+              _JsonSampleBox(content: sampleBootstrapContent(_examplePath)),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A bordered, multi-line read-out of a sample JSON file body with a
+/// copy-to-clipboard action, styled to match the dialog's path boxes.
+class _JsonSampleBox extends StatelessWidget {
+  final String content;
+
+  const _JsonSampleBox({required this.content});
+
+  void _copy() {
+    Clipboard.setData(ClipboardData(text: content));
+    Toaster.show(ToastData.success(description: "$tr_storage.dialog.sample_copied".tr()));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: theme.dividerColor),
+      ),
+      padding: const EdgeInsets.fromLTRB(12, 4, 4, 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 8, bottom: 4),
+              child: SelectableText(content, style: theme.textTheme.bodyMedium),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Symbols.content_copy_rounded),
+            tooltip: "$tr_storage.dialog.copy_sample_tooltip".tr(),
+            visualDensity: VisualDensity.compact,
+            onPressed: _copy,
+          ),
+        ],
+      ),
     );
   }
 }
@@ -328,7 +439,11 @@ class _DataRootMigrationDialogState extends ConsumerState<_DataRootMigrationDial
         // Degraded: the real data is unreachable, so migrating would strand it.
         // Show the unavailable root and offer only the data-free clear action.
         if (_degraded) {
-          return _DegradedContent(root: configuredDataRoot, onClear: _clearOverride);
+          return _DegradedContent(
+            root: configuredDataRoot,
+            bootstrapFile: _source.supportDir.filePath(bootstrapFileName),
+            onClear: _clearOverride,
+          );
         }
         return _OverviewContent(
           source: _source,
@@ -511,6 +626,12 @@ class _OverviewContent extends StatelessWidget {
             ],
           ),
         ),
+        const SizedBox(height: 24),
+        _SectionHeader(label: "$tr_storage.dialog.bootstrap_heading".tr()),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+          child: _BootstrapFileHint(file: source.supportDir.filePath(bootstrapFileName)),
+        ),
       ],
     );
   }
@@ -524,9 +645,13 @@ class _OverviewContent extends StatelessWidget {
 class _DegradedContent extends StatelessWidget {
   /// The recorded-but-unreachable root, or `null` if it could not be recovered.
   final String? root;
+
+  /// The bootstrap file recording the root, surfaced so the user can hand-edit
+  /// or remove it if reconnecting the drive is not an option.
+  final FilePath bootstrapFile;
   final VoidCallback onClear;
 
-  const _DegradedContent({required this.root, required this.onClear});
+  const _DegradedContent({required this.root, required this.bootstrapFile, required this.onClear});
 
   @override
   Widget build(BuildContext context) {
@@ -549,6 +674,8 @@ class _DegradedContent extends StatelessWidget {
               ),
               const SizedBox(height: 16),
               Text("$tr_storage.dialog.unavailable_help".tr(), style: theme.textTheme.bodyMedium),
+              const SizedBox(height: 16),
+              _BootstrapFileHint(file: bootstrapFile),
               const SizedBox(height: 16),
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -574,6 +574,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.2"
+  flutter_context_menu:
+    dependency: "direct main"
+    description:
+      name: flutter_context_menu
+      sha256: "7040c03fb9cb2a113282d836edadf32b6cdff67cccdf3d158e7411ecc15d7712"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   flutter_driver:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   window_manager: ^0.5.1
   yaml: ^3.1.1
   material_symbols_icons: ^4.2928.1
+  flutter_context_menu: ^0.4.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

A batch of general GUI adjustments centered on the character detail screen and storage settings.

- **Context menu overhaul (chara_detail):** Replace the row context menu with a `flutter_context_menu`-based one that supports submenus, icon-ifies and regroups the entries, and tightens the column preset bar padding.
- **Archive image option:** Require an explicit archive image option when archiving records, instead of relying on an implicit default.
- **Pinned-row sort fix:** Keep the pinned-row boundary correct after a header sort.
- **Editable data root:** Surface `data_root.json` so users can hand-edit the data root, with bootstrap wiring and a storage-settings entry point.
- **CardDialog scroll fix:** Make the `CardDialog` scroll wrap opt-in so `Expanded` children stay valid.

## Changes by area

- `lib/src/gui/chara_detail/` — context menu, archive dialog, data table sorting, column preset bar, export button.
- `lib/src/gui/storage_settings.dart`, `lib/src/core/bootstrap.dart`, `lib/src/gui/common.dart` — editable data root + opt-in scroll wrap.
- `pubspec.yaml` / `pubspec.lock` — add `flutter_context_menu`.
- `assets/translations/ja.json` — localized strings for the new menu/options.

## Test plan

- [ ] Open the row context menu and verify submenu navigation and grouped entries.
- [ ] Archive a record and confirm the image option must be chosen explicitly.
- [ ] Sort by a header and confirm pinned rows keep their boundary.
- [ ] Hand-edit `data_root.json` and confirm the app picks up the change.
- [ ] Open a `CardDialog` with `Expanded` content and confirm no layout errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
