### PR TITLE
feat(chara_detail): include archived records in dedup and inheritance

### DIFF
--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -12,7 +12,8 @@
         "record_quarantine_error": "読み込めない記録 {count} 件の退避に失敗しました。",
         "inheritance": {
             "resolved": "親子関係を {count} 件解決しました。",
-            "ambiguous": "親候補が複数一致したため {count} 件はリンクしませんでした。"
+            "ambiguous": "親候補が複数一致したため {count} 件はリンクしませんでした。",
+            "archive_not_ready": "アーカイブの読み込みが完了していないため、親子関係の再解決を中止しました。"
         }
     },
     "pages": {

--- a/lib/src/chara_detail/inheritance.dart
+++ b/lib/src/chara_detail/inheritance.dart
@@ -65,12 +65,17 @@ class InheritanceResolver {
     final changed = <CharaDetailRecord>[];
     final ambiguities = <AmbiguousMatch>[];
 
+    // Index [existing] by self key once so both directions resolve candidates in
+    // O(1) lookups instead of a full scan per slot/child. [existing] excludes
+    // newRecord, so no self-exclusion is needed here.
+    final index = _selfKeyIndex(existing);
+
     // Direction A: treat newRecord as a child and find its parents.
     var parent1 = newRecord.metadata.recordId.parent1;
     var parent2 = newRecord.metadata.recordId.parent2;
     for (final slot in const [1, 2]) {
       final key = _childKey(newRecord, slot);
-      final candidates = existing.where((p) => _selfKey(p) == key).toList();
+      final candidates = index[key] ?? const <CharaDetailRecord>[];
       if (candidates.length == 1) {
         if (slot == 1) {
           parent1 = candidates.first.id;
@@ -87,6 +92,7 @@ class InheritanceResolver {
 
     // Direction B: treat newRecord as a parent and find existing children.
     final newSelfKey = _selfKey(newRecord);
+    final sameSelf = index[newSelfKey] ?? const <CharaDetailRecord>[];
     final childUpdates = <String, CharaDetailRecord>{};
     for (final child in existing) {
       for (final slot in const [1, 2]) {
@@ -95,7 +101,7 @@ class InheritanceResolver {
         }
         // Any other stored record that also satisfies this slot makes the match
         // ambiguous (the child should already be linked to it), so skip linking.
-        final others = existing.where((p) => p.id != child.id && _selfKey(p) == newSelfKey);
+        final others = sameSelf.where((p) => p.id != child.id);
         if (others.isNotEmpty) {
           ambiguities.add(AmbiguousMatch(child.id, slot, others.length + 1));
           continue;

--- a/lib/src/chara_detail/inheritance.dart
+++ b/lib/src/chara_detail/inheritance.dart
@@ -16,6 +16,13 @@ import '/src/chara_detail/chara_detail_record.dart';
 ///
 /// The factor list order is guaranteed by the recognizer, so the lists are
 /// compared as-is (no sorting). Matching is keyed on a `card|factors` string.
+///
+/// Deleting a record does not clean up links that point at it: a child keeps the
+/// deleted id in its `parentN` slot. That dangling id is harmless — it resolves
+/// to "no parent" in `resolveRegisteredAncestors` — and is cleared the next time
+/// the authoritative [resolveAll] (manual re-resolution) runs. This holds for
+/// both the active and archive sets; a deletion in either leaves the other's
+/// links to be reconciled on the next manual pass.
 class InheritanceResolver {
   const InheritanceResolver._();
 

--- a/lib/src/chara_detail/storage.dart
+++ b/lib/src/chara_detail/storage.dart
@@ -239,11 +239,14 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
   Future<List<CharaDetailRecord>> build() async {
     final pathInfo = await ref.watch(pathInfoLoader.future);
     rootDirectory = pathInfo.charaDetailActiveDir;
-    // Kick off the archive load in parallel so capture-time dedup and inheritance
-    // resolution can consider archived records. read (not watch): this triggers the
-    // archive build without subscribing, so later archive mutations (e.g. an
-    // inheritance write-back) do not rebuild this store.
-    final archiveLoad = ref.read(charaDetailArchiveStorageLoaderProvider.future);
+    // Trigger the archive build in parallel so capture-time dedup and inheritance
+    // resolution can consider archived records. read (not watch, and not awaited):
+    // this starts the archive build without subscribing, so later archive
+    // mutations (e.g. an inheritance write-back) do not rebuild this store, and
+    // the capture listener below is registered without waiting for the archive
+    // scan. Until the scan lands, add() reads its asData snapshot and degrades to
+    // active-only via the `?? const []` fallback.
+    ref.read(charaDetailArchiveStorageLoaderProvider);
     final List<CharaDetailRecord> records = [];
     if (rootDirectory.existsSync()) {
       final results = await compute(_loadAllCharaDetailRecord, rootDirectory);
@@ -256,19 +259,15 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
     for (final e in records) {
       _updateRecordInfo(e);
     }
-    // Ensure the archive has finished loading before we start accepting captures,
-    // so add()'s synchronous read sees it. Guard so an archive load failure does
-    // not take down the active store; add() then degrades to active-only via the
-    // `?? const []` fallback.
-    try {
-      await archiveLoad;
-    } catch (e, s) {
-      logger.w("Archive preload failed; dedup/inheritance fall back to active-only: $e\n$s");
-    }
     // riverpod 3 removed StreamProvider.stream; listen to the AsyncValue and react
-    // to each newly captured record id. The callback stays synchronous so add()
-    // (and its duplicate-fail override) completes within the stream-delivery
-    // microtask, before the next native capture message is processed.
+    // to each newly captured record id. Registered with no intervening await after
+    // the active load (the archive load above is deliberately not awaited), so the
+    // window between this store building and the listener attaching stays as small
+    // as it was before archived records were considered: the capture event stream
+    // is a broadcast stream with no buffering, so an event delivered before this
+    // listener attaches is lost. The callback stays synchronous so add() (and its
+    // duplicate-fail override) completes within the stream-delivery microtask,
+    // before the next native capture message is processed.
     ref.listen(charaDetailRecordCapturedEventProvider, (_, next) {
       next.whenData((e) => addFromFile(e));
     });
@@ -355,11 +354,20 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
   /// Unlike the per-capture resolution, this is authoritative: it both sets and
   /// clears links so the whole storage reflects the current matches. The active
   /// and archive sets are resolved together, and each changed record is rewritten
-  /// to disk and republished in its owning store. The archive is loaded by the
-  /// time this store exists (build() awaits it), so the read is synchronous.
+  /// to disk and republished in its owning store. Aborts with a warning if the
+  /// archive has not loaded (build() no longer awaits it), because clearing links
+  /// against a missing archive would destroy valid active->archive links.
   void resolveAllInheritance() {
-    final archiveRecords =
-        ref.read(charaDetailArchiveStorageLoaderProvider).asData?.value ?? const <CharaDetailRecord>[];
+    // resolveAll is authoritative: it clears links that no longer resolve. If the
+    // archive failed to load (or is still building), treating it as empty would
+    // clear every active->archive link as unresolvable and rewrite those
+    // record.json files, destroying valid links. Abort instead of degrading; the
+    // capture-time add() path is additive and stays safe without this guard.
+    final archiveRecords = ref.read(charaDetailArchiveStorageLoaderProvider).asData?.value;
+    if (archiveRecords == null) {
+      Toaster.show(ToastData.warning(description: "app.inheritance.archive_not_ready".tr()));
+      return;
+    }
     final resolution = InheritanceResolver.resolveAll([..._records, ...archiveRecords]);
     final archiveIds = {for (final e in archiveRecords) e.id};
     _routeInheritanceChanges(resolution, archiveIds, (updated) {
@@ -498,6 +506,9 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
   }
 
   void delete(String id) {
+    // Deleting a record does not clear other records' parentN links to it; the
+    // dangling id is harmless and is cleared on the next resolveAllInheritance
+    // (see InheritanceResolver).
     final record = getBy(id: id);
     // Guard rather than assert: the record can vanish between a dialog opening
     // and its confirm (a background capture reload, or an archive of the same

--- a/lib/src/chara_detail/storage.dart
+++ b/lib/src/chara_detail/storage.dart
@@ -208,6 +208,15 @@ void copyRecordImageToClipboard(RefBase ref, DirectoryPath recordDir, CharaDetai
   unawaited(ClipboardAlt.pasteImage(ref, imagePath));
 }
 
+/// Writes [record] to `record.json` under [recordDir], in the 4-space-indent
+/// on-disk format the native recognizer and the exporter produce.
+///
+/// Shared by both stores' `_persist`, which only differ in the record directory
+/// their `recordPathOf` resolves (active vs. archive root).
+void _persistRecordJson(DirectoryPath recordDir, CharaDetailRecord record) {
+  recordDir.filePath("record.json").writeAsStringSync(const JsonEncoder.withIndent('    ').convert(record.toMap()));
+}
+
 /// The mutation surface shared by the active ([CharaDetailRecordStorage]) and
 /// archive ([CharaDetailArchiveStorage]) stores.
 ///
@@ -313,20 +322,13 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
     final resolvedRecord = resolution.changed.firstWhereOrNull((e) => e.id == record.id) ?? record;
     final archiveIds = {for (final e in archiveRecords) e.id};
     final activeChildUpdates = <String, CharaDetailRecord>{};
-    final archiveChildUpdates = <CharaDetailRecord>[];
-    for (final updated in resolution.changed) {
-      if (archiveIds.contains(updated.id)) {
-        archiveChildUpdates.add(updated);
-      } else {
-        // The new record (always active) and any active children persist here.
-        _persist(updated);
-        if (updated.id != record.id) {
-          activeChildUpdates[updated.id] = updated;
-        }
+    // The new record (always active) persists here too; only existing active
+    // children feed the republish map.
+    _routeInheritanceChanges(resolution, archiveIds, (updated) {
+      if (updated.id != record.id) {
+        activeChildUpdates[updated.id] = updated;
       }
-    }
-    // Archived children are written back and republished by the archive store.
-    ref.read(charaDetailArchiveStorageLoaderProvider.notifier).applyInheritanceUpdates(archiveChildUpdates);
+    });
     _updateRecordInfo(resolvedRecord);
 
     // `activeRecords` already folds in any pending batch updates, so publishing it
@@ -360,18 +362,34 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
         ref.read(charaDetailArchiveStorageLoaderProvider).asData?.value ?? const <CharaDetailRecord>[];
     final resolution = InheritanceResolver.resolveAll([..._records, ...archiveRecords]);
     final archiveIds = {for (final e in archiveRecords) e.id};
+    _routeInheritanceChanges(resolution, archiveIds, (updated) {
+      replaceBy(updated, id: updated.id);
+    });
+    forceRebuild();
+    _surfaceInheritance(resolution, alwaysReport: true);
+  }
+
+  /// Routes each changed record to its owning store.
+  ///
+  /// Active records are persisted here and then handed to [onActive] for the
+  /// store-specific in-memory republish; archived records are collected and
+  /// written back (and republished) by the archive store in a single
+  /// [CharaDetailArchiveStorage.applyInheritanceUpdates] call.
+  void _routeInheritanceChanges(
+    InheritanceResolution resolution,
+    Set<String> archiveIds,
+    void Function(CharaDetailRecord updated) onActive,
+  ) {
     final archiveUpdates = <CharaDetailRecord>[];
     for (final updated in resolution.changed) {
       if (archiveIds.contains(updated.id)) {
         archiveUpdates.add(updated);
       } else {
         _persist(updated);
-        replaceBy(updated, id: updated.id);
+        onActive(updated);
       }
     }
     ref.read(charaDetailArchiveStorageLoaderProvider.notifier).applyInheritanceUpdates(archiveUpdates);
-    forceRebuild();
-    _surfaceInheritance(resolution, alwaysReport: true);
   }
 
   /// Reports the outcome of an inheritance resolution via toasts.
@@ -396,13 +414,8 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
     }
   }
 
-  /// Writes [record] back to its `record.json`, matching the on-disk format
-  /// (4-space indent) that the native recognizer and the exporter produce.
-  void _persist(CharaDetailRecord record) {
-    recordPathOf(
-      record,
-    ).filePath("record.json").writeAsStringSync(const JsonEncoder.withIndent('    ').convert(record.toMap()));
-  }
+  /// Writes [record] back to its active `record.json` via [_persistRecordJson].
+  void _persist(CharaDetailRecord record) => _persistRecordJson(recordPathOf(record), record);
 
   void addFromFile(String id) {
     final result = CharaDetailRecord.load(rootDirectory / id);
@@ -620,14 +633,8 @@ class CharaDetailArchiveStorage extends AsyncNotifier<List<CharaDetailRecord>> i
     return state.asData?.value.firstWhereOrNull((e) => e.id == id);
   }
 
-  /// Writes [record] back to its archived `record.json`, matching the on-disk
-  /// 4-space-indent format of [CharaDetailRecordStorage._persist] and the native
-  /// recognizer.
-  void _persist(CharaDetailRecord record) {
-    recordPathOf(
-      record,
-    ).filePath("record.json").writeAsStringSync(const JsonEncoder.withIndent('    ').convert(record.toMap()));
-  }
+  /// Writes [record] back to its archived `record.json` via [_persistRecordJson].
+  void _persist(CharaDetailRecord record) => _persistRecordJson(recordPathOf(record), record);
 
   /// Persists inheritance-updated archived [records] and swaps them into the
   /// in-memory list by id.

--- a/lib/src/chara_detail/storage.dart
+++ b/lib/src/chara_detail/storage.dart
@@ -230,6 +230,11 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
   Future<List<CharaDetailRecord>> build() async {
     final pathInfo = await ref.watch(pathInfoLoader.future);
     rootDirectory = pathInfo.charaDetailActiveDir;
+    // Kick off the archive load in parallel so capture-time dedup and inheritance
+    // resolution can consider archived records. read (not watch): this triggers the
+    // archive build without subscribing, so later archive mutations (e.g. an
+    // inheritance write-back) do not rebuild this store.
+    final archiveLoad = ref.read(charaDetailArchiveStorageLoaderProvider.future);
     final List<CharaDetailRecord> records = [];
     if (rootDirectory.existsSync()) {
       final results = await compute(_loadAllCharaDetailRecord, rootDirectory);
@@ -242,8 +247,19 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
     for (final e in records) {
       _updateRecordInfo(e);
     }
+    // Ensure the archive has finished loading before we start accepting captures,
+    // so add()'s synchronous read sees it. Guard so an archive load failure does
+    // not take down the active store; add() then degrades to active-only via the
+    // `?? const []` fallback.
+    try {
+      await archiveLoad;
+    } catch (e, s) {
+      logger.w("Archive preload failed; dedup/inheritance fall back to active-only: $e\n$s");
+    }
     // riverpod 3 removed StreamProvider.stream; listen to the AsyncValue and react
-    // to each newly captured record id.
+    // to each newly captured record id. The callback stays synchronous so add()
+    // (and its duplicate-fail override) completes within the stream-delivery
+    // microtask, before the next native capture message is processed.
     ref.listen(charaDetailRecordCapturedEventProvider, (_, next) {
       next.whenData((e) => addFromFile(e));
     });
@@ -275,8 +291,14 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
   }
 
   void add(CharaDetailRecord record) {
-    final records = _records;
-    final duplicated = records.firstWhereOrNull((e) => record.isSameChara(e));
+    final activeRecords = _records;
+    // Consider archived records too, so a re-capture of an archived chara is
+    // rejected as a duplicate and inheritance can link across both sets. Falls
+    // back to active-only if the archive failed to preload (see build()).
+    final archiveRecords =
+        ref.read(charaDetailArchiveStorageLoaderProvider).asData?.value ?? const <CharaDetailRecord>[];
+    final existing = [...activeRecords, ...archiveRecords];
+    final duplicated = existing.firstWhereOrNull((e) => record.isSameChara(e));
     if (duplicated != null && duplicated.id != record.id) {
       (rootDirectory / record.id).deleteSyncWithCheck(recursive: true);
       _duplicatedCharaEvent.add(_duplicatedCharaEventSequence++);
@@ -284,25 +306,37 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
       return;
     }
 
-    // Link this record to existing parents/children by matching factors and
-    // card, then persist any record.json (this record and/or existing children)
-    // whose parent ids changed.
-    final resolution = InheritanceResolver.resolveForNewRecord(record, records);
+    // Link this record to existing parents/children (in either the active or the
+    // archive set) by matching factors and card, then persist any record.json
+    // whose parent ids changed, routing each change back to its owning store.
+    final resolution = InheritanceResolver.resolveForNewRecord(record, existing);
     final resolvedRecord = resolution.changed.firstWhereOrNull((e) => e.id == record.id) ?? record;
-    final childUpdates = {for (final e in resolution.changed.where((e) => e.id != record.id)) e.id: e};
+    final archiveIds = {for (final e in archiveRecords) e.id};
+    final activeChildUpdates = <String, CharaDetailRecord>{};
+    final archiveChildUpdates = <CharaDetailRecord>[];
     for (final updated in resolution.changed) {
-      _persist(updated);
+      if (archiveIds.contains(updated.id)) {
+        archiveChildUpdates.add(updated);
+      } else {
+        // The new record (always active) and any active children persist here.
+        _persist(updated);
+        if (updated.id != record.id) {
+          activeChildUpdates[updated.id] = updated;
+        }
+      }
     }
+    // Archived children are written back and republished by the archive store.
+    ref.read(charaDetailArchiveStorageLoaderProvider.notifier).applyInheritanceUpdates(archiveChildUpdates);
     _updateRecordInfo(resolvedRecord);
 
-    // `records` already folds in any pending batch updates, so publishing it
+    // `activeRecords` already folds in any pending batch updates, so publishing it
     // and clearing the buffer keeps the next replaceBy re-snapshotting cleanly.
     // Drop any existing entry with the same id so re-adding a record (same id)
     // replaces it instead of appending a duplicate.
     _pendingRecords = null;
     state = AsyncData([
-      for (final e in records)
-        if (e.id != resolvedRecord.id) childUpdates[e.id] ?? e,
+      for (final e in activeRecords)
+        if (e.id != resolvedRecord.id) activeChildUpdates[e.id] ?? e,
       resolvedRecord,
     ]);
 
@@ -317,14 +351,25 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
   /// Re-resolves parent/child links across every stored record (manual action).
   ///
   /// Unlike the per-capture resolution, this is authoritative: it both sets and
-  /// clears links so the whole storage reflects the current matches. Records
-  /// whose links change are rewritten to disk and republished.
+  /// clears links so the whole storage reflects the current matches. The active
+  /// and archive sets are resolved together, and each changed record is rewritten
+  /// to disk and republished in its owning store. The archive is loaded by the
+  /// time this store exists (build() awaits it), so the read is synchronous.
   void resolveAllInheritance() {
-    final resolution = InheritanceResolver.resolveAll(_records);
+    final archiveRecords =
+        ref.read(charaDetailArchiveStorageLoaderProvider).asData?.value ?? const <CharaDetailRecord>[];
+    final resolution = InheritanceResolver.resolveAll([..._records, ...archiveRecords]);
+    final archiveIds = {for (final e in archiveRecords) e.id};
+    final archiveUpdates = <CharaDetailRecord>[];
     for (final updated in resolution.changed) {
-      _persist(updated);
-      replaceBy(updated, id: updated.id);
+      if (archiveIds.contains(updated.id)) {
+        archiveUpdates.add(updated);
+      } else {
+        _persist(updated);
+        replaceBy(updated, id: updated.id);
+      }
     }
+    ref.read(charaDetailArchiveStorageLoaderProvider.notifier).applyInheritanceUpdates(archiveUpdates);
     forceRebuild();
     _surfaceInheritance(resolution, alwaysReport: true);
   }
@@ -543,12 +588,14 @@ final charaDetailRecordStorageProvider = Provider<List<CharaDetailRecord>>((ref)
   return ref.watch(charaDetailRecordStorageLoaderProvider).requireValue;
 });
 
-/// Read-only view over the archived records under `chara_detail/archive/`.
+/// Storage for the archived records under `chara_detail/archive/`.
 ///
 /// Deliberately minimal: unlike [CharaDetailRecordStorage] it registers no
-/// capture listener, runs no version check, and builds no card/inheritance maps.
-/// That keeps capture, dedup, and re-recognition bound exclusively to the active
-/// set, so archived records are structurally excluded from re-recognition.
+/// capture listener and runs no version check, so archived records are
+/// structurally excluded from re-recognition. They are, however, included in
+/// capture-time and manual inheritance resolution and in capture dedup: the
+/// active store reads this set as extra candidates and writes back any archived
+/// record whose parent links change via [applyInheritanceUpdates].
 class CharaDetailArchiveStorage extends AsyncNotifier<List<CharaDetailRecord>> implements CharaDetailRecordMutator {
   late DirectoryPath rootDirectory;
 
@@ -571,6 +618,37 @@ class CharaDetailArchiveStorage extends AsyncNotifier<List<CharaDetailRecord>> i
 
   CharaDetailRecord? getBy({required String id}) {
     return state.asData?.value.firstWhereOrNull((e) => e.id == id);
+  }
+
+  /// Writes [record] back to its archived `record.json`, matching the on-disk
+  /// 4-space-indent format of [CharaDetailRecordStorage._persist] and the native
+  /// recognizer.
+  void _persist(CharaDetailRecord record) {
+    recordPathOf(
+      record,
+    ).filePath("record.json").writeAsStringSync(const JsonEncoder.withIndent('    ').convert(record.toMap()));
+  }
+
+  /// Persists inheritance-updated archived [records] and swaps them into the
+  /// in-memory list by id.
+  ///
+  /// Called by the active store's capture-time and manual inheritance resolution
+  /// when an archived record's parent links change. A no-op for an empty list.
+  /// Disk is always updated; the in-memory swap is skipped only if the archive
+  /// view never loaded (the next build reads the updated json from disk).
+  void applyInheritanceUpdates(List<CharaDetailRecord> records) {
+    if (records.isEmpty) {
+      return;
+    }
+    for (final record in records) {
+      _persist(record);
+    }
+    final current = state.asData?.value;
+    if (current == null) {
+      return;
+    }
+    final byId = {for (final record in records) record.id: record};
+    state = AsyncData([for (final e in current) byId[e.id] ?? e]);
   }
 
   /// Appends just-archived [records] to the in-memory list, mirroring the active

--- a/lib/src/core/providers.dart
+++ b/lib/src/core/providers.dart
@@ -95,7 +95,9 @@ class PathInfo {
   /// Sibling of [charaDetailActiveDir] holding archived records.
   ///
   /// Archived records are moved here, out of the scanned `active/` tree, so they
-  /// are excluded from capture/dedup/re-recognition while remaining browsable.
+  /// are excluded from re-recognition while remaining browsable. They are still
+  /// considered for capture dedup and inheritance resolution, which read both the
+  /// active and archive sets.
   DirectoryPath get charaDetailArchiveDir => charaDetailDir / "archive";
 
   DirectoryPath get charaDetailQuarantineDir => charaDetailDir / "quarantine";

--- a/test/inheritance_resolver_test.dart
+++ b/test/inheritance_resolver_test.dart
@@ -110,6 +110,22 @@ void main() {
       expect(result.ambiguities.single.candidateCount, 2);
     });
 
+    test('new parent is not linked when another stored record already satisfies the slot', () {
+      // Direction B ambiguity: the new parent and an existing record both match
+      // the child's slot, so the child is left unlinked and reported instead.
+      final child = makeRecord(id: 'c', card: 20, parent1Card: 10, parent1: [const Factor(1, 1)]);
+      final existingParent = makeRecord(id: 'p_existing', card: 10, self: [const Factor(1, 1)]);
+      final newParent = makeRecord(id: 'p_new', card: 10, self: [const Factor(1, 1)]);
+
+      final result = InheritanceResolver.resolveForNewRecord(newParent, [child, existingParent]);
+
+      expect(result.changed, isEmpty);
+      expect(result.ambiguities, hasLength(1));
+      expect(result.ambiguities.single.recordId, 'c');
+      expect(result.ambiguities.single.slot, 1);
+      expect(result.ambiguities.single.candidateCount, 2);
+    });
+
     test('card mismatch does not link', () {
       final parent = makeRecord(id: 'p', card: 11, self: [const Factor(1, 1)]);
       final child = makeRecord(id: 'c', card: 20, parent1Card: 10, parent1: [const Factor(1, 1)]);

--- a/test/storage_archive_inheritance_test.dart
+++ b/test/storage_archive_inheritance_test.dart
@@ -169,4 +169,55 @@ void main() {
     expect(active.length, lengthBefore, reason: 'duplicate not added to the active set');
     expect(container.read(charaDetailCaptureStateProvider).error, 'duplicated_character');
   });
+
+  test('resolveAllInheritance keeps active->archive links when the archive failed to load', () async {
+    final root = DirectoryPath(tempRoot.path);
+    final info = pathInfoFor(root);
+    final activeDir = info.charaDetailActiveDir;
+
+    // Active child already linked to an archived parent on disk. resolveAll is
+    // authoritative and would clear this link if it treated the (failed) archive
+    // as empty; the guard must abort and leave the link intact.
+    writeRecord(
+      activeDir,
+      makeRecord(
+        id: 'child-active',
+        card: 20,
+        parent1Card: 10,
+        parent1: const [Factor(1, 1)],
+        parent1Id: 'parent-archive',
+      ),
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        pathInfoLoader.overrideWith((ref) async => pathInfoFor(root)),
+        moduleVersionLoader.overrideWith((ref) async => null),
+        // Force the archive store into an error state so its asData is null.
+        charaDetailArchiveStorageLoaderProvider.overrideWith(_FailingArchiveStorage.new),
+      ],
+    );
+    addTearDown(container.dispose);
+    final active = container.read(charaDetailRecordStorageLoaderProvider.notifier);
+    await container.read(charaDetailRecordStorageLoaderProvider.future);
+    // Let the overridden archive build settle into AsyncError before resolving.
+    await container.read(charaDetailArchiveStorageLoaderProvider.future).catchError((_) => <CharaDetailRecord>[]);
+
+    expect(parentOnDisk(activeDir, 'child-active', 1), 'parent-archive', reason: 'precondition: starts linked');
+
+    active.resolveAllInheritance();
+
+    // Link preserved on disk and in memory; not cleared against the missing archive.
+    expect(parentOnDisk(activeDir, 'child-active', 1), 'parent-archive');
+    expect(active.getBy(id: 'child-active')!.metadata.recordId.parent1, 'parent-archive');
+  });
+}
+
+/// Archive store stand-in whose build always fails, so its provider settles into
+/// [AsyncError] (asData == null) — exercising resolveAllInheritance's guard.
+class _FailingArchiveStorage extends CharaDetailArchiveStorage {
+  @override
+  Future<List<CharaDetailRecord>> build() async {
+    throw StateError('archive load failed');
+  }
 }

--- a/test/storage_archive_inheritance_test.dart
+++ b/test/storage_archive_inheritance_test.dart
@@ -1,0 +1,172 @@
+// Verifies that capture dedup and inheritance resolution span the active AND
+// archive record sets: a re-capture matching an archived chara is rejected, the
+// manual full resolution links an active child to an archived parent, and an
+// archived child's record.json is written back when its parent resolves.
+//
+// Drives the real CharaDetailRecordStorage / CharaDetailArchiveStorage notifiers
+// over temp directories seeded with synthetic record.json files.
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/storage_archive_inheritance_test.dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/chara_detail/chara_detail_record.dart';
+import 'package:umacapture/src/chara_detail/storage.dart';
+import 'package:umacapture/src/core/mapper_init.dart';
+import 'package:umacapture/src/core/path_entity.dart';
+import 'package:umacapture/src/core/platform_controller.dart';
+import 'package:umacapture/src/core/providers.dart';
+import 'package:umacapture/src/core/version_check.dart';
+
+Character _chara(int card) => Character(0, 0, card, 0);
+
+Parent _parent(int card) => Parent(_chara(card), _chara(0), _chara(0), null);
+
+// Builds a record carrying only the fields dedup and the resolver read; the rest
+// is dummy. Mirrors the helper in inheritance_resolver_test.dart.
+CharaDetailRecord makeRecord({
+  required String id,
+  required int card,
+  List<Factor> self = const [],
+  int parent1Card = 0,
+  List<Factor> parent1 = const [],
+  String? parent1Id,
+}) {
+  final metadata = Metadata(
+    '1.0.0',
+    'JPN',
+    RecordId(id, parent1Id, null),
+    'trainer',
+    '2026-01-01T00:00:00+0900',
+    '2026-01-01T00:00:00+0900',
+    RecordStage.active,
+    0,
+    null,
+    RecordType.standard,
+  );
+  return CharaDetailRecord(
+    metadata,
+    _chara(card),
+    0,
+    const CharacterStatus(0, 0, 0, 0, 0),
+    const AptitudeSet(GroundAptitude(0, 0), DistanceAptitude(0, 0, 0, 0), StyleAptitude(0, 0, 0, 0)),
+    const <Skill>[],
+    FactorSet(self, parent1, const []),
+    const <SupportCard>[],
+    Family(_parent(parent1Card), _parent(0)),
+    0,
+    const Scenario(0),
+    null,
+    null,
+    '2026/01/01',
+    const <Race>[],
+  );
+}
+
+void main() {
+  setUpAll(initializeMappers);
+
+  late Directory tempRoot;
+  setUp(() => tempRoot = Directory.systemTemp.createTempSync('uma_arch_inh'));
+  tearDown(() => tempRoot.deleteSync(recursive: true));
+
+  PathInfo pathInfoFor(DirectoryPath root) => PathInfo(
+    documentDir: root,
+    supportDir: root,
+    executableDir: root / 'exe',
+    downloadDir: root / 'dl',
+    dataRoot: root,
+  );
+
+  // Writes [record] as record.json under [storeDir]/<id>, as the recognizer would.
+  void writeRecord(DirectoryPath storeDir, CharaDetailRecord record) {
+    File('${(storeDir / record.id).path}/record.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(const JsonEncoder.withIndent('    ').convert(record.toMap()));
+  }
+
+  String? parentOnDisk(DirectoryPath storeDir, String id, int slot) {
+    final map = jsonDecode(File('${(storeDir / id).path}/record.json').readAsStringSync()) as Map<String, dynamic>;
+    return (map['metadata']['record_id'] as Map)['parent$slot'] as String?;
+  }
+
+  ProviderContainer makeContainer(DirectoryPath root) {
+    return ProviderContainer(
+      overrides: [
+        pathInfoLoader.overrideWith((ref) async => pathInfoFor(root)),
+        // Skip the (network/version) module check so build() returns immediately.
+        moduleVersionLoader.overrideWith((ref) async => null),
+      ],
+    );
+  }
+
+  test('manual resolveAllInheritance links across active+archive and writes both stores', () async {
+    final root = DirectoryPath(tempRoot.path);
+    final info = pathInfoFor(root);
+    final activeDir = info.charaDetailActiveDir;
+    final archiveDir = info.charaDetailArchiveDir;
+
+    // active child whose slot1 parent lives in the archive (initially unlinked).
+    writeRecord(activeDir, makeRecord(id: 'child-active', card: 20, parent1Card: 10, parent1: const [Factor(1, 1)]));
+    // archived parent that satisfies that slot.
+    writeRecord(archiveDir, makeRecord(id: 'parent-archive', card: 10, self: const [Factor(1, 1)]));
+    // archived child + its archived parent (exercise the archive write-back).
+    writeRecord(archiveDir, makeRecord(id: 'child-archive', card: 30, parent1Card: 11, parent1: const [Factor(2, 2)]));
+    writeRecord(archiveDir, makeRecord(id: 'parent-archive2', card: 11, self: const [Factor(2, 2)]));
+
+    final container = makeContainer(root);
+    addTearDown(container.dispose);
+    final active = container.read(charaDetailRecordStorageLoaderProvider.notifier);
+    await container.read(charaDetailRecordStorageLoaderProvider.future);
+    await container.read(charaDetailArchiveStorageLoaderProvider.future);
+
+    expect(parentOnDisk(activeDir, 'child-active', 1), isNull, reason: 'precondition: starts unlinked');
+
+    active.resolveAllInheritance();
+
+    // Active child now points at the ARCHIVED parent, on disk and in memory.
+    expect(parentOnDisk(activeDir, 'child-active', 1), 'parent-archive');
+    expect(active.getBy(id: 'child-active')!.metadata.recordId.parent1, 'parent-archive');
+
+    // Archived child's own record.json was rewritten with its resolved parent.
+    expect(parentOnDisk(archiveDir, 'child-archive', 1), 'parent-archive2');
+    final archInMemory = container
+        .read(charaDetailArchiveStorageLoaderProvider)
+        .asData!
+        .value
+        .firstWhere((e) => e.id == 'child-archive');
+    expect(archInMemory.metadata.recordId.parent1, 'parent-archive2');
+  });
+
+  test('capture dedup rejects a record matching an archived chara', () async {
+    final root = DirectoryPath(tempRoot.path);
+    final info = pathInfoFor(root);
+    final activeDir = info.charaDetailActiveDir;
+    final archiveDir = info.charaDetailArchiveDir;
+
+    // The chara lives only in the archive; active holds one unrelated record.
+    writeRecord(archiveDir, makeRecord(id: 'archived-chara', card: 50, self: const [Factor(5, 1)]));
+    writeRecord(activeDir, makeRecord(id: 'unrelated', card: 99));
+
+    final container = makeContainer(root);
+    addTearDown(container.dispose);
+    final active = container.read(charaDetailRecordStorageLoaderProvider.notifier);
+    await container.read(charaDetailRecordStorageLoaderProvider.future);
+    await container.read(charaDetailArchiveStorageLoaderProvider.future);
+    final lengthBefore = active.length;
+
+    // A fresh capture with a new id but the same chara content as the archived one.
+    final captured = makeRecord(id: 'newly-captured', card: 50, self: const [Factor(5, 1)]);
+    expect(captured.isSameChara(makeRecord(id: 'archived-chara', card: 50, self: const [Factor(5, 1)])), isTrue);
+    writeRecord(activeDir, captured); // the recognizer drops the dir before add()
+    final newDir = activeDir / 'newly-captured';
+
+    active.add(captured);
+
+    expect(newDir.existsSync(), isFalse, reason: 'duplicate capture dir deleted');
+    expect(active.length, lengthBefore, reason: 'duplicate not added to the active set');
+    expect(container.read(charaDetailCaptureStateProvider).error, 'duplicated_character');
+  });
+}


### PR DESCRIPTION
## Summary

Archived records (under `chara_detail/archive/`) were previously excluded from capture-time dedup and inheritance resolution: only the active set was considered. This meant re-capturing an archived chara created a duplicate, and parent/child links could not span the active↔archive boundary. This branch includes the archive set in both dedup and inheritance, while keeping archived records structurally excluded from re-recognition.

## Changes

- **Preload the archive in parallel** (`storage.dart` `build()`): the active store `read`s (not `watch`es, not `await`s) the archive loader so capture-time dedup/inheritance can see archived records. Not subscribing means archive write-backs don't rebuild the active store; not awaiting keeps the capture-listener registration window as small as before. Until the scan lands, `add()` degrades to active-only via a `?? const []` fallback.
- **Capture-time dedup & inheritance across both sets** (`add()`): existing candidates are now `active + archive`. Changed records are routed back to their owning store via `_routeInheritanceChanges` — active records persist + republish locally; archived records are batched into `CharaDetailArchiveStorage.applyInheritanceUpdates` (disk always written; in-memory swap skipped if the archive view never loaded).
- **Manual `resolveAllInheritance()` guarded**: `resolveAll` is authoritative (it *clears* stale links), so it aborts with a warning toast (`archive_not_ready`) if the archive hasn't loaded — treating a missing archive as empty would destroy valid active→archive links. The additive capture-time path stays safe without the guard.
- **`InheritanceResolver` indexing**: `resolveForNewRecord` now builds a self-key index once for O(1) candidate lookups instead of a full scan per slot/child. Documented that deletion leaves dangling parent ids, which are harmless and cleared on the next manual resolve.
- **Shared persist helper** `_persistRecordJson` extracted; both stores' `_persist` delegate to it.
- Doc comments updated (`providers.dart`, archive store) to reflect that archived records participate in dedup/inheritance but not re-recognition.

## Tests

- `test/storage_archive_inheritance_test.dart` (new): archive-spanning dedup and inheritance.
- `test/inheritance_resolver_test.dart`: added coverage for the indexed resolution path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
