### PR TITLE
feat(chara_detail): user-resizable columns, row-height modes, and table settings

### DIFF
--- a/assets/license_info.json
+++ b/assets/license_info.json
@@ -772,6 +772,17 @@
         "isSdk": false
     },
     {
+        "name": "flutter_context_menu",
+        "description": "Create and display a customizable context menus in your app.",
+        "homepage": "https://github.com/salah-rashad/flutter_context_menu",
+        "repository": "https://github.com/salah-rashad/flutter_context_menu",
+        "authors": [],
+        "version": "0.4.2",
+        "license": "BSD 3-Clause License\n\nCopyright (c) 2023, Salah Rashad\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice, this\n   list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\n   this list of conditions and the following disclaimer in the documentation\n   and/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its\n   contributors may be used to endorse or promote products derived from\n   this software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"\nAND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\nIMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+        "isMarkdown": false,
+        "isSdk": false
+    },
+    {
         "name": "flutter_driver",
         "description": "Integration and performance test API for Flutter applications",
         "homepage": "https://flutter.dev",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -111,10 +111,20 @@
             "regenerating_message": "認識結果を更新しています",
             "toolbar": {
                 "preset_group": "プリセット",
-                "record_group": "レコード",
-                "row_height": {
-                    "expand_tooltip": "行の高さを内容に合わせて広げる",
-                    "collapse_tooltip": "行の高さを固定し2行で省略する"
+                "record_group": "レコード"
+            },
+            "settings": {
+                "button_tooltip": "テーブルの表示設定",
+                "dialog": {
+                    "title": "テーブル設定",
+                    "close_button": "閉じる"
+                },
+                "display": {
+                    "title": "表示",
+                    "auto_row_height": {
+                        "title": "行の高さを内容に合わせる",
+                        "description": "オンにすると長いテキストを折り返して行を高くします。オフにすると行の高さを固定し、2行を超えるテキストは省略します。"
+                    }
                 }
             },
             "archive_records": {

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -114,7 +114,7 @@
                 "record_group": "レコード"
             },
             "settings": {
-                "button_tooltip": "テーブルの表示設定",
+                "button_tooltip": "テーブル設定",
                 "dialog": {
                     "title": "テーブル設定",
                     "close_button": "閉じる"
@@ -122,17 +122,22 @@
                 "display": {
                     "title": "表示",
                     "row_height_mode": {
-                        "title": "行の高さ",
-                        "description": "行の高さの調整方法を選びます。",
+                        "title": "行高さ自動調整",
+                        "description": "文字数が多いセルの高さの調整方法を指定します。",
                         "choice": {
                             "wrap": "折り返し",
                             "auto_per_row": "自動調整（行）",
                             "auto_uniform": "自動調整（均一）"
+                        },
+                        "tooltip": {
+                            "wrap": "行の高さを下限値で固定し、収まらない文字は省略記号で表示します。",
+                            "auto_per_row": "行ごとに高さを調整して、すべての内容が収まるようにします。",
+                            "auto_uniform": "すべての行を最も高い行に揃えて、すべての内容が収まるようにします。"
                         }
                     },
                     "min_row_lines": {
-                        "title": "最低行高さ（行数）",
-                        "description": "折り返しでは固定の行数、自動調整では行の高さの下限になります。"
+                        "title": "行高さ下限",
+                        "description": "すべての行の高さの下限とする行数を指定します。"
                     }
                 }
             },

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -111,7 +111,11 @@
             "regenerating_message": "認識結果を更新しています",
             "toolbar": {
                 "preset_group": "プリセット",
-                "record_group": "レコード"
+                "record_group": "レコード",
+                "row_height": {
+                    "expand_tooltip": "行の高さを内容に合わせて広げる",
+                    "collapse_tooltip": "行の高さを固定し2行で省略する"
+                }
             },
             "archive_records": {
                 "progress_message": "アーカイブしています",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -949,6 +949,10 @@
                 "archive_record": "データをアーカイブ",
                 "group_file": "ファイル"
             },
+            "column_context_menu": {
+                "reset_width": "列幅を自動調整に戻す",
+                "reset_all_widths": "すべての列幅を自動調整に戻す"
+            },
             "preview": {
                 "rental": "レンタル",
                 "dialog": {

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -974,7 +974,12 @@
             },
             "column_context_menu": {
                 "reset_width": "列幅を自動調整に戻す",
-                "reset_all_widths": "すべての列幅を自動調整に戻す"
+                "sort": {
+                    "label": "ソート順",
+                    "ascending": "昇順",
+                    "descending": "降順",
+                    "none": "ソート解除"
+                }
             },
             "preview": {
                 "rental": "レンタル",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -121,9 +121,18 @@
                 },
                 "display": {
                     "title": "表示",
-                    "auto_row_height": {
-                        "title": "行の高さを内容に合わせる",
-                        "description": "オンにすると長いテキストを折り返して行を高くします。オフにすると行の高さを固定し、2行を超えるテキストは省略します。"
+                    "row_height_mode": {
+                        "title": "行の高さ",
+                        "description": "行の高さの調整方法を選びます。",
+                        "choice": {
+                            "wrap": "折り返し",
+                            "auto_per_row": "自動調整（行）",
+                            "auto_uniform": "自動調整（均一）"
+                        }
+                    },
+                    "min_row_lines": {
+                        "title": "最低行高さ（行数）",
+                        "description": "折り返しでは固定の行数、自動調整では行の高さの下限になります。"
                     }
                 }
             },

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -75,7 +75,7 @@ class _RowHeightModeNotifier extends ExclusiveItemsNotifier<RowHeightMode> {
 /// The minimum row height in text lines (default two). Acts as the fixed height
 /// in [RowHeightMode.wrap] and as the floor in the auto modes.
 final charaDetailMinRowLinesProvider = IntNotifierProvider(() {
-  return IntNotifier(entryKey: SettingsEntryKey.minRowLines.name, defaultValue: 2, min: 1, max: 6);
+  return IntNotifier(entryKey: SettingsEntryKey.minRowLines.name, defaultValue: 2, min: 1, max: 20);
 });
 
 /// Renders a text-based cell, capping the line count only in

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -211,6 +211,21 @@ abstract class ColumnSpec<T> with ColumnSpecMappable<T> {
   /// it generically here.
   String? get description => null;
 
+  /// User-pinned display width for this column in logical pixels, or null when the
+  /// column auto-fits to its content. A non-null value makes [autoFitColumns] skip
+  /// the column so the user's chosen width survives data and layout changes; null
+  /// (the default, and what legacy specs saved before this field existed decode to)
+  /// keeps the content-driven auto-fit. Every editable concrete spec overrides this
+  /// with a stored field and implements [withWidth].
+  double? get width => null;
+
+  /// Returns a copy of this spec with its pinned [width] replaced (null clears it,
+  /// reverting the column to auto-fit). Like [withHidden], every editable concrete
+  /// spec must override this via copyWith; the base throws rather than silently
+  /// no-op'ing so a spec that forgets to override fails loudly. The undecodable
+  /// placeholder, which is never editable, overrides this back to a no-op.
+  ColumnSpec withWidth(double? width) => throw UnsupportedError('Concrete specs must override withWidth');
+
   /// Returns a copy of this spec with its [hidden] flag replaced. Every concrete,
   /// editable spec must override this via copyWith. Unlike [withChildren] (which
   /// leaf columns legitimately no-op on), the base throws rather than silently
@@ -359,6 +374,11 @@ class BrokenPlaceholderSpec extends ColumnSpec<Null> {
   // Inert for the same reason as [withHidden]: a broken column is never edited.
   @override
   ColumnSpec withDescription(String? description) => this;
+
+  // Inert like [withHidden]/[withDescription]: a broken column is never resized.
+  // Its width getter inherits the base default (null), so it always auto-fits.
+  @override
+  ColumnSpec withWidth(double? width) => this;
 
   @override
   List<Null> parse(RefBase ref, List<CharaDetailRecord> records) {
@@ -827,6 +847,12 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
       // would shrink it below the checkbox's intrinsic width and clip it. Leave
       // its fixed width untouched.
       if (col.enableRowChecked) {
+        continue;
+      }
+      // A column the user has pinned to an explicit width (spec.width != null) is
+      // intentionally excluded so its chosen width survives data/layout changes.
+      // Its width was applied at plutoColumn build time and must not be remeasured.
+      if (col.getUserData<ColumnSpec>()?.width != null) {
         continue;
       }
       final enabled = col.enableDropToResize;

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -17,6 +17,8 @@ import '/src/core/callback.dart';
 import '/src/core/json_adapter.dart';
 import '/src/core/utils.dart';
 import '/src/gui/toast.dart';
+import '/src/preference/notifier.dart';
+import '/src/preference/settings_state.dart';
 import '/src/preference/storage_box.dart';
 
 part 'base.mapper.dart';
@@ -26,6 +28,47 @@ const tr_common = "pages.chara_detail.column_predicate.common";
 
 typedef LabelMap = Map<String, List<String>>;
 typedef OnSpecChanged = void Function(ColumnSpec);
+
+/// Whether table cells grow their row to fit the wrapped text (true) or keep a
+/// fixed row height and ellipsize at two lines (false). A global display toggle,
+/// persisted in settings and watched by [CellText] and the row-height pass, so a
+/// narrowed column either reflows into taller rows or truncates cleanly instead
+/// of clipping its third line.
+final charaDetailAutoRowHeightProvider = BooleanNotifierProvider(() {
+  return BooleanNotifier(entryKey: SettingsEntryKey.autoRowHeight.name, defaultValue: false);
+});
+
+/// Renders a text-based cell, switching between auto-grow (full wrap, no line
+/// cap) and fixed-height (two lines + ellipsis) per [charaDetailAutoRowHeightProvider].
+///
+/// Every text column renderer uses this instead of a bare [Text] so the
+/// row-height toggle is honored consistently; the row-height pass measures the
+/// same text at the same width so a grown row exactly fits the wrapped lines.
+class CellText extends ConsumerWidget {
+  const CellText(this.data, {super.key, this.textAlign, this.style, this.opacity});
+
+  final String data;
+  final TextAlign? textAlign;
+  final TextStyle? style;
+
+  /// Dims the text (e.g. the memo placeholder) without a separate Opacity widget
+  /// that would change the cell's measured height.
+  final double? opacity;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final expand = ref.watch(charaDetailAutoRowHeightProvider);
+    final text = Text(
+      data,
+      textAlign: textAlign,
+      style: style,
+      softWrap: true,
+      maxLines: expand ? null : 2,
+      overflow: expand ? null : TextOverflow.ellipsis,
+    );
+    return opacity == null ? text : Opacity(opacity: opacity!, child: text);
+  }
+}
 
 enum ColumnCategory {
   trainee,
@@ -225,6 +268,13 @@ abstract class ColumnSpec<T> with ColumnSpecMappable<T> {
   /// no-op'ing so a spec that forgets to override fails loudly. The undecodable
   /// placeholder, which is never editable, overrides this back to a no-op.
   ColumnSpec withWidth(double? width) => throw UnsupportedError('Concrete specs must override withWidth');
+
+  /// Whether this column renders wrapping text (and so can grow a row's height
+  /// when narrowed). Columns that render a fixed-height widget or icon (character
+  /// portrait, logic mark, rating stars, family-registration badge) override this
+  /// to false so the auto row-height pass never inflates a row from their
+  /// width-measurement placeholder text. Defaults to true.
+  bool get wrapsText => true;
 
   /// Returns a copy of this spec with its [hidden] flag replaced. Every concrete,
   /// editable spec must override this via copyWith. Unlike [withChildren] (which
@@ -865,6 +915,89 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
       }
       col.enableDropToResize = enabled;
     }
+  }
+
+  // Measures the rendered height of [text] wrapped to [maxWidth] in [style],
+  // matching how [CellText] lays the same text out so a grown row fits exactly.
+  double _wrappedTextHeight(BuildContext context, String text, TextStyle style, double maxWidth) {
+    if (text.isEmpty || maxWidth <= 0) {
+      return 0;
+    }
+    final textPainter = TextPainter(
+      text: TextSpan(style: style, text: text),
+      textDirection: ui.TextDirection.ltr,
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout(maxWidth: maxWidth);
+    return textPainter.height;
+  }
+
+  // The height a row needs to fully show its pinned columns' wrapped text, or null
+  // when the fixed grid height already suffices. Only pinned ([width] != null),
+  // text-rendering ([wrapsText]) columns can wrap — auto-fit columns are sized to
+  // their widest cell, and widget/icon columns render at a fixed height — so the
+  // scan is bounded to those.
+  double? _expandedRowHeight(BuildContext context, TrinaRow row, TextStyle style, double base) {
+    var maxHeight = base;
+    for (final col in columns) {
+      final spec = col.getUserData<ColumnSpec>();
+      if (spec == null || spec.width == null || !spec.wrapsText) {
+        continue;
+      }
+      final cellPadding = col.cellPadding ?? configuration.style.defaultCellPadding;
+      final text = col.formattedValueForDisplay(row.cells[col.field]?.value);
+      final height =
+          _wrappedTextHeight(context, text, style, col.width - cellPadding.horizontal) + cellPadding.vertical;
+      if (height > maxHeight) {
+        maxHeight = height;
+      }
+    }
+    // The 2px buffer absorbs sub-pixel rounding so the last wrapped line is never
+    // clipped. null leaves the row at the grid default (no growth needed).
+    return maxHeight > base ? maxHeight + 2 : null;
+  }
+
+  // Sets each row's height to fit wrapped text in pinned columns ([expand]), or
+  // clears it back to the fixed grid height (!expand). trina's setRowHeight
+  // rebuilds the row, dropping its attached record and notifying per row, so rows
+  // are replaced here in one pass — carrying over cells, key, flags, and the
+  // record user-data — and the caller notifies once. Returns whether anything
+  // changed.
+  bool applyAutoRowHeights({required bool expand}) {
+    final context = gridKey.currentContext;
+    if (context == null) {
+      return false;
+    }
+    final style = DefaultTextStyle.of(context).style;
+    final base = configuration.style.rowHeight;
+    var changed = false;
+    for (var i = 0; i < refRows.length; i++) {
+      final row = refRows[i];
+      final target = expand ? _expandedRowHeight(context, row, style, base) : null;
+      if (row.height == target) {
+        continue;
+      }
+      final record = row.getUserData<CharaDetailRecord>();
+      final newRow =
+          TrinaRow(
+              cells: row.cells,
+              type: row.type,
+              sortIdx: row.sortIdx,
+              data: row.data,
+              checked: row.checked ?? false,
+              key: row.key,
+              frozen: row.frozen,
+              height: target,
+              metadata: row.metadata,
+            )
+            ..setParent(row.parent)
+            ..setState(row.state);
+      if (record != null) {
+        newRow.setUserData(record);
+      }
+      refRows[i] = newRow;
+      changed = true;
+    }
+    return changed;
   }
 
   TrinaColumn? getColumn(String field) {

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:collection/collection.dart';
@@ -29,20 +30,60 @@ const tr_common = "pages.chara_detail.column_predicate.common";
 typedef LabelMap = Map<String, List<String>>;
 typedef OnSpecChanged = void Function(ColumnSpec);
 
-/// Whether table cells grow their row to fit the wrapped text (true) or keep a
-/// fixed row height and ellipsize at two lines (false). A global display toggle,
-/// persisted in settings and watched by [CellText] and the row-height pass, so a
-/// narrowed column either reflows into taller rows or truncates cleanly instead
-/// of clipping its third line.
-final charaDetailAutoRowHeightProvider = BooleanNotifierProvider(() {
-  return BooleanNotifier(entryKey: SettingsEntryKey.autoRowHeight.name, defaultValue: false);
+/// How table rows size themselves to their text. A global display preference,
+/// persisted in settings and watched by [CellText] and the row-height pass.
+///
+/// - [wrap]: every row is fixed at the minimum height; text wraps up to the
+///   minimum line count and then ellipsizes (the former "auto off" behavior,
+///   now with a configurable line count).
+/// - [autoPerRow]: each row grows to fit its own wrapped text, floored at the
+///   minimum height (the former "auto on" behavior, now with a floor).
+/// - [autoUniform]: every row takes the height of the tallest row's wrapped
+///   text, floored at the minimum height, so the grid stays visually even.
+@MappableEnum(caseStyle: CaseStyle.snakeCase)
+enum RowHeightMode { wrap, autoPerRow, autoUniform }
+
+/// The current row-height mode, persisted across launches. Migrates the legacy
+/// boolean [SettingsEntryKey.autoRowHeight] on first read: a user who had
+/// auto-grow on lands on [RowHeightMode.autoPerRow], everyone else on the
+/// default [RowHeightMode.wrap].
+final charaDetailRowHeightModeProvider = ExclusiveItemsNotifierProvider<RowHeightMode>(() {
+  return _RowHeightModeNotifier();
 });
 
-/// Renders a text-based cell, switching between auto-grow (full wrap, no line
-/// cap) and fixed-height (two lines + ellipsis) per [charaDetailAutoRowHeightProvider].
+class _RowHeightModeNotifier extends ExclusiveItemsNotifier<RowHeightMode> {
+  _RowHeightModeNotifier()
+    : super(
+        entryKey: SettingsEntryKey.rowHeightMode.name,
+        values: RowHeightMode.values,
+        defaultValue: RowHeightMode.wrap,
+      );
+
+  @override
+  RowHeightMode build() {
+    final stored = super.build();
+    final box = ref.read(storageBoxProvider);
+    if (box.pull<RowHeightMode>(SettingsEntryKey.rowHeightMode.name) != null) {
+      return stored;
+    }
+    // No new-style value yet: honor the retired auto-row-height toggle once.
+    final legacy = box.pull<bool>(SettingsEntryKey.autoRowHeight.name);
+    return legacy == true ? RowHeightMode.autoPerRow : stored;
+  }
+}
+
+/// The minimum row height in text lines (default two). Acts as the fixed height
+/// in [RowHeightMode.wrap] and as the floor in the auto modes.
+final charaDetailMinRowLinesProvider = IntNotifierProvider(() {
+  return IntNotifier(entryKey: SettingsEntryKey.minRowLines.name, defaultValue: 2, min: 1, max: 6);
+});
+
+/// Renders a text-based cell, capping the line count only in
+/// [RowHeightMode.wrap] (minimum lines + ellipsis) and otherwise wrapping
+/// freely so the row-height pass can grow the row to fit.
 ///
 /// Every text column renderer uses this instead of a bare [Text] so the
-/// row-height toggle is honored consistently; the row-height pass measures the
+/// row-height mode is honored consistently; the row-height pass measures the
 /// same text at the same width so a grown row exactly fits the wrapped lines.
 class CellText extends ConsumerWidget {
   const CellText(this.data, {super.key, this.textAlign, this.style, this.opacity});
@@ -57,14 +98,15 @@ class CellText extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final expand = ref.watch(charaDetailAutoRowHeightProvider);
+    final clamp = ref.watch(charaDetailRowHeightModeProvider) == RowHeightMode.wrap;
+    final minLines = ref.watch(charaDetailMinRowLinesProvider);
     final text = Text(
       data,
       textAlign: textAlign,
       style: style,
       softWrap: true,
-      maxLines: expand ? null : 2,
-      overflow: expand ? null : TextOverflow.ellipsis,
+      maxLines: clamp ? minLines : null,
+      overflow: clamp ? TextOverflow.ellipsis : null,
     );
     return opacity == null ? text : Opacity(opacity: opacity!, child: text);
   }
@@ -931,13 +973,12 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     return textPainter.height;
   }
 
-  // The height a row needs to fully show its pinned columns' wrapped text, or null
-  // when the fixed grid height already suffices. Only pinned ([width] != null),
-  // text-rendering ([wrapsText]) columns can wrap — auto-fit columns are sized to
-  // their widest cell, and widget/icon columns render at a fixed height — so the
-  // scan is bounded to those.
-  double? _expandedRowHeight(BuildContext context, TrinaRow row, TextStyle style, double base) {
-    var maxHeight = base;
+  // The rendered height of a row's wrapped text across its pinned, text-rendering
+  // columns, or 0 when none can wrap. Only pinned ([width] != null), text
+  // ([wrapsText]) columns wrap — auto-fit columns are sized to their widest cell,
+  // and widget/icon columns render at a fixed height — so the scan skips them.
+  double _contentHeight(BuildContext context, TrinaRow row, TextStyle style) {
+    var maxHeight = 0.0;
     for (final col in columns) {
       final spec = col.getUserData<ColumnSpec>();
       if (spec == null || spec.width == null || !spec.wrapsText) {
@@ -951,28 +992,48 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
         maxHeight = height;
       }
     }
-    // The 2px buffer absorbs sub-pixel rounding so the last wrapped line is never
-    // clipped. null leaves the row at the grid default (no growth needed).
-    return maxHeight > base ? maxHeight + 2 : null;
+    // The 2px buffer absorbs sub-pixel rounding so the last wrapped line is never clipped.
+    return maxHeight > 0 ? maxHeight + 2 : 0;
   }
 
-  // Sets each row's height to fit wrapped text in pinned columns ([expand]), or
-  // clears it back to the fixed grid height (!expand). trina's setRowHeight
-  // rebuilds the row, dropping its attached record and notifying per row, so rows
-  // are replaced here in one pass — carrying over cells, key, flags, and the
-  // record user-data — and the caller notifies once. Returns whether anything
-  // changed.
-  bool applyAutoRowHeights({required bool expand}) {
+  // The pixel height of [minLines] text lines plus the default cell padding,
+  // serving as the fixed height in wrap mode and the floor in the auto modes.
+  double _minRowHeight(BuildContext context, TextStyle style, int minLines) {
+    final painter = TextPainter(
+      text: TextSpan(style: style, text: 'X'),
+      textDirection: ui.TextDirection.ltr,
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout();
+    return painter.preferredLineHeight * minLines + configuration.style.defaultCellPadding.vertical;
+  }
+
+  // Sizes every row for [mode], flooring at [minLines] text lines: wrap fixes all
+  // rows at the floor, autoPerRow grows each to its own text, autoUniform grows
+  // all to the tallest row's text. trina's setRowHeight rebuilds the row, dropping
+  // its attached record and notifying per row, so rows are replaced here in one
+  // pass — carrying over cells, key, flags, and the record user-data — and the
+  // caller notifies once. Returns whether anything changed.
+  bool applyRowHeights({required RowHeightMode mode, required int minLines}) {
     final context = gridKey.currentContext;
     if (context == null) {
       return false;
     }
     final style = DefaultTextStyle.of(context).style;
-    final base = configuration.style.rowHeight;
+    final minHeight = _minRowHeight(context, style, minLines);
+    final List<double> targets;
+    switch (mode) {
+      case RowHeightMode.wrap:
+        targets = List.filled(refRows.length, minHeight);
+      case RowHeightMode.autoPerRow:
+        targets = [for (final row in refRows) max(minHeight, _contentHeight(context, row, style))];
+      case RowHeightMode.autoUniform:
+        final tallest = refRows.fold<double>(minHeight, (h, row) => max(h, _contentHeight(context, row, style)));
+        targets = List.filled(refRows.length, tallest);
+    }
     var changed = false;
     for (var i = 0; i < refRows.length; i++) {
       final row = refRows[i];
-      final target = expand ? _expandedRowHeight(context, row, style, base) : null;
+      final target = targets[i];
       if (row.height == target) {
         continue;
       }

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -913,6 +913,54 @@ final selectedColumnSpecEntryKeyProvider = Provider<String>((ref) {
 // incremental so scroll offset and row identity are preserved.
 const _bulkReconcileThreshold = 32;
 
+// A text-rendering ([ColumnSpec.wrapsText]) column paired with its per-pass
+// layout: the content max-width text wraps within and the vertical cell padding
+// added to the wrapped height. Constant across rows within one row-height pass.
+typedef _WrapColumn = ({TrinaColumn col, ColumnSpec spec, double maxWidth, double verticalPadding});
+
+// Measures wrapped-text row heights for one [applyRowHeights] pass. Built once
+// from the wrapping columns' fixed layout so the per-row scan does no repeated
+// column-metadata lookups, and reuses a single [TextPainter] across every cell
+// instead of allocating one per measurement. Call [dispose] when the pass ends.
+class _RowHeightMeasurer {
+  _RowHeightMeasurer({required this._columns, required this._style, required TextScaler textScaler})
+    : _painter = TextPainter(textDirection: ui.TextDirection.ltr, textScaler: textScaler);
+
+  final List<_WrapColumn> _columns;
+  final TextStyle _style;
+  final TextPainter _painter;
+
+  // The rendered height of [row]'s wrapped text across its text-rendering
+  // columns, or 0 when none wrap. Mirrors how [CellText] lays the same text out
+  // so a grown row fits exactly: a column clamped below its content wraps and
+  // must grow the row, while an auto-fit column stays one line and adds nothing.
+  double contentHeight(TrinaRow row) {
+    var maxHeight = 0.0;
+    for (final column in _columns) {
+      final cell = row.cells[column.col.field];
+      final text = column.spec.measuredText(cell, column.col.formattedValueForDisplay(cell?.value));
+      final height = _wrappedHeight(text, column.maxWidth) + column.verticalPadding;
+      if (height > maxHeight) {
+        maxHeight = height;
+      }
+    }
+    // The 2px buffer absorbs sub-pixel rounding so the last wrapped line is never clipped.
+    return maxHeight > 0 ? maxHeight + 2 : 0;
+  }
+
+  double _wrappedHeight(String text, double maxWidth) {
+    if (text.isEmpty || maxWidth <= 0) {
+      return 0;
+    }
+    _painter
+      ..text = TextSpan(style: _style, text: text)
+      ..layout(maxWidth: maxWidth);
+    return _painter.height;
+  }
+
+  void dispose() => _painter.dispose();
+}
+
 extension TrinaGridStateManagerExtension on TrinaGridStateManager {
   double _visualTextWidth(BuildContext context, String text, TextStyle style) {
     if (text.isEmpty) {
@@ -984,45 +1032,27 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     }
   }
 
-  // Measures the rendered height of [text] wrapped to [maxWidth] in [style],
-  // matching how [CellText] lays the same text out so a grown row fits exactly.
-  double _wrappedTextHeight(BuildContext context, String text, TextStyle style, double maxWidth) {
-    if (text.isEmpty || maxWidth <= 0) {
-      return 0;
-    }
-    final textPainter = TextPainter(
-      text: TextSpan(style: style, text: text),
-      textDirection: ui.TextDirection.ltr,
-      textScaler: MediaQuery.textScalerOf(context),
-    )..layout(maxWidth: maxWidth);
-    return textPainter.height;
-  }
-
-  // The rendered height of a row's wrapped text across its text-rendering
-  // columns, or 0 when none wrap. Every text ([wrapsText]) column is measured:
-  // an auto-fit column normally sized to its widest cell stays one line and adds
-  // nothing, but a column clamped below its content (by the [maxWidth] cap in
-  // [autoFitColumns], or by a text scale larger than the auto-fit measurement
-  // assumed) wraps and must grow the row. Widget/icon columns render at a fixed
-  // height, so the scan skips them.
-  double _contentHeight(BuildContext context, TrinaRow row, TextStyle style) {
-    var maxHeight = 0.0;
+  // The text-rendering ([ColumnSpec.wrapsText]) columns paired with their fixed
+  // per-pass layout (content max-width and vertical padding), computed once so
+  // the per-row height scan in [_RowHeightMeasurer] does no repeated
+  // column-metadata lookups. Widget/icon columns render at a fixed height and a
+  // column without a spec (the checkbox column) is excluded.
+  List<_WrapColumn> _wrappingColumns() {
+    final result = <_WrapColumn>[];
     for (final col in columns) {
       final spec = col.getUserData<ColumnSpec>();
       if (spec == null || !spec.wrapsText) {
         continue;
       }
       final cellPadding = col.cellPadding ?? configuration.style.defaultCellPadding;
-      final cell = row.cells[col.field];
-      final text = spec.measuredText(cell, col.formattedValueForDisplay(cell?.value));
-      final height =
-          _wrappedTextHeight(context, text, style, col.width - cellPadding.horizontal) + cellPadding.vertical;
-      if (height > maxHeight) {
-        maxHeight = height;
-      }
+      result.add((
+        col: col,
+        spec: spec,
+        maxWidth: col.width - cellPadding.horizontal,
+        verticalPadding: cellPadding.vertical,
+      ));
     }
-    // The 2px buffer absorbs sub-pixel rounding so the last wrapped line is never clipped.
-    return maxHeight > 0 ? maxHeight + 2 : 0;
+    return result;
   }
 
   // The pixel height of [minLines] text lines plus the default cell padding,
@@ -1033,7 +1063,9 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
       textDirection: ui.TextDirection.ltr,
       textScaler: MediaQuery.textScalerOf(context),
     )..layout();
-    return painter.preferredLineHeight * minLines + configuration.style.defaultCellPadding.vertical;
+    final height = painter.preferredLineHeight * minLines + configuration.style.defaultCellPadding.vertical;
+    painter.dispose();
+    return height;
   }
 
   // Sizes every row for [mode], flooring at [minLines] text lines: wrap fixes all
@@ -1049,15 +1081,23 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     }
     final style = DefaultTextStyle.of(context).style;
     final minHeight = _minRowHeight(context, style, minLines);
+    // The auto modes measure wrapped text; wrap fills the floor without measuring.
+    final measurer = mode == RowHeightMode.wrap
+        ? null
+        : _RowHeightMeasurer(columns: _wrappingColumns(), style: style, textScaler: MediaQuery.textScalerOf(context));
     final List<double> targets;
-    switch (mode) {
-      case RowHeightMode.wrap:
-        targets = List.filled(refRows.length, minHeight);
-      case RowHeightMode.autoPerRow:
-        targets = [for (final row in refRows) max(minHeight, _contentHeight(context, row, style))];
-      case RowHeightMode.autoUniform:
-        final tallest = refRows.fold<double>(minHeight, (h, row) => max(h, _contentHeight(context, row, style)));
-        targets = List.filled(refRows.length, tallest);
+    try {
+      switch (mode) {
+        case RowHeightMode.wrap:
+          targets = List.filled(refRows.length, minHeight);
+        case RowHeightMode.autoPerRow:
+          targets = [for (final row in refRows) max(minHeight, measurer!.contentHeight(row))];
+        case RowHeightMode.autoUniform:
+          final tallest = refRows.fold<double>(minHeight, (h, row) => max(h, measurer!.contentHeight(row)));
+          targets = List.filled(refRows.length, tallest);
+      }
+    } finally {
+      measurer?.dispose();
     }
     var changed = false;
     for (var i = 0; i < refRows.length; i++) {
@@ -1185,12 +1225,20 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     }
   }
 
-  /// Copies the renderer and title from each freshly built column onto the
-  /// matching live column (by field), so columns whose renderer captured a
-  /// provider snapshot (e.g. ratings) repaint with current data — and columns
-  /// whose title is provider-derived (e.g. a renamed rating/label set, whose
-  /// field is the stable spec id) show the new header — without a structural
-  /// replace that would drop their width and sort indicator.
+  /// Copies the renderer, title, and [ColumnSpec] user data from each freshly
+  /// built column onto the matching live column (by field), so columns whose
+  /// renderer captured a provider snapshot (e.g. ratings) repaint with current
+  /// data — and columns whose title is provider-derived (e.g. a renamed
+  /// rating/label set, whose field is the stable spec id) show the new header —
+  /// without a structural replace that would drop their width and sort indicator.
+  ///
+  /// Re-seating the spec keeps the live column's user data in sync with the
+  /// current spec after a non-structural edit (e.g. a skill column's display
+  /// count). Width-persisting callers read the spec back off the live column, so
+  /// a stale spec here would let a later resize/reset overwrite that edit. The
+  /// rebuilt spec carries the current pinned width (every spec mutation also
+  /// persists it), so re-seating never loses a width. The checkbox column has no
+  /// spec and is left untouched.
   ///
   /// Cell-driven columns (e.g. memo, which reads the cell's user data) are
   /// refreshed by [reconcileRows] replacing their row instead; copying their
@@ -1202,6 +1250,10 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
       if (next != null) {
         live.renderer = next.renderer;
         live.title = next.title;
+        final nextSpec = next.getUserData<ColumnSpec>();
+        if (nextSpec != null) {
+          live.setUserData(nextSpec);
+        }
       }
     }
   }

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -261,6 +261,10 @@ extension ColumnSpecCellActionExtension on ColumnSpecCellAction {
   }
 }
 
+/// Upper bound for a pinned column width. Generous on purpose: it only guards
+/// against corrupted/absurd persisted values, not legitimately wide columns.
+const _maxPinnedColumnWidth = 2000.0;
+
 @MappableClass(discriminatorKey: 'type')
 abstract class ColumnSpec<T> with ColumnSpecMappable<T> {
   String get type => runtimeType.toString();
@@ -302,6 +306,22 @@ abstract class ColumnSpec<T> with ColumnSpecMappable<T> {
   /// keeps the content-driven auto-fit. Every editable concrete spec overrides this
   /// with a stored field and implements [withWidth].
   double? get width => null;
+
+  /// The pinned [width] sanitized for rendering, or null when unpinned. trina
+  /// only enforces [TrinaGridSettings.minColumnWidth] during interactive resize,
+  /// not at column construction, so a corrupted or hand-edited persisted value
+  /// (negative, zero, NaN, infinity, or absurdly large) would otherwise render a
+  /// broken layout. A non-finite value falls back to the default width.
+  double? get clampedWidth {
+    final value = width;
+    if (value == null) {
+      return null;
+    }
+    if (!value.isFinite) {
+      return TrinaGridSettings.columnWidth;
+    }
+    return value.clamp(TrinaGridSettings.minColumnWidth, _maxPinnedColumnWidth);
+  }
 
   /// Returns a copy of this spec with its pinned [width] replaced (null clears it,
   /// reverting the column to auto-fit). Like [withHidden], every editable concrete
@@ -978,15 +998,18 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
     return textPainter.height;
   }
 
-  // The rendered height of a row's wrapped text across its pinned, text-rendering
-  // columns, or 0 when none can wrap. Only pinned ([width] != null), text
-  // ([wrapsText]) columns wrap — auto-fit columns are sized to their widest cell,
-  // and widget/icon columns render at a fixed height — so the scan skips them.
+  // The rendered height of a row's wrapped text across its text-rendering
+  // columns, or 0 when none wrap. Every text ([wrapsText]) column is measured:
+  // an auto-fit column normally sized to its widest cell stays one line and adds
+  // nothing, but a column clamped below its content (by the [maxWidth] cap in
+  // [autoFitColumns], or by a text scale larger than the auto-fit measurement
+  // assumed) wraps and must grow the row. Widget/icon columns render at a fixed
+  // height, so the scan skips them.
   double _contentHeight(BuildContext context, TrinaRow row, TextStyle style) {
     var maxHeight = 0.0;
     for (final col in columns) {
       final spec = col.getUserData<ColumnSpec>();
-      if (spec == null || spec.width == null || !spec.wrapsText) {
+      if (spec == null || !spec.wrapsText) {
         continue;
       }
       final cellPadding = col.cellPadding ?? configuration.style.defaultCellPadding;

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -14,7 +14,6 @@ import '/src/chara_detail/chara_detail_record.dart';
 import '/src/chara_detail/exporter.dart';
 import '/src/chara_detail/spec/preset.dart';
 import '/src/chara_detail/spec/spec_tree.dart';
-import '/src/core/callback.dart';
 import '/src/core/json_adapter.dart';
 import '/src/core/utils.dart';
 import '/src/gui/toast.dart';
@@ -317,6 +316,12 @@ abstract class ColumnSpec<T> with ColumnSpecMappable<T> {
   /// to false so the auto row-height pass never inflates a row from their
   /// width-measurement placeholder text. Defaults to true.
   bool get wrapsText => true;
+
+  /// The text the cell actually paints, used by the row-height pass to measure
+  /// wrapped height. Defaults to the trina-formatted cell value; specs whose
+  /// renderer substitutes text (e.g. memo's null placeholder) override this so
+  /// the measured height matches what is shown.
+  String measuredText(TrinaCell? cell, String formatted) => formatted;
 
   /// Returns a copy of this spec with its [hidden] flag replaced. Every concrete,
   /// editable spec must override this via copyWith. Unlike [withChildren] (which
@@ -985,7 +990,8 @@ extension TrinaGridStateManagerExtension on TrinaGridStateManager {
         continue;
       }
       final cellPadding = col.cellPadding ?? configuration.style.defaultCellPadding;
-      final text = col.formattedValueForDisplay(row.cells[col.field]?.value);
+      final cell = row.cells[col.field];
+      final text = spec.measuredText(cell, col.formattedValueForDisplay(cell?.value));
       final height =
           _wrappedTextHeight(context, text, style, col.width - cellPadding.horizontal) + cellPadding.vertical;
       if (height > maxHeight) {
@@ -1353,6 +1359,15 @@ extension TrinaColumnWithUserData on TrinaColumn {
   void setUserData<T>(T value) => _userData[this] = value;
 }
 
+/// Handles a cell selection (tap), given a live [RefBase] supplied by the table
+/// at call time and the trina select event. Returns whether it consumed the tap.
+///
+/// The ref is passed in rather than captured because a long-lived cell closure
+/// must not hold the grid-build ref: that ref is disposed whenever
+/// [currentGridProvider] rebuilds (e.g. a column resize persists its width, or a
+/// memo/rating is saved), after which a kept cell would read through a dead ref.
+typedef CellSelectedCallback = bool Function(RefBase ref, TrinaGridOnSelectedEvent event);
+
 abstract class CellData implements Exportable {
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected;
+  CellSelectedCallback? get onSelected;
 }

--- a/lib/src/chara_detail/spec/base.mapper.dart
+++ b/lib/src/chara_detail/spec/base.mapper.dart
@@ -7,6 +7,56 @@
 
 part of 'base.dart';
 
+class RowHeightModeMapper extends EnumMapper<RowHeightMode> {
+  RowHeightModeMapper._();
+
+  static RowHeightModeMapper? _instance;
+  static RowHeightModeMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = RowHeightModeMapper._());
+    }
+    return _instance!;
+  }
+
+  static RowHeightMode fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  RowHeightMode decode(dynamic value) {
+    switch (value) {
+      case r'wrap':
+        return RowHeightMode.wrap;
+      case r'auto_per_row':
+        return RowHeightMode.autoPerRow;
+      case r'auto_uniform':
+        return RowHeightMode.autoUniform;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(RowHeightMode self) {
+    switch (self) {
+      case RowHeightMode.wrap:
+        return r'wrap';
+      case RowHeightMode.autoPerRow:
+        return r'auto_per_row';
+      case RowHeightMode.autoUniform:
+        return r'auto_uniform';
+    }
+  }
+}
+
+extension RowHeightModeMapperExtension on RowHeightMode {
+  String toValue() {
+    RowHeightModeMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<RowHeightMode>(this) as String;
+  }
+}
+
 class ColumnSpecCellActionMapper extends EnumMapper<ColumnSpecCellAction> {
   ColumnSpecCellActionMapper._();
 

--- a/lib/src/chara_detail/spec/chara_rank.dart
+++ b/lib/src/chara_detail/spec/chara_rank.dart
@@ -25,6 +25,7 @@ class CharaRankColumnSpec extends RangedLabelColumnSpec with CharaRankColumnSpec
     required super.predicate,
     super.hidden,
     super.description,
+    super.width,
   });
 
   @override
@@ -50,6 +51,7 @@ class CharaRankColumnSpec extends RangedLabelColumnSpec with CharaRankColumnSpec
     IsInRangeIntegerPredicate? predicate,
     bool? hidden,
     Object? description = _unset,
+    Object? width = _unset,
   }) {
     return CharaRankColumnSpec(
       id: id ?? this.id,
@@ -59,6 +61,7 @@ class CharaRankColumnSpec extends RangedLabelColumnSpec with CharaRankColumnSpec
       predicate: predicate ?? this.predicate,
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 }

--- a/lib/src/chara_detail/spec/chara_rank.mapper.dart
+++ b/lib/src/chara_detail/spec/chara_rank.mapper.dart
@@ -59,6 +59,12 @@ class CharaRankColumnSpecMapper
     _$description,
     opt: true,
   );
+  static double? _$width(CharaRankColumnSpec v) => v.width;
+  static const Field<CharaRankColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
   static ColumnSpecCellAction _$cellAction(CharaRankColumnSpec v) =>
       v.cellAction;
   static const Field<CharaRankColumnSpec, ColumnSpecCellAction> _f$cellAction =
@@ -73,6 +79,7 @@ class CharaRankColumnSpecMapper
     #predicate: _f$predicate,
     #hidden: _f$hidden,
     #description: _f$description,
+    #width: _f$width,
     #cellAction: _f$cellAction,
   };
   @override
@@ -95,6 +102,7 @@ class CharaRankColumnSpecMapper
       predicate: data.dec(_f$predicate),
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/character.dart
+++ b/lib/src/chara_detail/spec/character.dart
@@ -75,6 +75,10 @@ class CharacterCardColumnSpec extends ColumnSpec<int> with CharacterCardColumnSp
   @override
   ColumnSpecCellAction get cellAction => ColumnSpecCellAction.openSkillPreview;
 
+  // Renders a fixed-size trainee portrait, not wrapping text.
+  @override
+  bool get wrapsText => false;
+
   CharacterCardColumnSpec({
     required this.id,
     required this.title,

--- a/lib/src/chara_detail/spec/character.dart
+++ b/lib/src/chara_detail/spec/character.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:collection/collection.dart';
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -200,30 +202,43 @@ class _FriendMarkedIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      fit: StackFit.passthrough,
-      children: [
-        icon,
-        Positioned(
-          left: 0,
-          right: 0,
-          bottom: 0,
-          child: FractionallySizedBox(
-            widthFactor: 0.6,
-            child: Container(
-              decoration: const ShapeDecoration(color: Color(0xFFEC6A8E), shape: StadiumBorder()),
-              padding: const EdgeInsets.symmetric(horizontal: 4),
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                child: Text(
-                  "$tr_character.marker.friend".tr(),
-                  style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 11),
+    // The portrait is a square fit to the cell, so its side is the smaller of the
+    // available width and height — which shrinks/grows as the row height (or
+    // column width) changes. Derive the banner's width, font, and padding from
+    // that side so the rental marker resizes at the icon's scale instead of
+    // staying pinned to a fixed font.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final height = constraints.maxHeight;
+        final side = (width.isFinite && height.isFinite) ? min(width, height) : (height.isFinite ? height : width);
+        final bannerWidth = side * 0.75;
+        return Stack(
+          fit: StackFit.passthrough,
+          children: [
+            icon,
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: Center(
+                child: Container(
+                  width: bannerWidth,
+                  decoration: const ShapeDecoration(color: Color(0xFFEC6A8E), shape: StadiumBorder()),
+                  padding: EdgeInsets.symmetric(horizontal: bannerWidth * 0.08, vertical: bannerWidth * 0.02),
+                  child: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      "$tr_character.marker.friend".tr(),
+                      style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: bannerWidth * 0.3),
+                    ),
+                  ),
                 ),
               ),
             ),
-          ),
-        ),
-      ],
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/src/chara_detail/spec/character.dart
+++ b/lib/src/chara_detail/spec/character.dart
@@ -70,6 +70,9 @@ class CharacterCardColumnSpec extends ColumnSpec<int> with CharacterCardColumnSp
   final String? description;
 
   @override
+  final double? width;
+
+  @override
   ColumnSpecCellAction get cellAction => ColumnSpecCellAction.openSkillPreview;
 
   CharacterCardColumnSpec({
@@ -79,6 +82,7 @@ class CharacterCardColumnSpec extends ColumnSpec<int> with CharacterCardColumnSp
     required this.predicate,
     this.hidden = false,
     this.description,
+    this.width,
   });
 
   @override
@@ -87,6 +91,9 @@ class CharacterCardColumnSpec extends ColumnSpec<int> with CharacterCardColumnSp
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
 
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
+
   CharacterCardColumnSpec copyWith({
     String? id,
     String? title,
@@ -94,6 +101,7 @@ class CharacterCardColumnSpec extends ColumnSpec<int> with CharacterCardColumnSp
     CharacterCardPredicate? predicate,
     bool? hidden,
     Object? description = _unset,
+    Object? width = _unset,
   }) {
     return CharacterCardColumnSpec(
       id: id ?? this.id,
@@ -102,6 +110,7 @@ class CharacterCardColumnSpec extends ColumnSpec<int> with CharacterCardColumnSp
       predicate: predicate ?? this.predicate,
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -133,8 +142,9 @@ class CharacterCardColumnSpec extends ColumnSpec<int> with CharacterCardColumnSp
       title: title,
       field: id,
       type: TrinaColumnType.number(),
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {

--- a/lib/src/chara_detail/spec/character.dart
+++ b/lib/src/chara_detail/spec/character.dart
@@ -14,7 +14,6 @@ import '/src/chara_detail/spec/base.dart' hide tr_common;
 import '/src/chara_detail/spec/loader.dart';
 import '/src/chara_detail/spec/parser.dart';
 import '/src/chara_detail/storage.dart';
-import '/src/core/callback.dart';
 import '/src/core/providers.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
@@ -51,7 +50,7 @@ class CharacterCardCellData implements CellData {
   String get csv => name;
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 @MappableClass(discriminatorValue: 'CharacterCardColumnSpec', ignoreNull: true)

--- a/lib/src/chara_detail/spec/character.mapper.dart
+++ b/lib/src/chara_detail/spec/character.mapper.dart
@@ -110,6 +110,12 @@ class CharacterCardColumnSpecMapper
     _$description,
     opt: true,
   );
+  static double? _$width(CharacterCardColumnSpec v) => v.width;
+  static const Field<CharacterCardColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
 
   @override
   final MappableFields<CharacterCardColumnSpec> fields = const {
@@ -119,6 +125,7 @@ class CharacterCardColumnSpecMapper
     #predicate: _f$predicate,
     #hidden: _f$hidden,
     #description: _f$description,
+    #width: _f$width,
   };
   @override
   final bool ignoreNull = true;
@@ -143,6 +150,7 @@ class CharacterCardColumnSpecMapper
       predicate: data.dec(_f$predicate),
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/datetime.dart
+++ b/lib/src/chara_detail/spec/datetime.dart
@@ -10,7 +10,6 @@ import '/src/chara_detail/chara_detail_record.dart';
 import '/src/chara_detail/spec/base.dart';
 import '/src/chara_detail/spec/parser.dart';
 import '/src/chara_detail/storage.dart';
-import '/src/core/callback.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
 import '/src/gui/chara_detail/common.dart';
@@ -61,7 +60,7 @@ class DateTimeCellData implements CellData {
   String get csv => value.toString();
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 @MappableClass(discriminatorValue: 'DateTimeColumnSpec', ignoreNull: true)

--- a/lib/src/chara_detail/spec/datetime.dart
+++ b/lib/src/chara_detail/spec/datetime.dart
@@ -82,6 +82,9 @@ class DateTimeColumnSpec extends ColumnSpec<DateTime> with DateTimeColumnSpecMap
   final String? description;
 
   @override
+  final double? width;
+
+  @override
   ColumnSpecCellAction get cellAction => ColumnSpecCellAction.openCampaignPreview;
 
   DateTimeColumnSpec({
@@ -91,6 +94,7 @@ class DateTimeColumnSpec extends ColumnSpec<DateTime> with DateTimeColumnSpecMap
     required this.predicate,
     this.hidden = false,
     this.description,
+    this.width,
   });
 
   @override
@@ -99,6 +103,9 @@ class DateTimeColumnSpec extends ColumnSpec<DateTime> with DateTimeColumnSpecMap
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
 
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
+
   DateTimeColumnSpec copyWith({
     String? id,
     String? title,
@@ -106,6 +113,7 @@ class DateTimeColumnSpec extends ColumnSpec<DateTime> with DateTimeColumnSpecMap
     IsInRangeDateTimePredicate? predicate,
     bool? hidden,
     Object? description = _unset,
+    Object? width = _unset,
   }) {
     return DateTimeColumnSpec(
       id: id ?? this.id,
@@ -114,6 +122,7 @@ class DateTimeColumnSpec extends ColumnSpec<DateTime> with DateTimeColumnSpecMap
       predicate: predicate ?? this.predicate,
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -139,8 +148,9 @@ class DateTimeColumnSpec extends ColumnSpec<DateTime> with DateTimeColumnSpecMap
       title: title,
       field: id,
       type: TrinaColumnType.text(),
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {

--- a/lib/src/chara_detail/spec/datetime.dart
+++ b/lib/src/chara_detail/spec/datetime.dart
@@ -154,7 +154,7 @@ class DateTimeColumnSpec extends ColumnSpec<DateTime> with DateTimeColumnSpecMap
       enableColumnDrag: false,
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {
-        return Text(context.cell.value, textAlign: TextAlign.center);
+        return CellText(context.cell.value, textAlign: TextAlign.center);
       },
     )..setUserData(this);
   }

--- a/lib/src/chara_detail/spec/datetime.mapper.dart
+++ b/lib/src/chara_detail/spec/datetime.mapper.dart
@@ -124,6 +124,12 @@ class DateTimeColumnSpecMapper extends SubClassMapperBase<DateTimeColumnSpec> {
     _$description,
     opt: true,
   );
+  static double? _$width(DateTimeColumnSpec v) => v.width;
+  static const Field<DateTimeColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
 
   @override
   final MappableFields<DateTimeColumnSpec> fields = const {
@@ -133,6 +139,7 @@ class DateTimeColumnSpecMapper extends SubClassMapperBase<DateTimeColumnSpec> {
     #predicate: _f$predicate,
     #hidden: _f$hidden,
     #description: _f$description,
+    #width: _f$width,
   };
   @override
   final bool ignoreNull = true;
@@ -157,6 +164,7 @@ class DateTimeColumnSpecMapper extends SubClassMapperBase<DateTimeColumnSpec> {
       predicate: data.dec(_f$predicate),
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/factor.dart
+++ b/lib/src/chara_detail/spec/factor.dart
@@ -12,7 +12,6 @@ import '/src/chara_detail/chara_detail_record.dart';
 import '/src/chara_detail/spec/base.dart';
 import '/src/chara_detail/spec/loader.dart';
 import '/src/chara_detail/spec/parser.dart';
-import '/src/core/callback.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
 import '/src/gui/chara_detail/common.dart';
@@ -235,7 +234,7 @@ class FactorCellData implements CellData {
   FactorCellData(this.label, {String? csv}) : csv = (csv ?? label);
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 @MappableEnum()

--- a/lib/src/chara_detail/spec/factor.dart
+++ b/lib/src/chara_detail/spec/factor.dart
@@ -376,7 +376,7 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {
         final data = context.cell.getUserData<FactorCellData>()!;
-        return Text(data.label);
+        return CellText(data.label);
       },
     )..setUserData(this);
   }

--- a/lib/src/chara_detail/spec/factor.dart
+++ b/lib/src/chara_detail/spec/factor.dart
@@ -264,6 +264,9 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
   final String? description;
 
   @override
+  final double? width;
+
+  @override
   ColumnSpecCellAction get cellAction => ColumnSpecCellAction.openFactorPreview;
 
   FactorColumnSpec({
@@ -276,6 +279,7 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
     this.hiddenElements = const {},
     this.hidden = false,
     this.description,
+    this.width,
   });
 
   @override
@@ -283,6 +287,9 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
 
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
+
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
 
   FactorColumnSpec copyWith({
     String? id,
@@ -294,6 +301,7 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
     Set<FactorDialogElements>? hiddenElements,
     bool? hidden,
     Object? description = _unset,
+    Object? width = _unset,
   }) {
     return FactorColumnSpec(
       id: id ?? this.id,
@@ -305,6 +313,7 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
       hiddenElements: hiddenElements ?? this.hiddenElements,
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -360,8 +369,9 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
       title: title,
       field: id,
       type: TrinaColumnType.text(),
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {

--- a/lib/src/chara_detail/spec/factor.mapper.dart
+++ b/lib/src/chara_detail/spec/factor.mapper.dart
@@ -555,6 +555,12 @@ class FactorColumnSpecMapper extends SubClassMapperBase<FactorColumnSpec> {
     _$description,
     opt: true,
   );
+  static double? _$width(FactorColumnSpec v) => v.width;
+  static const Field<FactorColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
   static String _$labelKey(FactorColumnSpec v) => v.labelKey;
   static const Field<FactorColumnSpec, String> _f$labelKey = Field(
     'labelKey',
@@ -573,6 +579,7 @@ class FactorColumnSpecMapper extends SubClassMapperBase<FactorColumnSpec> {
     #hiddenElements: _f$hiddenElements,
     #hidden: _f$hidden,
     #description: _f$description,
+    #width: _f$width,
     #labelKey: _f$labelKey,
   };
   @override
@@ -601,6 +608,7 @@ class FactorColumnSpecMapper extends SubClassMapperBase<FactorColumnSpec> {
       hiddenElements: data.dec(_f$hiddenElements),
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/family_registration.dart
+++ b/lib/src/chara_detail/spec/family_registration.dart
@@ -8,7 +8,6 @@ import 'package:uuid/uuid.dart';
 
 import '/src/chara_detail/chara_detail_record.dart';
 import '/src/chara_detail/spec/base.dart';
-import '/src/core/callback.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
 import '/src/gui/chara_detail/common.dart';
@@ -123,7 +122,7 @@ class FamilyRegistrationCellData implements CellData {
   String get csv => plainText;
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 @MappableClass(discriminatorValue: 'FamilyRegistrationColumnSpec', ignoreNull: true)

--- a/lib/src/chara_detail/spec/family_registration.dart
+++ b/lib/src/chara_detail/spec/family_registration.dart
@@ -149,6 +149,10 @@ class FamilyRegistrationColumnSpec extends ColumnSpec<FamilyRegistrationStatus>
   @override
   ColumnSpecCellAction? get cellAction => ColumnSpecCellAction.openFactorPreview;
 
+  // Renders a fixed-size registration badge widget, not wrapping text.
+  @override
+  bool get wrapsText => false;
+
   FamilyRegistrationColumnSpec({
     required this.id,
     required this.title,

--- a/lib/src/chara_detail/spec/family_registration.dart
+++ b/lib/src/chara_detail/spec/family_registration.dart
@@ -144,6 +144,9 @@ class FamilyRegistrationColumnSpec extends ColumnSpec<FamilyRegistrationStatus>
   final String? description;
 
   @override
+  final double? width;
+
+  @override
   ColumnSpecCellAction? get cellAction => ColumnSpecCellAction.openFactorPreview;
 
   FamilyRegistrationColumnSpec({
@@ -152,6 +155,7 @@ class FamilyRegistrationColumnSpec extends ColumnSpec<FamilyRegistrationStatus>
     required this.predicate,
     this.hidden = false,
     this.description,
+    this.width,
   });
 
   @override
@@ -160,12 +164,16 @@ class FamilyRegistrationColumnSpec extends ColumnSpec<FamilyRegistrationStatus>
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
 
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
+
   FamilyRegistrationColumnSpec copyWith({
     String? id,
     String? title,
     FamilyRegistrationPredicate? predicate,
     bool? hidden,
     Object? description = _unset,
+    Object? width = _unset,
   }) {
     return FamilyRegistrationColumnSpec(
       id: id ?? this.id,
@@ -173,6 +181,7 @@ class FamilyRegistrationColumnSpec extends ColumnSpec<FamilyRegistrationStatus>
       predicate: predicate ?? this.predicate,
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -202,8 +211,9 @@ class FamilyRegistrationColumnSpec extends ColumnSpec<FamilyRegistrationStatus>
       title: title,
       field: id,
       type: TrinaColumnType.text(),
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       readOnly: true,
       renderer: (TrinaColumnRendererContext context) {

--- a/lib/src/chara_detail/spec/family_registration.mapper.dart
+++ b/lib/src/chara_detail/spec/family_registration.mapper.dart
@@ -113,6 +113,12 @@ class FamilyRegistrationColumnSpecMapper
   static String? _$description(FamilyRegistrationColumnSpec v) => v.description;
   static const Field<FamilyRegistrationColumnSpec, String> _f$description =
       Field('description', _$description, opt: true);
+  static double? _$width(FamilyRegistrationColumnSpec v) => v.width;
+  static const Field<FamilyRegistrationColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
 
   @override
   final MappableFields<FamilyRegistrationColumnSpec> fields = const {
@@ -121,6 +127,7 @@ class FamilyRegistrationColumnSpecMapper
     #predicate: _f$predicate,
     #hidden: _f$hidden,
     #description: _f$description,
+    #width: _f$width,
   };
   @override
   final bool ignoreNull = true;
@@ -144,6 +151,7 @@ class FamilyRegistrationColumnSpecMapper
       predicate: data.dec(_f$predicate),
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/loader.dart
+++ b/lib/src/chara_detail/spec/loader.dart
@@ -560,6 +560,17 @@ Grid _buildGrid(
   // that builds the rendered grid works from [visibleSpecs] instead.
   final visibleSpecs = displaySpecs.where((spec) => !spec.hidden).toList();
   final columns = visibleSpecs.map((spec) => spec.plutoColumn(ref)).toList();
+  // Sanitize pinned widths read back from storage (see ColumnSpec.clampedWidth):
+  // trina clamps to minColumnWidth only on interactive resize, not at build, so a
+  // corrupted persisted value would otherwise render broken. Index-aligned with
+  // visibleSpecs since columns is the map() of it; the checkbox column is inserted
+  // below and is not a ColumnSpec, so it is unaffected.
+  for (final (index, spec) in visibleSpecs.indexed) {
+    final width = spec.clampedWidth;
+    if (width != null) {
+      columns[index].width = width;
+    }
+  }
   // A leading checkbox column drives bulk selection. Its cells are added to
   // every row below; the column's field must match those cell keys.
   if (selectionMode) {

--- a/lib/src/chara_detail/spec/logic.dart
+++ b/lib/src/chara_detail/spec/logic.dart
@@ -87,6 +87,9 @@ class LogicColumnSpec extends ColumnSpec<bool> with LogicColumnSpecMappable, Con
   @override
   final String? description;
 
+  @override
+  final double? width;
+
   LogicColumnSpec({
     required this.id,
     required this.title,
@@ -94,6 +97,7 @@ class LogicColumnSpec extends ColumnSpec<bool> with LogicColumnSpecMappable, Con
     this.children = const [],
     this.hidden = false,
     this.description,
+    this.width,
   });
 
   @override
@@ -112,6 +116,9 @@ class LogicColumnSpec extends ColumnSpec<bool> with LogicColumnSpecMappable, Con
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
 
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
+
   LogicColumnSpec copyWith({
     String? id,
     String? title,
@@ -119,6 +126,7 @@ class LogicColumnSpec extends ColumnSpec<bool> with LogicColumnSpecMappable, Con
     List<ColumnSpec>? children,
     bool? hidden,
     Object? description = _unset,
+    Object? width = _unset,
   }) {
     return LogicColumnSpec(
       id: id ?? this.id,
@@ -127,6 +135,7 @@ class LogicColumnSpec extends ColumnSpec<bool> with LogicColumnSpecMappable, Con
       children: children ?? this.children,
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -177,8 +186,9 @@ class LogicColumnSpec extends ColumnSpec<bool> with LogicColumnSpecMappable, Con
       field: id,
       type: TrinaColumnType.number(),
       textAlign: TrinaColumnTextAlign.center,
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       enableEditingMode: false,
       readOnly: true,

--- a/lib/src/chara_detail/spec/logic.dart
+++ b/lib/src/chara_detail/spec/logic.dart
@@ -100,6 +100,10 @@ class LogicColumnSpec extends ColumnSpec<bool> with LogicColumnSpecMappable, Con
     this.width,
   });
 
+  // Renders a fixed-size pass/fail icon, not wrapping text.
+  @override
+  bool get wrapsText => false;
+
   @override
   bool get acceptsChildren => true;
 

--- a/lib/src/chara_detail/spec/logic.dart
+++ b/lib/src/chara_detail/spec/logic.dart
@@ -8,7 +8,6 @@ import 'package:uuid/uuid.dart';
 
 import '/src/chara_detail/chara_detail_record.dart';
 import '/src/chara_detail/spec/base.dart';
-import '/src/core/callback.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
 import '/src/gui/chara_detail/common.dart';
@@ -57,7 +56,7 @@ class LogicCellData implements CellData {
   String get csv => passed ? "1" : "0";
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 /// A column that combines the filter conditions of its [children] with a logical

--- a/lib/src/chara_detail/spec/logic.mapper.dart
+++ b/lib/src/chara_detail/spec/logic.mapper.dart
@@ -118,6 +118,12 @@ class LogicColumnSpecMapper extends SubClassMapperBase<LogicColumnSpec> {
     _$description,
     opt: true,
   );
+  static double? _$width(LogicColumnSpec v) => v.width;
+  static const Field<LogicColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
 
   @override
   final MappableFields<LogicColumnSpec> fields = const {
@@ -127,6 +133,7 @@ class LogicColumnSpecMapper extends SubClassMapperBase<LogicColumnSpec> {
     #children: _f$children,
     #hidden: _f$hidden,
     #description: _f$description,
+    #width: _f$width,
   };
   @override
   final bool ignoreNull = true;
@@ -151,6 +158,7 @@ class LogicColumnSpecMapper extends SubClassMapperBase<LogicColumnSpec> {
       children: data.dec(_f$children),
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/memo.dart
+++ b/lib/src/chara_detail/spec/memo.dart
@@ -79,6 +79,9 @@ class MemoColumnSpec extends ColumnSpec<String?> with MemoColumnSpecMappable {
   final bool hidden;
 
   @override
+  final double? width;
+
+  @override
   ColumnSpecCellAction get cellAction => ColumnSpecCellAction.openSkillPreview;
 
   MemoColumnSpec({
@@ -89,6 +92,7 @@ class MemoColumnSpec extends ColumnSpec<String?> with MemoColumnSpecMappable {
     required this.storageKey,
     this.description,
     this.hidden = false,
+    this.width,
   });
 
   @override
@@ -96,6 +100,9 @@ class MemoColumnSpec extends ColumnSpec<String?> with MemoColumnSpecMappable {
 
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
+
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
 
   MemoColumnSpec copyWith({
     String? id,
@@ -105,6 +112,7 @@ class MemoColumnSpec extends ColumnSpec<String?> with MemoColumnSpecMappable {
     String? storageKey,
     Object? description = _unset,
     bool? hidden,
+    Object? width = _unset,
   }) {
     return MemoColumnSpec(
       id: id ?? this.id,
@@ -114,6 +122,7 @@ class MemoColumnSpec extends ColumnSpec<String?> with MemoColumnSpecMappable {
       storageKey: storageKey ?? this.storageKey,
       description: identical(description, _unset) ? this.description : description as String?,
       hidden: hidden ?? this.hidden,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -151,8 +160,9 @@ class MemoColumnSpec extends ColumnSpec<String?> with MemoColumnSpecMappable {
       title: title,
       field: id,
       type: TrinaColumnType.text(),
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       renderer: (TrinaColumnRendererContext context) {
         final data = context.cell.getUserData<MemoCellData>()!;

--- a/lib/src/chara_detail/spec/memo.dart
+++ b/lib/src/chara_detail/spec/memo.dart
@@ -167,9 +167,9 @@ class MemoColumnSpec extends ColumnSpec<String?> with MemoColumnSpecMappable {
       renderer: (TrinaColumnRendererContext context) {
         final data = context.cell.getUserData<MemoCellData>()!;
         if (data.value == null) {
-          return Opacity(opacity: 0.4, child: Text("$tr_memo.cell.description".tr()));
+          return CellText("$tr_memo.cell.description".tr(), opacity: 0.4);
         } else {
-          return Text(data.value!);
+          return CellText(data.value!);
         }
       },
     )..setUserData(this);

--- a/lib/src/chara_detail/spec/memo.dart
+++ b/lib/src/chara_detail/spec/memo.dart
@@ -12,7 +12,6 @@ import '/src/chara_detail/spec/base.dart';
 import '/src/chara_detail/spec/loader.dart';
 import '/src/chara_detail/spec/parser.dart';
 import '/src/chara_detail/storage.dart';
-import '/src/core/callback.dart';
 import '/src/core/providers.dart';
 import '/src/core/sentry_util.dart';
 import '/src/core/utils.dart';
@@ -48,7 +47,7 @@ class MemoCellData implements CellData {
   final String? value;
 
   @override
-  final Predicate<TrinaGridOnSelectedEvent>? onSelected;
+  final CellSelectedCallback? onSelected;
 
   @override
   String get csv => value ?? "";
@@ -104,6 +103,10 @@ class MemoColumnSpec extends ColumnSpec<String?> with MemoColumnSpecMappable {
   @override
   ColumnSpec withWidth(double? width) => copyWith(width: width);
 
+  @override
+  String measuredText(TrinaCell? cell, String formatted) =>
+      cell?.getUserData<MemoCellData>()?.value == null ? "$tr_memo.cell.description".tr() : formatted;
+
   MemoColumnSpec copyWith({
     String? id,
     String? title,
@@ -138,9 +141,13 @@ class MemoColumnSpec extends ColumnSpec<String?> with MemoColumnSpecMappable {
   }
 
   @override
-  TrinaCell plutoCell(RefBase ref, String? value) {
+  TrinaCell plutoCell(RefBase _, String? value) {
+    // The onSelected closure must NOT capture this build-scoped grid ref: it is
+    // disposed when [currentGridProvider] rebuilds (a column resize, a memo save),
+    // and a kept cell would then read through a dead ref. The table passes a live
+    // ref in at tap time instead (see [CellSelectedCallback]).
     return TrinaCell(value: value ?? "_" * 20)..setUserData(
-      MemoCellData(value, (TrinaGridOnSelectedEvent event) {
+      MemoCellData(value, (RefBase ref, TrinaGridOnSelectedEvent event) {
         final record = event.row!.getUserData<CharaDetailRecord>()!;
         final memos = ref.read(charaDetailRecordMemoProvider(storageKey));
         _RecordMemoDialog.show(

--- a/lib/src/chara_detail/spec/memo.mapper.dart
+++ b/lib/src/chara_detail/spec/memo.mapper.dart
@@ -109,6 +109,12 @@ class MemoColumnSpecMapper extends SubClassMapperBase<MemoColumnSpec> {
     opt: true,
     def: false,
   );
+  static double? _$width(MemoColumnSpec v) => v.width;
+  static const Field<MemoColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
 
   @override
   final MappableFields<MemoColumnSpec> fields = const {
@@ -119,6 +125,7 @@ class MemoColumnSpecMapper extends SubClassMapperBase<MemoColumnSpec> {
     #storageKey: _f$storageKey,
     #description: _f$description,
     #hidden: _f$hidden,
+    #width: _f$width,
   };
   @override
   final bool ignoreNull = true;
@@ -144,6 +151,7 @@ class MemoColumnSpecMapper extends SubClassMapperBase<MemoColumnSpec> {
       storageKey: data.dec(_f$storageKey),
       description: data.dec(_f$description),
       hidden: data.dec(_f$hidden),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/ranged_integer.dart
+++ b/lib/src/chara_detail/spec/ranged_integer.dart
@@ -9,7 +9,6 @@ import '/src/chara_detail/chara_detail_record.dart';
 import '/src/chara_detail/spec/base.dart';
 import '/src/chara_detail/spec/parser.dart';
 import '/src/chara_detail/storage.dart';
-import '/src/core/callback.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
 import '/src/gui/chara_detail/common.dart';
@@ -48,7 +47,7 @@ class RangedIntegerCellData implements CellData {
   String get csv => value.toString();
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 @MappableClass(discriminatorValue: 'RangedIntegerColumnSpec', ignoreNull: true)

--- a/lib/src/chara_detail/spec/ranged_integer.dart
+++ b/lib/src/chara_detail/spec/ranged_integer.dart
@@ -144,7 +144,7 @@ class RangedIntegerColumnSpec extends ColumnSpec<int> with RangedIntegerColumnSp
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {
         final data = context.cell.getUserData<RangedIntegerCellData>()!;
-        return Text(data.value.toNumberString(), textAlign: TextAlign.center);
+        return CellText(data.value.toNumberString(), textAlign: TextAlign.center);
       },
     )..setUserData(this);
   }

--- a/lib/src/chara_detail/spec/ranged_integer.dart
+++ b/lib/src/chara_detail/spec/ranged_integer.dart
@@ -71,6 +71,9 @@ class RangedIntegerColumnSpec extends ColumnSpec<int> with RangedIntegerColumnSp
   @override
   final String? description;
 
+  @override
+  final double? width;
+
   RangedIntegerColumnSpec({
     required this.id,
     required this.title,
@@ -79,6 +82,7 @@ class RangedIntegerColumnSpec extends ColumnSpec<int> with RangedIntegerColumnSp
     ColumnSpecCellAction? cellAction,
     this.hidden = false,
     this.description,
+    this.width,
   }) : cellAction = cellAction ?? ColumnSpecCellAction.openSkillPreview;
 
   @override
@@ -87,6 +91,9 @@ class RangedIntegerColumnSpec extends ColumnSpec<int> with RangedIntegerColumnSp
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
 
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
+
   RangedIntegerColumnSpec copyWith({
     String? id,
     String? title,
@@ -94,6 +101,7 @@ class RangedIntegerColumnSpec extends ColumnSpec<int> with RangedIntegerColumnSp
     IsInRangeIntegerPredicate? predicate,
     bool? hidden,
     Object? description = _unset,
+    Object? width = _unset,
   }) {
     return RangedIntegerColumnSpec(
       id: id ?? this.id,
@@ -103,6 +111,7 @@ class RangedIntegerColumnSpec extends ColumnSpec<int> with RangedIntegerColumnSp
       cellAction: cellAction,
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -128,8 +137,9 @@ class RangedIntegerColumnSpec extends ColumnSpec<int> with RangedIntegerColumnSp
       field: id,
       type: TrinaColumnType.number(),
       textAlign: TrinaColumnTextAlign.right,
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {

--- a/lib/src/chara_detail/spec/ranged_integer.mapper.dart
+++ b/lib/src/chara_detail/spec/ranged_integer.mapper.dart
@@ -130,6 +130,12 @@ class RangedIntegerColumnSpecMapper
     _$description,
     opt: true,
   );
+  static double? _$width(RangedIntegerColumnSpec v) => v.width;
+  static const Field<RangedIntegerColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
 
   @override
   final MappableFields<RangedIntegerColumnSpec> fields = const {
@@ -140,6 +146,7 @@ class RangedIntegerColumnSpecMapper
     #cellAction: _f$cellAction,
     #hidden: _f$hidden,
     #description: _f$description,
+    #width: _f$width,
   };
   @override
   final bool ignoreNull = true;
@@ -165,6 +172,7 @@ class RangedIntegerColumnSpecMapper
       cellAction: data.dec(_f$cellAction),
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/ranged_label.dart
+++ b/lib/src/chara_detail/spec/ranged_label.dart
@@ -58,6 +58,9 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
   @override
   final String? description;
 
+  @override
+  final double? width;
+
   RangedLabelColumnSpec({
     required this.id,
     required this.title,
@@ -67,6 +70,7 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
     ColumnSpecCellAction? cellAction,
     this.hidden = false,
     this.description,
+    this.width,
   }) : cellAction = cellAction ?? ColumnSpecCellAction.openSkillPreview;
 
   @override
@@ -74,6 +78,9 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
 
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
+
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
 
   RangedLabelColumnSpec copyWith({
     String? id,
@@ -83,6 +90,7 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
     IsInRangeIntegerPredicate? predicate,
     bool? hidden,
     Object? description = _unset,
+    Object? width = _unset,
   }) {
     return RangedLabelColumnSpec(
       id: id ?? this.id,
@@ -92,6 +100,7 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
       predicate: predicate ?? this.predicate,
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -117,8 +126,9 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
       title: title,
       field: id,
       type: TrinaColumnType.number(),
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {

--- a/lib/src/chara_detail/spec/ranged_label.dart
+++ b/lib/src/chara_detail/spec/ranged_label.dart
@@ -11,7 +11,6 @@ import '/src/chara_detail/spec/loader.dart';
 import '/src/chara_detail/spec/parser.dart';
 import '/src/chara_detail/spec/ranged_integer.dart';
 import '/src/chara_detail/storage.dart';
-import '/src/core/callback.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
 import '/src/gui/chara_detail/common.dart';
@@ -34,7 +33,7 @@ class RangedLabelCellData implements CellData {
   String get csv => label;
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 @MappableClass(discriminatorValue: 'RangedLabelColumnSpec', ignoreNull: true)

--- a/lib/src/chara_detail/spec/ranged_label.dart
+++ b/lib/src/chara_detail/spec/ranged_label.dart
@@ -133,7 +133,7 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {
         final data = context.cell.getUserData<RangedLabelCellData>()!;
-        return Text(data.label, textAlign: TextAlign.center);
+        return CellText(data.label, textAlign: TextAlign.center);
       },
     )..setUserData(this);
   }

--- a/lib/src/chara_detail/spec/ranged_label.mapper.dart
+++ b/lib/src/chara_detail/spec/ranged_label.mapper.dart
@@ -64,6 +64,12 @@ class RangedLabelColumnSpecMapper
     _$description,
     opt: true,
   );
+  static double? _$width(RangedLabelColumnSpec v) => v.width;
+  static const Field<RangedLabelColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
 
   @override
   final MappableFields<RangedLabelColumnSpec> fields = const {
@@ -75,6 +81,7 @@ class RangedLabelColumnSpecMapper
     #cellAction: _f$cellAction,
     #hidden: _f$hidden,
     #description: _f$description,
+    #width: _f$width,
   };
   @override
   final bool ignoreNull = true;
@@ -101,6 +108,7 @@ class RangedLabelColumnSpecMapper
       cellAction: data.dec(_f$cellAction),
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/rating.dart
+++ b/lib/src/chara_detail/spec/rating.dart
@@ -85,6 +85,9 @@ class RatingColumnSpec extends ColumnSpec<double?> with RatingColumnSpecMappable
   final bool hidden;
 
   @override
+  final double? width;
+
+  @override
   ColumnSpecCellAction get cellAction => ColumnSpecCellAction.openSkillPreview;
 
   final range = Range<double>(min: 0.0, max: 5.0);
@@ -97,6 +100,7 @@ class RatingColumnSpec extends ColumnSpec<double?> with RatingColumnSpecMappable
     required this.storageKey,
     this.description,
     this.hidden = false,
+    this.width,
   });
 
   @override
@@ -104,6 +108,9 @@ class RatingColumnSpec extends ColumnSpec<double?> with RatingColumnSpecMappable
 
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
+
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
 
   RatingColumnSpec copyWith({
     String? id,
@@ -113,6 +120,7 @@ class RatingColumnSpec extends ColumnSpec<double?> with RatingColumnSpecMappable
     String? storageKey,
     Object? description = _unset,
     bool? hidden,
+    Object? width = _unset,
   }) {
     return RatingColumnSpec(
       id: id ?? this.id,
@@ -122,6 +130,7 @@ class RatingColumnSpec extends ColumnSpec<double?> with RatingColumnSpecMappable
       storageKey: storageKey ?? this.storageKey,
       description: identical(description, _unset) ? this.description : description as String?,
       hidden: hidden ?? this.hidden,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -148,8 +157,9 @@ class RatingColumnSpec extends ColumnSpec<double?> with RatingColumnSpecMappable
       title: title,
       field: id,
       type: TrinaColumnType.text(),
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {

--- a/lib/src/chara_detail/spec/rating.dart
+++ b/lib/src/chara_detail/spec/rating.dart
@@ -13,7 +13,6 @@ import '/src/chara_detail/spec/base.dart';
 import '/src/chara_detail/spec/loader.dart';
 import '/src/chara_detail/spec/parser.dart';
 import '/src/chara_detail/storage.dart';
-import '/src/core/callback.dart';
 import '/src/core/providers.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
@@ -59,7 +58,7 @@ class RatingCellData implements CellData {
   String get csv => value == null ? "" : ratingFormatter.format(value);
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 @MappableClass(discriminatorValue: 'RatingColumnSpec', ignoreNull: true)

--- a/lib/src/chara_detail/spec/rating.dart
+++ b/lib/src/chara_detail/spec/rating.dart
@@ -90,6 +90,10 @@ class RatingColumnSpec extends ColumnSpec<double?> with RatingColumnSpecMappable
   @override
   ColumnSpecCellAction get cellAction => ColumnSpecCellAction.openSkillPreview;
 
+  // Renders fixed-size rating stars, not wrapping text.
+  @override
+  bool get wrapsText => false;
+
   final range = Range<double>(min: 0.0, max: 5.0);
 
   RatingColumnSpec({

--- a/lib/src/chara_detail/spec/rating.mapper.dart
+++ b/lib/src/chara_detail/spec/rating.mapper.dart
@@ -125,6 +125,12 @@ class RatingColumnSpecMapper extends SubClassMapperBase<RatingColumnSpec> {
     opt: true,
     def: false,
   );
+  static double? _$width(RatingColumnSpec v) => v.width;
+  static const Field<RatingColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
   static Range<double> _$range(RatingColumnSpec v) => v.range;
   static const Field<RatingColumnSpec, Range<double>> _f$range = Field(
     'range',
@@ -141,6 +147,7 @@ class RatingColumnSpecMapper extends SubClassMapperBase<RatingColumnSpec> {
     #storageKey: _f$storageKey,
     #description: _f$description,
     #hidden: _f$hidden,
+    #width: _f$width,
     #range: _f$range,
   };
   @override
@@ -167,6 +174,7 @@ class RatingColumnSpecMapper extends SubClassMapperBase<RatingColumnSpec> {
       storageKey: data.dec(_f$storageKey),
       description: data.dec(_f$description),
       hidden: data.dec(_f$hidden),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/script.dart
+++ b/lib/src/chara_detail/spec/script.dart
@@ -19,7 +19,6 @@ import '/src/chara_detail/spec/base.dart';
 import '/src/chara_detail/spec/loader.dart';
 import '/src/chara_detail/spec/script_facade.dart';
 import '/src/chara_detail/storage.dart';
-import '/src/core/callback.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/code_highlight_field.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
@@ -413,7 +412,7 @@ class ScriptCellData implements CellData {
   String get csv => result.display;
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 /// Column type for script cells: the whole [ScriptCellResult] lives in

--- a/lib/src/chara_detail/spec/script.dart
+++ b/lib/src/chara_detail/spec/script.dart
@@ -693,11 +693,7 @@ class _ScriptCell extends StatelessWidget {
       );
     }
     final iconData = result.icon == null ? null : _iconMap[result.icon!];
-    final text = Text(
-      result.display,
-      overflow: TextOverflow.ellipsis,
-      style: TextStyle(color: _resolveColor(result.color)),
-    );
+    final text = CellText(result.display, style: TextStyle(color: _resolveColor(result.color)));
     final row = Row(
       mainAxisSize: MainAxisSize.min,
       children: [

--- a/lib/src/chara_detail/spec/script.dart
+++ b/lib/src/chara_detail/spec/script.dart
@@ -511,6 +511,9 @@ class ScriptColumnSpec extends ColumnSpec<ScriptCellResult> with ScriptColumnSpe
   @override
   final bool hidden;
 
+  @override
+  final double? width;
+
   ScriptColumnSpec({
     required this.id,
     required this.title,
@@ -518,6 +521,7 @@ class ScriptColumnSpec extends ColumnSpec<ScriptCellResult> with ScriptColumnSpe
     this.apiVersion = scriptApiVersion,
     this.description,
     this.hidden = false,
+    this.width,
   });
 
   @override
@@ -526,6 +530,9 @@ class ScriptColumnSpec extends ColumnSpec<ScriptCellResult> with ScriptColumnSpe
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
 
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
+
   ScriptColumnSpec copyWith({
     String? id,
     String? title,
@@ -533,6 +540,7 @@ class ScriptColumnSpec extends ColumnSpec<ScriptCellResult> with ScriptColumnSpe
     int? apiVersion,
     Object? description = _unset,
     bool? hidden,
+    Object? width = _unset,
   }) {
     return ScriptColumnSpec(
       id: id ?? this.id,
@@ -541,6 +549,7 @@ class ScriptColumnSpec extends ColumnSpec<ScriptCellResult> with ScriptColumnSpe
       apiVersion: apiVersion ?? this.apiVersion,
       description: identical(description, _unset) ? this.description : description as String?,
       hidden: hidden ?? this.hidden,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -643,8 +652,9 @@ class ScriptColumnSpec extends ColumnSpec<ScriptCellResult> with ScriptColumnSpe
       field: id,
       type: const _ScriptColumnType(),
       textAlign: _numericSort ? TrinaColumnTextAlign.right : TrinaColumnTextAlign.left,
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       enableEditingMode: false,
       // Auto-fit measures formattedValueForDisplay(cell.value); make that the real

--- a/lib/src/chara_detail/spec/script.mapper.dart
+++ b/lib/src/chara_detail/spec/script.mapper.dart
@@ -54,6 +54,12 @@ class ScriptColumnSpecMapper extends SubClassMapperBase<ScriptColumnSpec> {
     opt: true,
     def: false,
   );
+  static double? _$width(ScriptColumnSpec v) => v.width;
+  static const Field<ScriptColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
 
   @override
   final MappableFields<ScriptColumnSpec> fields = const {
@@ -63,6 +69,7 @@ class ScriptColumnSpecMapper extends SubClassMapperBase<ScriptColumnSpec> {
     #apiVersion: _f$apiVersion,
     #description: _f$description,
     #hidden: _f$hidden,
+    #width: _f$width,
   };
   @override
   final bool ignoreNull = true;
@@ -87,6 +94,7 @@ class ScriptColumnSpecMapper extends SubClassMapperBase<ScriptColumnSpec> {
       apiVersion: data.dec(_f$apiVersion),
       description: data.dec(_f$description),
       hidden: data.dec(_f$hidden),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/simple_label.dart
+++ b/lib/src/chara_detail/spec/simple_label.dart
@@ -9,7 +9,6 @@ import '/src/chara_detail/chara_detail_record.dart';
 import '/src/chara_detail/spec/base.dart';
 import '/src/chara_detail/spec/loader.dart';
 import '/src/chara_detail/spec/parser.dart';
-import '/src/core/callback.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
 import '/src/gui/chara_detail/common.dart';
@@ -45,7 +44,7 @@ class SimpleLabelCellData implements CellData {
   String get csv => label;
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 @MappableClass(discriminatorValue: 'SimpleLabelColumnSpec', ignoreNull: true)

--- a/lib/src/chara_detail/spec/simple_label.dart
+++ b/lib/src/chara_detail/spec/simple_label.dart
@@ -144,7 +144,7 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
       readOnly: true,
       renderer: (TrinaColumnRendererContext context) {
         final data = context.cell.getUserData<SimpleLabelCellData>()!;
-        return Text(data.label, textAlign: TextAlign.center);
+        return CellText(data.label, textAlign: TextAlign.center);
       },
     )..setUserData(this);
   }

--- a/lib/src/chara_detail/spec/simple_label.dart
+++ b/lib/src/chara_detail/spec/simple_label.dart
@@ -69,6 +69,9 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
   @override
   final String? description;
 
+  @override
+  final double? width;
+
   SimpleLabelColumnSpec({
     required this.id,
     required this.title,
@@ -78,6 +81,7 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
     ColumnSpecCellAction? cellAction,
     this.hidden = false,
     this.description,
+    this.width,
   }) : cellAction = cellAction ?? ColumnSpecCellAction.openSkillPreview;
 
   @override
@@ -85,6 +89,9 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
 
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
+
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
 
   SimpleLabelColumnSpec copyWith({
     String? id,
@@ -94,6 +101,7 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
     SimpleLabelPredicate? predicate,
     bool? hidden,
     Object? description = _unset,
+    Object? width = _unset,
   }) {
     return SimpleLabelColumnSpec(
       id: id ?? this.id,
@@ -103,6 +111,7 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
       predicate: predicate ?? this.predicate,
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -128,8 +137,9 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
       title: title,
       field: id,
       type: TrinaColumnType.text(),
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       readOnly: true,
       renderer: (TrinaColumnRendererContext context) {

--- a/lib/src/chara_detail/spec/simple_label.mapper.dart
+++ b/lib/src/chara_detail/spec/simple_label.mapper.dart
@@ -119,6 +119,12 @@ class SimpleLabelColumnSpecMapper
     _$description,
     opt: true,
   );
+  static double? _$width(SimpleLabelColumnSpec v) => v.width;
+  static const Field<SimpleLabelColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
 
   @override
   final MappableFields<SimpleLabelColumnSpec> fields = const {
@@ -130,6 +136,7 @@ class SimpleLabelColumnSpecMapper
     #cellAction: _f$cellAction,
     #hidden: _f$hidden,
     #description: _f$description,
+    #width: _f$width,
   };
   @override
   final bool ignoreNull = true;
@@ -156,6 +163,7 @@ class SimpleLabelColumnSpecMapper
       cellAction: data.dec(_f$cellAction),
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/chara_detail/spec/skill.dart
+++ b/lib/src/chara_detail/spec/skill.dart
@@ -232,7 +232,7 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {
         final data = context.cell.getUserData<SkillCellData>()!;
-        return Text(data.label);
+        return CellText(data.label);
       },
     )..setUserData(this);
   }

--- a/lib/src/chara_detail/spec/skill.dart
+++ b/lib/src/chara_detail/spec/skill.dart
@@ -11,7 +11,6 @@ import '/src/chara_detail/chara_detail_record.dart';
 import '/src/chara_detail/spec/base.dart';
 import '/src/chara_detail/spec/loader.dart';
 import '/src/chara_detail/spec/parser.dart';
-import '/src/core/callback.dart';
 import '/src/core/utils.dart';
 import '/src/gui/chara_detail/column_spec_dialog.dart';
 import '/src/gui/chara_detail/common.dart';
@@ -114,7 +113,7 @@ class SkillCellData implements CellData {
   String get csv => const CsvEncoder().convert([skills]);
 
   @override
-  Predicate<TrinaGridOnSelectedEvent>? get onSelected => null;
+  CellSelectedCallback? get onSelected => null;
 }
 
 @MappableEnum()

--- a/lib/src/chara_detail/spec/skill.dart
+++ b/lib/src/chara_detail/spec/skill.dart
@@ -143,6 +143,9 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
   final String? description;
 
   @override
+  final double? width;
+
+  @override
   ColumnSpecCellAction get cellAction => ColumnSpecCellAction.openSkillPreview;
 
   SkillColumnSpec({
@@ -155,6 +158,7 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
     this.hiddenElements = const {},
     this.hidden = false,
     this.description,
+    this.width,
   });
 
   @override
@@ -162,6 +166,9 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
 
   @override
   ColumnSpec withDescription(String? description) => copyWith(description: description);
+
+  @override
+  ColumnSpec withWidth(double? width) => copyWith(width: width);
 
   SkillColumnSpec copyWith({
     String? id,
@@ -173,6 +180,7 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
     Set<SkillDialogElements>? hiddenElements,
     bool? hidden,
     Object? description = _unset,
+    Object? width = _unset,
   }) {
     return SkillColumnSpec(
       id: id ?? this.id,
@@ -184,6 +192,7 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
       hiddenElements: hiddenElements ?? this.hiddenElements,
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
+      width: identical(width, _unset) ? this.width : width as double?,
     );
   }
 
@@ -216,8 +225,9 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
       title: title,
       field: id,
       type: TrinaColumnType.text(),
+      width: width ?? TrinaGridSettings.columnWidth,
       enableContextMenu: false,
-      enableDropToResize: false,
+      enableDropToResize: true,
       enableColumnDrag: false,
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {

--- a/lib/src/chara_detail/spec/skill.mapper.dart
+++ b/lib/src/chara_detail/spec/skill.mapper.dart
@@ -326,6 +326,12 @@ class SkillColumnSpecMapper extends SubClassMapperBase<SkillColumnSpec> {
     _$description,
     opt: true,
   );
+  static double? _$width(SkillColumnSpec v) => v.width;
+  static const Field<SkillColumnSpec, double> _f$width = Field(
+    'width',
+    _$width,
+    opt: true,
+  );
   static String _$labelKey(SkillColumnSpec v) => v.labelKey;
   static const Field<SkillColumnSpec, String> _f$labelKey = Field(
     'labelKey',
@@ -344,6 +350,7 @@ class SkillColumnSpecMapper extends SubClassMapperBase<SkillColumnSpec> {
     #hiddenElements: _f$hiddenElements,
     #hidden: _f$hidden,
     #description: _f$description,
+    #width: _f$width,
     #labelKey: _f$labelKey,
   };
   @override
@@ -372,6 +379,7 @@ class SkillColumnSpecMapper extends SubClassMapperBase<SkillColumnSpec> {
       hiddenElements: data.dec(_f$hiddenElements),
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
+      width: data.dec(_f$width),
     );
   }
 

--- a/lib/src/core/mapper_init.dart
+++ b/lib/src/core/mapper_init.dart
@@ -94,4 +94,5 @@ void initializeMappers() {
   // Enums stored on their own in Hive.
   CharaDetailRecordImageModeMapper.ensureInitialized();
   ClipboardPasteImageModeMapper.ensureInitialized();
+  RowHeightModeMapper.ensureInitialized();
 }

--- a/lib/src/gui/chara_detail/chara_detail_settings_dialog.dart
+++ b/lib/src/gui/chara_detail/chara_detail_settings_dialog.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:recase/recase.dart';
 
 import '/src/chara_detail/spec/base.dart';
 import '/src/core/utils.dart';
@@ -64,7 +65,8 @@ class CharaDetailSettingsDialog extends ConsumerWidget {
   }
 }
 
-/// Display-related table preferences (currently just the row-height behavior).
+/// Display-related table preferences: the row-height mode and its minimum line
+/// count.
 class _DisplaySettingsGroup extends ConsumerWidget {
   const _DisplaySettingsGroup();
 
@@ -74,10 +76,18 @@ class _DisplaySettingsGroup extends ConsumerWidget {
       title: "$tr_table_settings.display.title".tr(),
       padding: EdgeInsets.zero,
       children: [
-        SwitchWidget(
-          title: Text("$tr_table_settings.display.auto_row_height.title".tr()),
-          description: Text("$tr_table_settings.display.auto_row_height.description".tr()),
-          provider: charaDetailAutoRowHeightProvider,
+        DropdownButtonWidget<RowHeightMode>(
+          title: "$tr_table_settings.display.row_height_mode.title".tr(),
+          description: "$tr_table_settings.display.row_height_mode.description".tr(),
+          name: (e) => "$tr_table_settings.display.row_height_mode.choice.${e.name.snakeCase}".tr(),
+          provider: charaDetailRowHeightModeProvider,
+        ),
+        StepperWidget(
+          title: Text("$tr_table_settings.display.min_row_lines.title".tr()),
+          description: Text("$tr_table_settings.display.min_row_lines.description".tr()),
+          provider: charaDetailMinRowLinesProvider,
+          min: 1,
+          max: 6,
         ),
       ],
     );

--- a/lib/src/gui/chara_detail/chara_detail_settings_dialog.dart
+++ b/lib/src/gui/chara_detail/chara_detail_settings_dialog.dart
@@ -81,6 +81,7 @@ class _DisplaySettingsGroup extends ConsumerWidget {
           title: "$tr_table_settings.display.row_height_mode.title".tr(),
           description: "$tr_table_settings.display.row_height_mode.description".tr(),
           name: (e) => "$tr_table_settings.display.row_height_mode.choice.${e.name.snakeCase}".tr(),
+          tooltip: (e) => "$tr_table_settings.display.row_height_mode.tooltip.${e.name.snakeCase}".tr(),
           provider: charaDetailRowHeightModeProvider,
         ),
         StepperWidget(

--- a/lib/src/gui/chara_detail/chara_detail_settings_dialog.dart
+++ b/lib/src/gui/chara_detail/chara_detail_settings_dialog.dart
@@ -1,0 +1,85 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+import '/src/chara_detail/spec/base.dart';
+import '/src/core/utils.dart';
+import '/src/gui/common.dart';
+import '/src/gui/settings.dart';
+
+// ignore: constant_identifier_names
+const tr_table_settings = "pages.chara_detail.settings";
+
+/// Toolbar button opening the chara-detail table settings dialog. Replaces the
+/// standalone row-height toggle so further table preferences have a home.
+class CharaDetailSettingsButton extends ConsumerWidget {
+  const CharaDetailSettingsButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Matches the other toolbar icon buttons (see SidePreviewToggleButton).
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 3),
+      child: IconButton(
+        icon: const Icon(Symbols.settings_rounded, size: 22),
+        tooltip: "$tr_table_settings.button_tooltip".tr(),
+        onPressed: () => CharaDetailSettingsDialog.show(ref.base),
+        visualDensity: VisualDensity.compact,
+        splashRadius: 20,
+        constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+        padding: EdgeInsets.zero,
+      ),
+    );
+  }
+}
+
+/// Settings dialog for the chara-detail table. Hosts one [ListCard] group per
+/// settings category; add a row to a group (or a new group widget to [content])
+/// as preferences grow — the same shape as the global [SettingsPage].
+class CharaDetailSettingsDialog extends ConsumerWidget {
+  const CharaDetailSettingsDialog({super.key});
+
+  static void show(RefBase ref) {
+    CardDialog.show(ref, (_) => const CharaDetailSettingsDialog());
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 520, maxHeight: 640),
+      child: CardDialog(
+        dialogTitle: "$tr_table_settings.dialog.title".tr(),
+        closeButtonTooltip: "$tr_table_settings.dialog.close_button".tr(),
+        usePageView: false,
+        scrollableContent: true,
+        content: const Padding(
+          padding: EdgeInsets.all(8),
+          // One group today; append more group widgets here (separated by a
+          // SizedBox(height: 8)) as the table gains settings.
+          child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [_DisplaySettingsGroup()]),
+        ),
+      ),
+    );
+  }
+}
+
+/// Display-related table preferences (currently just the row-height behavior).
+class _DisplaySettingsGroup extends ConsumerWidget {
+  const _DisplaySettingsGroup();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListCard(
+      title: "$tr_table_settings.display.title".tr(),
+      padding: EdgeInsets.zero,
+      children: [
+        SwitchWidget(
+          title: Text("$tr_table_settings.display.auto_row_height.title".tr()),
+          description: Text("$tr_table_settings.display.auto_row_height.description".tr()),
+          provider: charaDetailAutoRowHeightProvider,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/gui/chara_detail/chara_detail_settings_dialog.dart
+++ b/lib/src/gui/chara_detail/chara_detail_settings_dialog.dart
@@ -6,6 +6,7 @@ import 'package:recase/recase.dart';
 
 import '/src/chara_detail/spec/base.dart';
 import '/src/core/utils.dart';
+import '/src/gui/chara_detail/common.dart';
 import '/src/gui/common.dart';
 import '/src/gui/settings.dart';
 
@@ -35,9 +36,9 @@ class CharaDetailSettingsButton extends ConsumerWidget {
   }
 }
 
-/// Settings dialog for the chara-detail table. Hosts one [ListCard] group per
-/// settings category; add a row to a group (or a new group widget to [content])
-/// as preferences grow — the same shape as the global [SettingsPage].
+/// Settings dialog for the chara-detail table. Hosts one [FormGroup] per settings
+/// category — the same divider-headed grouping as the column-customize dialog —
+/// so further preferences can be added as new groups or rows.
 class CharaDetailSettingsDialog extends ConsumerWidget {
   const CharaDetailSettingsDialog({super.key});
 
@@ -57,7 +58,7 @@ class CharaDetailSettingsDialog extends ConsumerWidget {
         content: const Padding(
           padding: EdgeInsets.all(8),
           // One group today; append more group widgets here (separated by a
-          // SizedBox(height: 8)) as the table gains settings.
+          // SizedBox(height: 16)) as the table gains settings.
           child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [_DisplaySettingsGroup()]),
         ),
       ),
@@ -66,15 +67,15 @@ class CharaDetailSettingsDialog extends ConsumerWidget {
 }
 
 /// Display-related table preferences: the row-height mode and its minimum line
-/// count.
+/// count. Grouped under a [FormGroup] header, with each row in the same
+/// list-tile style as the global settings page.
 class _DisplaySettingsGroup extends ConsumerWidget {
   const _DisplaySettingsGroup();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ListCard(
-      title: "$tr_table_settings.display.title".tr(),
-      padding: EdgeInsets.zero,
+    return FormGroup(
+      title: Text("$tr_table_settings.display.title".tr()),
       children: [
         DropdownButtonWidget<RowHeightMode>(
           title: "$tr_table_settings.display.row_height_mode.title".tr(),
@@ -87,7 +88,7 @@ class _DisplaySettingsGroup extends ConsumerWidget {
           description: Text("$tr_table_settings.display.min_row_lines.description".tr()),
           provider: charaDetailMinRowLinesProvider,
           min: 1,
-          max: 6,
+          max: 20,
         ),
       ],
     );

--- a/lib/src/gui/chara_detail/column_preset_bar_widget.dart
+++ b/lib/src/gui/chara_detail/column_preset_bar_widget.dart
@@ -156,12 +156,16 @@ class ColumnPresetBarWidget extends ConsumerWidget {
                     // CharaDetailExportButton carries the same horizontal:3
                     // margin as _PresetActionButton, so no extra spacer is needed.
                     const CharaDetailExportButton(),
+                    // Caps the record group right after export, setting it off
+                    // from the right-pinned controls.
+                    const _ToolbarDivider(),
                   ],
                 ),
               ),
               // Table settings dialog, then the side preview toggle, pinned to
-              // the right edge.
+              // the right edge, with a divider between the two.
               const CharaDetailSettingsButton(),
+              const _ToolbarDivider(),
               const SidePreviewToggleButton(),
             ],
           ),

--- a/lib/src/gui/chara_detail/column_preset_bar_widget.dart
+++ b/lib/src/gui/chara_detail/column_preset_bar_widget.dart
@@ -28,6 +28,30 @@ const tr_toolbar = "pages.chara_detail.toolbar";
 /// widget's lifecycle.
 typedef _PresetNameSubmit = void Function(WidgetRef ref, String name);
 
+/// Toolbar button toggling whether table cells grow their row to fit wrapped
+/// text or stay fixed-height with a two-line ellipsis. Mirrors
+/// [SidePreviewToggleButton]'s styling; the on state is shown by the icon fill.
+class RowHeightToggleButton extends ConsumerWidget {
+  const RowHeightToggleButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final expand = ref.watch(charaDetailAutoRowHeightProvider);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 3),
+      child: IconButton(
+        icon: Icon(Symbols.wrap_text_rounded, size: 22, fill: expand ? 1 : 0),
+        tooltip: "$tr_toolbar.row_height.${expand ? "collapse" : "expand"}_tooltip".tr(),
+        onPressed: () => ref.read(charaDetailAutoRowHeightProvider.notifier).toggle(),
+        visualDensity: VisualDensity.compact,
+        splashRadius: 20,
+        constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+        padding: EdgeInsets.zero,
+      ),
+    );
+  }
+}
+
 /// Toolbar-style control row letting the user pick which column preset is
 /// applied and manage the preset list (create, duplicate, rename, delete). Sits
 /// above the column chips; the selected preset drives [columnPresetIndexProvider],
@@ -158,7 +182,9 @@ class ColumnPresetBarWidget extends ConsumerWidget {
                   ],
                 ),
               ),
-              // View toggle for the side preview panel, pinned to the right edge.
+              // Row-height (wrap vs. ellipsis) toggle, then the side preview
+              // toggle, pinned to the right edge.
+              const RowHeightToggleButton(),
               const SidePreviewToggleButton(),
             ],
           ),

--- a/lib/src/gui/chara_detail/column_preset_bar_widget.dart
+++ b/lib/src/gui/chara_detail/column_preset_bar_widget.dart
@@ -7,6 +7,7 @@ import '/src/chara_detail/spec/base.dart';
 import '/src/chara_detail/spec/preset.dart';
 import '/src/chara_detail/storage.dart';
 import '/src/core/utils.dart';
+import '/src/gui/chara_detail/chara_detail_settings_dialog.dart';
 import '/src/gui/chara_detail/export_button.dart';
 import '/src/gui/chara_detail/side_preview.dart';
 import '/src/gui/common.dart';
@@ -27,30 +28,6 @@ const tr_toolbar = "pages.chara_detail.toolbar";
 /// [WidgetRef] so the mutation runs against a live ref regardless of the bar
 /// widget's lifecycle.
 typedef _PresetNameSubmit = void Function(WidgetRef ref, String name);
-
-/// Toolbar button toggling whether table cells grow their row to fit wrapped
-/// text or stay fixed-height with a two-line ellipsis. Mirrors
-/// [SidePreviewToggleButton]'s styling; the on state is shown by the icon fill.
-class RowHeightToggleButton extends ConsumerWidget {
-  const RowHeightToggleButton({super.key});
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final expand = ref.watch(charaDetailAutoRowHeightProvider);
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 3),
-      child: IconButton(
-        icon: Icon(Symbols.wrap_text_rounded, size: 22, fill: expand ? 1 : 0),
-        tooltip: "$tr_toolbar.row_height.${expand ? "collapse" : "expand"}_tooltip".tr(),
-        onPressed: () => ref.read(charaDetailAutoRowHeightProvider.notifier).toggle(),
-        visualDensity: VisualDensity.compact,
-        splashRadius: 20,
-        constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
-        padding: EdgeInsets.zero,
-      ),
-    );
-  }
-}
 
 /// Toolbar-style control row letting the user pick which column preset is
 /// applied and manage the preset list (create, duplicate, rename, delete). Sits
@@ -182,9 +159,9 @@ class ColumnPresetBarWidget extends ConsumerWidget {
                   ],
                 ),
               ),
-              // Row-height (wrap vs. ellipsis) toggle, then the side preview
-              // toggle, pinned to the right edge.
-              const RowHeightToggleButton(),
+              // Table settings dialog, then the side preview toggle, pinned to
+              // the right edge.
+              const CharaDetailSettingsButton(),
               const SidePreviewToggleButton(),
             ],
           ),

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -318,6 +318,22 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     _appliedWidths = {for (final col in stateManager.columns) col.field: col.width};
   }
 
+  /// Reflows row heights for the current auto-row-height setting: grows rows to
+  /// fit wrapped text (on), or restores the fixed grid height (off). Runs after
+  /// every autoFit/resize since wrapping depends on the final column widths, and
+  /// on a setting toggle. Re-indexes the pinned block because the height pass
+  /// replaces the row objects it touches.
+  void _applyRowHeights() {
+    if (!_loaded) {
+      return;
+    }
+    final expand = ref.read(charaDetailAutoRowHeightProvider);
+    if (stateManager.applyAutoRowHeights(expand: expand)) {
+      _indexPinnedRows();
+      stateManager.notifyListeners();
+    }
+  }
+
   /// Pins any column the user just dragged: a live width that drifts from the
   /// recorded baseline persists onto its spec as an explicit width, which makes
   /// [autoFitColumns] skip it thereafter. The live column's user data is updated
@@ -347,6 +363,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
       selection.replaceById(spec);
     }
     _snapshotColumnWidths();
+    _applyRowHeights();
   }
 
   /// The column whose header occupies the local x offset [dx] (header band only),
@@ -434,6 +451,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     _afterFrame(() {
       stateManager.autoFitColumns();
       _snapshotColumnWidths();
+      _applyRowHeights();
     });
   }
 
@@ -461,6 +479,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     _afterFrame(() {
       stateManager.autoFitColumns();
       _snapshotColumnWidths();
+      _applyRowHeights();
     });
   }
 
@@ -542,6 +561,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
       _afterFrame(() {
         stateManager.autoFitColumns();
         _snapshotColumnWidths();
+        _applyRowHeights();
       });
     } else {
       stateManager.refreshColumnRenderers(next.columns);
@@ -560,6 +580,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
         _afterFrame(() {
           stateManager.autoFitColumns();
           _snapshotColumnWidths();
+          _applyRowHeights();
         });
       }
     }
@@ -589,14 +610,21 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     _purpose = purpose;
     if (themeChanged) {
       // The grid's long-lived row callbacks read _theme; nudge them to repaint
-      // with the new colors (a theme change doesn't touch currentGridProvider).
-      _afterFrame(() => stateManager.notifyListeners());
+      // with the new colors (a theme change doesn't touch currentGridProvider). A
+      // font/text-scale change also alters wrapping, so re-fit row heights too.
+      _afterFrame(() {
+        _applyRowHeights();
+        stateManager.notifyListeners();
+      });
     }
     // Apply subsequent grid changes to the live stateManager rather than letting
     // the watch above rebuild a fresh grid (TrinaGrid ignores changed columns/rows
     // after init). The watch stays only to seed the initial grid and the empty
     // checks below.
     ref.listen(currentGridProvider, (_, next) => _reconcile(next));
+    // Toggling auto row height doesn't rebuild the grid (only the CellText cells,
+    // which watch the setting), so reflow the live row heights here on change.
+    ref.listen(charaDetailAutoRowHeightProvider, (_, _) => _afterFrame(_applyRowHeights));
     // No source-switch listener needed: the panel tracks the grid's current record
     // and re-resolves it against the live sorted set each build, so a source switch
     // (the old record's id is absent from the new source) falls back to the empty
@@ -787,6 +815,7 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                     _appliedGrid = grid;
                     event.stateManager.autoFitColumns();
                     _snapshotColumnWidths();
+                    _applyRowHeights();
                     if (sortColumn != null) {
                       event.stateManager.sortColumnByField(sortColumn!, sortOrder);
                     }

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -403,7 +403,8 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
   }
 
   /// Opens the column-header context menu (right-click on a header) offering to
-  /// revert this column — or every column — to content-driven auto width.
+  /// sort the column (ascending/descending/clear, via a submenu) or revert it to
+  /// content-driven auto width.
   void _showColumnHeaderMenu(BuildContext context, Offset position, TrinaColumn column) {
     final theme = Theme.of(context);
     final style = theme.textTheme.labelMedium;
@@ -421,11 +422,30 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
           onSelected: (_) => _resetColumnWidth(column),
           label: Text("$tr_chara_detail.column_context_menu.reset_width".tr(), style: pinned ? style : disabledStyle),
         ),
-        MenuItem(
+        MenuItem.submenu(
           constraints: constraints,
-          icon: const Icon(Symbols.replay, weight: iconWeight),
-          onSelected: (_) => _resetAllColumnWidths(),
-          label: Text("$tr_chara_detail.column_context_menu.reset_all_widths".tr(), style: style),
+          icon: const Icon(Symbols.swap_vert, weight: iconWeight),
+          label: Text("$tr_chara_detail.column_context_menu.sort.label".tr(), style: style),
+          items: [
+            MenuItem(
+              constraints: constraints,
+              icon: const Icon(Symbols.arrow_upward, weight: iconWeight),
+              onSelected: (_) => _sortColumn(column, TrinaColumnSort.ascending),
+              label: Text("$tr_chara_detail.column_context_menu.sort.ascending".tr(), style: style),
+            ),
+            MenuItem(
+              constraints: constraints,
+              icon: const Icon(Symbols.arrow_downward, weight: iconWeight),
+              onSelected: (_) => _sortColumn(column, TrinaColumnSort.descending),
+              label: Text("$tr_chara_detail.column_context_menu.sort.descending".tr(), style: style),
+            ),
+            MenuItem(
+              constraints: constraints,
+              icon: const Icon(Symbols.close, weight: iconWeight),
+              onSelected: (_) => _sortColumn(column, TrinaColumnSort.none),
+              label: Text("$tr_chara_detail.column_context_menu.sort.none".tr(), style: style),
+            ),
+          ],
         ),
       ],
     );
@@ -457,32 +477,30 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     });
   }
 
-  /// Reverts every currently displayed column to auto width. Nested logic-column
-  /// children never carry a width, so clearing the live columns covers all pins.
-  void _resetAllColumnWidths() {
+  /// Sorts [column] in [order] from the header context menu. Unlike a header
+  /// click (toggleSortColumn), the direct sort calls don't fire onSorted, so the
+  /// sort bookkeeping and the pinned-row index are updated here to match — none
+  /// restores the original order via sortBySortIdx.
+  void _sortColumn(TrinaColumn column, TrinaColumnSort order) {
     if (!_loaded) {
       return;
     }
-    final selection = ref.read(currentColumnSpecsLoaderProvider.notifier);
-    var any = false;
-    for (final col in stateManager.columns) {
-      final spec = col.getUserData<ColumnSpec>();
-      if (spec == null || spec.width == null) {
-        continue;
-      }
-      final cleared = spec.withWidth(null);
-      col.setUserData(cleared);
-      selection.replaceById(cleared);
-      any = true;
+    switch (order) {
+      case TrinaColumnSort.ascending:
+        stateManager.sortAscending(column);
+      case TrinaColumnSort.descending:
+        stateManager.sortDescending(column);
+      case TrinaColumnSort.none:
+        stateManager.sortBySortIdx(column);
     }
-    if (!any) {
-      return;
+    if (order == TrinaColumnSort.none) {
+      sortColumn = null;
+      sortOrder = TrinaColumnSort.none;
+    } else {
+      sortColumn = column.field;
+      sortOrder = order;
     }
-    _afterFrame(() {
-      stateManager.autoFitColumns();
-      _snapshotColumnWidths();
-      _applyRowHeights();
-    });
+    _indexPinnedRows();
   }
 
   /// Whether two column lists describe the same columns in the same order.

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -318,17 +318,19 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     _appliedWidths = {for (final col in stateManager.columns) col.field: col.width};
   }
 
-  /// Reflows row heights for the current auto-row-height setting: grows rows to
-  /// fit wrapped text (on), or restores the fixed grid height (off). Runs after
-  /// every autoFit/resize since wrapping depends on the final column widths, and
-  /// on a setting toggle. Re-indexes the pinned block because the height pass
-  /// replaces the row objects it touches.
+  /// Reflows row heights for the current row-height mode and minimum line count:
+  /// wrap fixes rows at the floor, autoPerRow grows each row to its text, and
+  /// autoUniform grows all rows to the tallest. Runs after every autoFit/resize
+  /// since wrapping depends on the final column widths, and on a setting change.
+  /// Re-indexes the pinned block because the height pass replaces the row objects
+  /// it touches.
   void _applyRowHeights() {
     if (!_loaded) {
       return;
     }
-    final expand = ref.read(charaDetailAutoRowHeightProvider);
-    if (stateManager.applyAutoRowHeights(expand: expand)) {
+    final mode = ref.read(charaDetailRowHeightModeProvider);
+    final minLines = ref.read(charaDetailMinRowLinesProvider);
+    if (stateManager.applyRowHeights(mode: mode, minLines: minLines)) {
       _indexPinnedRows();
       stateManager.notifyListeners();
     }
@@ -622,9 +624,11 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     // after init). The watch stays only to seed the initial grid and the empty
     // checks below.
     ref.listen(currentGridProvider, (_, next) => _reconcile(next));
-    // Toggling auto row height doesn't rebuild the grid (only the CellText cells,
-    // which watch the setting), so reflow the live row heights here on change.
-    ref.listen(charaDetailAutoRowHeightProvider, (_, _) => _afterFrame(_applyRowHeights));
+    // Changing the row-height mode or minimum doesn't rebuild the grid (only the
+    // CellText cells, which watch the settings), so reflow the live row heights
+    // here on change.
+    ref.listen(charaDetailRowHeightModeProvider, (_, _) => _afterFrame(_applyRowHeights));
+    ref.listen(charaDetailMinRowLinesProvider, (_, _) => _afterFrame(_applyRowHeights));
     // No source-switch listener needed: the panel tracks the grid's current record
     // and re-resolves it against the live sorted set each build, so a source switch
     // (the old record's id is absent from the new source) falls back to the empty

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -339,8 +339,10 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
   /// Pins any column the user just dragged: a live width that drifts from the
   /// recorded baseline persists onto its spec as an explicit width, which makes
   /// [autoFitColumns] skip it thereafter. The live column's user data is updated
-  /// in lockstep (refreshColumnRenderers preserves it) so a later content re-fit
-  /// keeps skipping the now-pinned column rather than measuring it back to auto.
+  /// in lockstep so a later content re-fit keeps skipping the now-pinned column
+  /// rather than measuring it back to auto. The replaceById below also rebuilds
+  /// the grid, and refreshColumnRenderers re-seats this same spec onto the live
+  /// column, so the user data stays in sync with the loader either way.
   void _persistResizedColumns() {
     if (!_loaded) {
       return;

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -368,9 +368,10 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     _applyRowHeights();
   }
 
-  /// The column whose header occupies the local x offset [dx] (header band only),
-  /// accounting for frozen columns and the horizontal scroll offset. Returns null
-  /// outside any column (e.g. past the last column or in an empty grid).
+  /// The column whose header occupies the content-space x offset [dx] (grid
+  /// inset already removed by the caller), accounting for frozen columns and the
+  /// horizontal scroll offset. Returns null outside any column (e.g. past the
+  /// last column or in an empty grid).
   TrinaColumn? _columnAtHeaderOffset(double dx) {
     final sm = stateManager;
     if (sm.showFrozenColumn) {
@@ -685,10 +686,16 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                 if (!_loaded || event.buttons != kSecondaryButton) {
                   return;
                 }
-                if (event.localPosition.dy > stateManager.columnHeight) {
+                // trina's _GridContainer insets its content by gridBorderWidth +
+                // gridPadding, which the Listener's localPosition doesn't account
+                // for. Map into content space before the header-band check and
+                // column hit-test so both land on the right column / boundary.
+                final inset = stateManager.gridBorderWidth + stateManager.gridPadding;
+                final local = event.localPosition - Offset(inset, inset);
+                if (local.dy < 0 || local.dy > stateManager.columnHeight) {
                   return;
                 }
-                final column = _columnAtHeaderOffset(event.localPosition.dx);
+                final column = _columnAtHeaderOffset(local.dx);
                 if (column == null || column.enableRowChecked) {
                   return;
                 }
@@ -888,7 +895,10 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                   onSelected: (TrinaGridOnSelectedEvent event) {
                     try {
                       final data = event.cell?.getUserData<CellData>();
-                      if (!(data?.onSelected?.call(event) ?? false)) {
+                      // Pass this State's live ref (stable for the widget's
+                      // lifetime), never a grid-build ref the cell captured: the
+                      // grid provider may have rebuilt and disposed that one.
+                      if (!(data?.onSelected?.call(ref.base, event) ?? false)) {
                         final record = event.cell?.row.getUserData<CharaDetailRecord>();
                         if (record == null) {
                           return;

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -1,4 +1,5 @@
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_context_menu/flutter_context_menu.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -66,6 +67,13 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
   // A grid update that arrived before onLoaded captured the stateManager. Applied
   // once the grid is ready.
   Grid? _pending;
+
+  // field -> the width each live column had right after the last build, autoFit,
+  // or resize-persist. On pointer-up, a column whose live width drifts from this
+  // was dragged by the user, so it is pinned (spec.width persisted); columns that
+  // match are left as auto. Refreshed after every autoFit so a content-driven
+  // width change is never mistaken for a user drag.
+  Map<String, double> _appliedWidths = const {};
 
   // The current theme and selection purpose, mirrored here so the long-lived
   // rowColorCallback/rowWrapper closures (captured once at grid init) read fresh
@@ -299,6 +307,163 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
     );
   }
 
+  /// Records the live width of every column as the baseline against which the
+  /// next pointer-up detects a user drag. Called right after every autoFit (and
+  /// the initial load) so a content-driven re-fit resets the baseline rather than
+  /// reading as a manual resize.
+  void _snapshotColumnWidths() {
+    if (!_loaded) {
+      return;
+    }
+    _appliedWidths = {for (final col in stateManager.columns) col.field: col.width};
+  }
+
+  /// Pins any column the user just dragged: a live width that drifts from the
+  /// recorded baseline persists onto its spec as an explicit width, which makes
+  /// [autoFitColumns] skip it thereafter. The live column's user data is updated
+  /// in lockstep (refreshColumnRenderers preserves it) so a later content re-fit
+  /// keeps skipping the now-pinned column rather than measuring it back to auto.
+  void _persistResizedColumns() {
+    if (!_loaded) {
+      return;
+    }
+    final resized = <(TrinaColumn, ColumnSpec)>[];
+    for (final col in stateManager.columns) {
+      final previous = _appliedWidths[col.field];
+      if (previous == null || (col.width - previous).abs() < 0.5) {
+        continue;
+      }
+      final spec = col.getUserData<ColumnSpec>();
+      if (spec != null) {
+        resized.add((col, spec.withWidth(col.width)));
+      }
+    }
+    if (resized.isEmpty) {
+      return;
+    }
+    final selection = ref.read(currentColumnSpecsLoaderProvider.notifier);
+    for (final (col, spec) in resized) {
+      col.setUserData(spec);
+      selection.replaceById(spec);
+    }
+    _snapshotColumnWidths();
+  }
+
+  /// The column whose header occupies the local x offset [dx] (header band only),
+  /// accounting for frozen columns and the horizontal scroll offset. Returns null
+  /// outside any column (e.g. past the last column or in an empty grid).
+  TrinaColumn? _columnAtHeaderOffset(double dx) {
+    final sm = stateManager;
+    if (sm.showFrozenColumn) {
+      var acc = 0.0;
+      for (final col in sm.leftFrozenColumns) {
+        acc += col.width;
+        if (dx < acc) {
+          return col;
+        }
+      }
+      final bodyDx = dx - sm.leftFrozenColumnsWidth + (sm.scroll.horizontal?.offset ?? 0);
+      var bodyAcc = 0.0;
+      for (final col in sm.bodyColumns) {
+        bodyAcc += col.width;
+        if (bodyDx < bodyAcc) {
+          return col;
+        }
+      }
+      return null;
+    }
+    final scrolledDx = dx + (sm.scroll.horizontal?.offset ?? 0);
+    var acc = 0.0;
+    for (final col in sm.columns) {
+      acc += col.width;
+      if (scrolledDx < acc) {
+        return col;
+      }
+    }
+    return null;
+  }
+
+  /// Opens the column-header context menu (right-click on a header) offering to
+  /// revert this column — or every column — to content-driven auto width.
+  void _showColumnHeaderMenu(BuildContext context, Offset position, TrinaColumn column) {
+    final theme = Theme.of(context);
+    final style = theme.textTheme.labelMedium;
+    final disabledStyle = style?.copyWith(color: theme.disabledColor);
+    const constraints = BoxConstraints(minHeight: 40);
+    const iconWeight = 700.0;
+    final pinned = column.getUserData<ColumnSpec>()?.width != null;
+    final menu = ContextMenu(
+      position: position,
+      entries: <ContextMenuEntry>[
+        MenuItem(
+          constraints: constraints,
+          enabled: pinned,
+          icon: Icon(Symbols.restart_alt, weight: iconWeight, color: pinned ? null : theme.disabledColor),
+          onSelected: (_) => _resetColumnWidth(column),
+          label: Text("$tr_chara_detail.column_context_menu.reset_width".tr(), style: pinned ? style : disabledStyle),
+        ),
+        MenuItem(
+          constraints: constraints,
+          icon: const Icon(Symbols.replay, weight: iconWeight),
+          onSelected: (_) => _resetAllColumnWidths(),
+          label: Text("$tr_chara_detail.column_context_menu.reset_all_widths".tr(), style: style),
+        ),
+      ],
+    );
+    showContextMenu(
+      context,
+      contextMenu: menu,
+      routeOptions: const MenuRouteOptions(
+        transitionDuration: Duration(milliseconds: 120),
+        reverseTransitionDuration: Duration(milliseconds: 120),
+      ),
+    );
+  }
+
+  /// Reverts a single column to auto width: clears its spec's pinned width (live
+  /// user data first so the deferred autoFit no longer skips it), persists the
+  /// change, then re-fits since a same-columns reconcile alone would not.
+  void _resetColumnWidth(TrinaColumn column) {
+    final spec = column.getUserData<ColumnSpec>();
+    if (spec == null || spec.width == null) {
+      return;
+    }
+    final cleared = spec.withWidth(null);
+    column.setUserData(cleared);
+    ref.read(currentColumnSpecsLoaderProvider.notifier).replaceById(cleared);
+    _afterFrame(() {
+      stateManager.autoFitColumns();
+      _snapshotColumnWidths();
+    });
+  }
+
+  /// Reverts every currently displayed column to auto width. Nested logic-column
+  /// children never carry a width, so clearing the live columns covers all pins.
+  void _resetAllColumnWidths() {
+    if (!_loaded) {
+      return;
+    }
+    final selection = ref.read(currentColumnSpecsLoaderProvider.notifier);
+    var any = false;
+    for (final col in stateManager.columns) {
+      final spec = col.getUserData<ColumnSpec>();
+      if (spec == null || spec.width == null) {
+        continue;
+      }
+      final cleared = spec.withWidth(null);
+      col.setUserData(cleared);
+      selection.replaceById(cleared);
+      any = true;
+    }
+    if (!any) {
+      return;
+    }
+    _afterFrame(() {
+      stateManager.autoFitColumns();
+      _snapshotColumnWidths();
+    });
+  }
+
   /// Whether two column lists describe the same columns in the same order.
   ///
   /// Compared by field id (not object identity): the provider hands back fresh
@@ -374,7 +539,10 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
       // autoFitColumns measures via gridKey.currentContext, which needs the new
       // columns laid out first, so defer it one frame (the grid may have left the
       // tree before the frame, disposing its stateManager — _afterFrame guards that).
-      _afterFrame(() => stateManager.autoFitColumns());
+      _afterFrame(() {
+        stateManager.autoFitColumns();
+        _snapshotColumnWidths();
+      });
     } else {
       stateManager.refreshColumnRenderers(next.columns);
       // _reconcile notifies once at the end (after restoreCurrentRecord), so the
@@ -389,7 +557,10 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
       // longer value), matching the pre-incremental behavior. Skipped on a
       // selection/sort-only reconcile so widths don't churn needlessly.
       if (rowsChanged) {
-        _afterFrame(() => stateManager.autoFitColumns());
+        _afterFrame(() {
+          stateManager.autoFitColumns();
+          _snapshotColumnWidths();
+        });
       }
     }
     // Re-highlight the same record on the same column when possible (skips the
@@ -453,259 +624,285 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
             // repaints the unfocused current cell with gridBackgroundColor
             // (trina_base_cell.dart), which would otherwise punch a hole in the
             // row highlight. Transparent lets the row color show through instead.
-            return ColoredBox(
-              color: theme.colorScheme.surface,
-              child: TrinaGrid(
-                // Stable key keeps one grid (and its stateManager) alive across
-                // rebuilds. Data changes are pushed in imperatively via
-                // [_reconcile]; the columns/rows below only seed the initial grid.
-                key: const ValueKey("chara_detail_grid"),
-                columns: grid.columns,
-                rows: grid.rows,
-                mode: TrinaGridMode.select,
-                // Paint the selected row ourselves so the highlight stays
-                // visible even when the grid loses focus (e.g. the app is
-                // deactivated). TrinaGrid's built-in activatedColor is gated on
-                // hasFocus, so it disappears otherwise. Setting rowColorCallback
-                // overrides the default striping, so reproduce it for other rows.
-                rowColorCallback: (rowContext) {
-                  final theme = _theme;
-                  // Detect the highlighted row by record id, not row index. With
-                  // pinned (frozen) rows present, currentRowIdx is an index into
-                  // the full refRows while rowContext.rowIdx is a display index
-                  // (frozen rows render in a separate block), so an index compare
-                  // would highlight the wrong row.
-                  if (rowContext.stateManager.isCurrentRecord(rowContext.row)) {
-                    return theme.colorScheme.primaryContainer;
-                  }
-                  return rowContext.rowIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor;
-                },
-                // Checked rows get a translucent amber overlay that dims the
-                // cells and is labeled "archive", so the destructive (lossy,
-                // irreversible) intent of the bulk selection is unmistakable.
-                rowWrapper: (context, rowWidget, rowData, stateManager) {
-                  final theme = _theme;
-                  final purpose = _purpose;
-                  Widget row = rowWidget;
-                  if (rowData.checked == true && purpose != null) {
-                    row = _SelectionRowOverlay(purpose: purpose, child: row);
-                  }
-                  // Frozen (pinned) rows bypass rowColorCallback and the normal
-                  // row border, so reproduce both here: the same alternating
-                  // stripe (and current-row highlight) as rowColorCallback above,
-                  // a normal-weight separator between pinned rows, and a single
-                  // thick rule only at the boundary with the scrollable rows.
-                  if (rowData.frozen == TrinaRowFrozen.start) {
-                    // Position within the frozen block, precomputed by
-                    // [_indexPinnedRows] from the live row order.
-                    final rowId = stateManager.recordIdOf(rowData);
-                    final pinnedIdx = rowId == null ? -1 : (_pinnedIndexById[rowId] ?? -1);
-                    if (pinnedIdx >= 0) {
-                      final isLast = pinnedIdx == _pinnedRowCount - 1;
-                      // The stripe and separator don't depend on the selection, so
-                      // compute them once; only the current-row highlight below is
-                      // recomputed per notify.
-                      final stripe = pinnedIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor;
-                      final separator = isLast
-                          ? BorderSide(color: theme.colorScheme.outline, width: 3)
-                          : BorderSide(
-                              color: theme.focusColor,
-                              width: stateManager.configuration.style.cellHorizontalBorderWidth,
+            // trina_grid exposes no resize-complete callback, so wrap the grid and
+            // read column widths on pointer-up: any column whose width drifted from
+            // the recorded baseline was dragged, and is pinned. A secondary press on
+            // the header band opens the auto-width reset menu (trina has no
+            // header-secondary-tap event either).
+            return Listener(
+              onPointerUp: (_) => _persistResizedColumns(),
+              onPointerDown: (event) {
+                if (!_loaded || event.buttons != kSecondaryButton) {
+                  return;
+                }
+                if (event.localPosition.dy > stateManager.columnHeight) {
+                  return;
+                }
+                final column = _columnAtHeaderOffset(event.localPosition.dx);
+                if (column == null || column.enableRowChecked) {
+                  return;
+                }
+                _showColumnHeaderMenu(context, event.position, column);
+              },
+              child: ColoredBox(
+                color: theme.colorScheme.surface,
+                child: TrinaGrid(
+                  // Stable key keeps one grid (and its stateManager) alive across
+                  // rebuilds. Data changes are pushed in imperatively via
+                  // [_reconcile]; the columns/rows below only seed the initial grid.
+                  key: const ValueKey("chara_detail_grid"),
+                  columns: grid.columns,
+                  rows: grid.rows,
+                  mode: TrinaGridMode.select,
+                  // Paint the selected row ourselves so the highlight stays
+                  // visible even when the grid loses focus (e.g. the app is
+                  // deactivated). TrinaGrid's built-in activatedColor is gated on
+                  // hasFocus, so it disappears otherwise. Setting rowColorCallback
+                  // overrides the default striping, so reproduce it for other rows.
+                  rowColorCallback: (rowContext) {
+                    final theme = _theme;
+                    // Detect the highlighted row by record id, not row index. With
+                    // pinned (frozen) rows present, currentRowIdx is an index into
+                    // the full refRows while rowContext.rowIdx is a display index
+                    // (frozen rows render in a separate block), so an index compare
+                    // would highlight the wrong row.
+                    if (rowContext.stateManager.isCurrentRecord(rowContext.row)) {
+                      return theme.colorScheme.primaryContainer;
+                    }
+                    return rowContext.rowIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor;
+                  },
+                  // Checked rows get a translucent amber overlay that dims the
+                  // cells and is labeled "archive", so the destructive (lossy,
+                  // irreversible) intent of the bulk selection is unmistakable.
+                  rowWrapper: (context, rowWidget, rowData, stateManager) {
+                    final theme = _theme;
+                    final purpose = _purpose;
+                    Widget row = rowWidget;
+                    if (rowData.checked == true && purpose != null) {
+                      row = _SelectionRowOverlay(purpose: purpose, child: row);
+                    }
+                    // Frozen (pinned) rows bypass rowColorCallback and the normal
+                    // row border, so reproduce both here: the same alternating
+                    // stripe (and current-row highlight) as rowColorCallback above,
+                    // a normal-weight separator between pinned rows, and a single
+                    // thick rule only at the boundary with the scrollable rows.
+                    if (rowData.frozen == TrinaRowFrozen.start) {
+                      // Position within the frozen block, precomputed by
+                      // [_indexPinnedRows] from the live row order.
+                      final rowId = stateManager.recordIdOf(rowData);
+                      final pinnedIdx = rowId == null ? -1 : (_pinnedIndexById[rowId] ?? -1);
+                      if (pinnedIdx >= 0) {
+                        final isLast = pinnedIdx == _pinnedRowCount - 1;
+                        // The stripe and separator don't depend on the selection, so
+                        // compute them once; only the current-row highlight below is
+                        // recomputed per notify.
+                        final stripe = pinnedIdx.isEven ? theme.colorScheme.surface : theme.colorScheme.stripedRowColor;
+                        final separator = isLast
+                            ? BorderSide(color: theme.colorScheme.outline, width: 3)
+                            : BorderSide(
+                                color: theme.focusColor,
+                                width: stateManager.configuration.style.cellHorizontalBorderWidth,
+                              );
+                        final bordered = DecoratedBox(
+                          position: DecorationPosition.foreground,
+                          decoration: BoxDecoration(border: Border(bottom: separator)),
+                          child: row,
+                        );
+                        // The current-row highlight must track currentCell changes.
+                        // Scrollable rows get this for free: their highlight is
+                        // painted inside TrinaBaseRow (via rowColorCallback), which
+                        // listens to the stateManager and rebuilds on every notify.
+                        // Frozen rows render with a transparent frozenRowColor and
+                        // bypass rowColorCallback, so this outer wrapper paints their
+                        // highlight — but it only re-runs on a body rebuild, leaving a
+                        // stale highlight when the selection moves to another row.
+                        // Listen to the stateManager here so the background repaints by
+                        // record id whenever the current row changes.
+                        row = ListenableBuilder(
+                          listenable: stateManager,
+                          builder: (context, child) {
+                            final background = stateManager.isCurrentRecord(rowData)
+                                ? theme.colorScheme.primaryContainer
+                                : stripe;
+                            return DecoratedBox(
+                              decoration: BoxDecoration(color: background),
+                              child: child,
                             );
-                      final bordered = DecoratedBox(
-                        position: DecorationPosition.foreground,
-                        decoration: BoxDecoration(border: Border(bottom: separator)),
-                        child: row,
-                      );
-                      // The current-row highlight must track currentCell changes.
-                      // Scrollable rows get this for free: their highlight is
-                      // painted inside TrinaBaseRow (via rowColorCallback), which
-                      // listens to the stateManager and rebuilds on every notify.
-                      // Frozen rows render with a transparent frozenRowColor and
-                      // bypass rowColorCallback, so this outer wrapper paints their
-                      // highlight — but it only re-runs on a body rebuild, leaving a
-                      // stale highlight when the selection moves to another row.
-                      // Listen to the stateManager here so the background repaints by
-                      // record id whenever the current row changes.
-                      row = ListenableBuilder(
-                        listenable: stateManager,
-                        builder: (context, child) {
-                          final background = stateManager.isCurrentRecord(rowData)
-                              ? theme.colorScheme.primaryContainer
-                              : stripe;
-                          return DecoratedBox(
-                            decoration: BoxDecoration(color: background),
-                            child: child,
-                          );
-                        },
-                        child: bordered,
-                      );
+                          },
+                          child: bordered,
+                        );
+                      }
                     }
-                  }
-                  return row;
-                },
-                configuration: TrinaGridConfiguration(
-                  enterKeyAction: TrinaGridEnterKeyAction.toggleEditing,
-                  // Never auto-select the first row. In select mode TrinaGrid
-                  // otherwise highlights row 0 on (re)mount whenever no cell is
-                  // current, which would override the user's row selection and
-                  // make it appear to jump to the top.
-                  enableAutoSelectFirstRow: false,
-                  scrollbar: const TrinaGridScrollbarConfig(isAlwaysShown: true, radius: 8, thickness: 12),
-                  style: TrinaGridStyleConfig(
-                    enableCellBorderVertical: false,
-                    gridBackgroundColor: Colors.transparent,
-                    // Not the per-row striping (rowColorCallback overrides that),
-                    // but the body background painted behind/around the rows,
-                    // e.g. the empty space right of the last column. Without it
-                    // this falls back to TrinaGrid's default Colors.white.
-                    rowColor: theme.colorScheme.surface,
-                    // Keep the checked-row background neutral; the amber cue is
-                    // drawn as an overlay via rowWrapper instead (see below).
-                    rowCheckedColor: Colors.transparent,
-                    // Disable trina's built-in current-row fill. It highlights
-                    // the row where `currentRowIdx == widget.rowIdx`, comparing
-                    // a (tap-set) display index against each row's display
-                    // index. With pinned (frozen) rows that index space drifts
-                    // out of sync with refRows after a reconcile, so the
-                    // built-in fill lands on the wrong row — a second highlight
-                    // on top of the record-id one we paint in rowColorCallback/
-                    // rowWrapper. A transparent color fails trina's
-                    // `activatedColor.a > 0` guard, leaving our callback's color
-                    // in place, so the highlight is driven solely by record id.
-                    activatedColor: Colors.transparent,
-                    // TrinaGrid paints frozen (pinned) rows from these and
-                    // bypasses rowColorCallback for them, so its single
-                    // frozenRowColor can't reproduce the normal alternating
-                    // stripe. Make both transparent and paint the stripe + the
-                    // row separators ourselves in rowWrapper instead, so pinned
-                    // rows match normal rows except for the block boundary.
-                    frozenRowColor: Colors.transparent,
-                    frozenRowBorderColor: Colors.transparent,
-                    gridBorderColor: theme.colorScheme.outline,
-                    borderColor: theme.focusColor,
-                    activatedBorderColor: theme.focusColor,
-                    inactivatedBorderColor: theme.focusColor,
-                    columnTextStyle: theme.textTheme.titleSmall!,
-                    cellTextStyle: theme.textTheme.bodyMedium!,
+                    return row;
+                  },
+                  configuration: TrinaGridConfiguration(
+                    enterKeyAction: TrinaGridEnterKeyAction.toggleEditing,
+                    // Never auto-select the first row. In select mode TrinaGrid
+                    // otherwise highlights row 0 on (re)mount whenever no cell is
+                    // current, which would override the user's row selection and
+                    // make it appear to jump to the top.
+                    enableAutoSelectFirstRow: false,
+                    scrollbar: const TrinaGridScrollbarConfig(isAlwaysShown: true, radius: 8, thickness: 12),
+                    style: TrinaGridStyleConfig(
+                      enableCellBorderVertical: false,
+                      gridBackgroundColor: Colors.transparent,
+                      // Not the per-row striping (rowColorCallback overrides that),
+                      // but the body background painted behind/around the rows,
+                      // e.g. the empty space right of the last column. Without it
+                      // this falls back to TrinaGrid's default Colors.white.
+                      rowColor: theme.colorScheme.surface,
+                      // Keep the checked-row background neutral; the amber cue is
+                      // drawn as an overlay via rowWrapper instead (see below).
+                      rowCheckedColor: Colors.transparent,
+                      // Disable trina's built-in current-row fill. It highlights
+                      // the row where `currentRowIdx == widget.rowIdx`, comparing
+                      // a (tap-set) display index against each row's display
+                      // index. With pinned (frozen) rows that index space drifts
+                      // out of sync with refRows after a reconcile, so the
+                      // built-in fill lands on the wrong row — a second highlight
+                      // on top of the record-id one we paint in rowColorCallback/
+                      // rowWrapper. A transparent color fails trina's
+                      // `activatedColor.a > 0` guard, leaving our callback's color
+                      // in place, so the highlight is driven solely by record id.
+                      activatedColor: Colors.transparent,
+                      // TrinaGrid paints frozen (pinned) rows from these and
+                      // bypasses rowColorCallback for them, so its single
+                      // frozenRowColor can't reproduce the normal alternating
+                      // stripe. Make both transparent and paint the stripe + the
+                      // row separators ourselves in rowWrapper instead, so pinned
+                      // rows match normal rows except for the block boundary.
+                      frozenRowColor: Colors.transparent,
+                      frozenRowBorderColor: Colors.transparent,
+                      gridBorderColor: theme.colorScheme.outline,
+                      borderColor: theme.focusColor,
+                      activatedBorderColor: theme.focusColor,
+                      inactivatedBorderColor: theme.focusColor,
+                      columnTextStyle: theme.textTheme.titleSmall!,
+                      cellTextStyle: theme.textTheme.bodyMedium!,
+                    ),
                   ),
-                ),
-                onLoaded: (TrinaGridOnLoadedEvent event) {
-                  stateManager = event.stateManager;
-                  _loaded = true;
-                  _appliedGrid = grid;
-                  event.stateManager.autoFitColumns();
-                  if (sortColumn != null) {
-                    event.stateManager.sortColumnByField(sortColumn!, sortOrder);
-                  }
-                  // Index the pinned block so frozen rows are styled on first
-                  // load; a later _pending reconcile reindexes (harmlessly).
-                  _indexPinnedRows();
-                  // A grid change may have arrived before the stateManager was
-                  // ready; apply the latest one now.
-                  if (_pending != null) {
-                    final pending = _pending!;
-                    _pending = null;
-                    _reconcile(pending);
-                  }
-                  // Seed the side preview's record tracker from whatever is current
-                  // after load (normally nothing, since auto-select is disabled).
-                  _currentRecordId.value = event.stateManager.currentRecord?.id;
-                },
-                // The side preview panel follows the grid's current record. This
-                // fires on every current-cell change — user taps and the
-                // programmatic restoreCurrentRecord in _navigateSidePreview alike
-                // (setCurrentCell calls it even with notify:false) — so mirroring the
-                // id here keeps the panel in sync without the panel storing its own.
-                onActiveCellChanged: (_) => _currentRecordId.value = stateManager.currentRecord?.id,
-                onRowSecondaryTap: (TrinaGridOnRowSecondaryTapEvent event) {
-                  // event.row (== getRowByIdx(rowIdx)) is unreliable once any
-                  // row is frozen (pinned): TrinaGrid renders frozen rows in a
-                  // separate block with positional indices that don't map back
-                  // through refRows, so it would return a different record.
-                  // The tapped cell's own row is always correct.
-                  final record = event.cell.row.getUserData<CharaDetailRecord>()!;
-                  final spec = event.cell.column.getUserData<ColumnSpec>();
-                  showPopup(context, ref, event.offset, record, spec!.cellAction?.tabIdx ?? 0);
-                },
-                onRowChecked: (TrinaGridOnRowCheckedEvent event) {
-                  // Recompute the whole checked set (covers single + select-all
-                  // toggles) so the toolbar's archive action reads a live set.
-                  final ids = stateManager.checkedRows
-                      .map((row) => row.getUserData<CharaDetailRecord>()?.id)
-                      .nonNulls
-                      .toSet();
-                  ref.read(selectedRecordIdsProvider.notifier).set(ids);
-                  // The amber overlay is drawn by rowWrapper, which only re-runs
-                  // when the row list repaints — not when a single checkbox cell
-                  // updates itself. Nudge the grid to repaint its rows (this
-                  // reuses the existing rows, so checked state is preserved).
-                  _afterFrame(() => stateManager.notifyListeners());
-                },
-                onSelected: (TrinaGridOnSelectedEvent event) {
-                  try {
-                    final data = event.cell?.getUserData<CellData>();
-                    if (!(data?.onSelected?.call(event) ?? false)) {
-                      final record = event.cell?.row.getUserData<CharaDetailRecord>();
-                      if (record == null) {
-                        return;
-                      }
-                      // While the side preview panel is open (and visible — not in
-                      // the narrow layout where it is hidden), a cell click only
-                      // picks which screen to show (the column's mode); the panel
-                      // follows the grid's current record (already set by the tap, via
-                      // onActiveCellChanged), so it isn't set here. Suppress the dialog.
-                      //
-                      // The breakpoint is re-evaluated here, not read from the
-                      // build-scope `narrow`: TrinaGrid captures this onSelected
-                      // closure once (at grid load) and never refreshes it, so a
-                      // captured `narrow` would stay frozen at its first-build value
-                      // and feed the hidden panel after the window shrinks.
-                      final sidePreview = ref.read(sidePreviewProvider);
-                      if (sidePreview != null && isSidePreviewAllowed(context)) {
-                        final action = event.cell?.column.getUserData<ColumnSpec>()?.cellAction;
-                        final mode = imageModeForColumnAction(action);
-                        if (mode != sidePreview.mode) {
-                          ref.read(sidePreviewProvider.notifier).set(SidePreviewState(mode: mode));
-                        }
-                        return;
-                      }
-                      final source = ref.read(recordSourceProvider);
-                      final pathInfo = ref.read(pathInfoProvider);
-                      // event.rowIdx is unreliable once any row is frozen
-                      // (pinned): frozen rows render in a separate block and
-                      // shift the scrollable rows' indices, so it no longer maps
-                      // to getSortedRecords. Resolve the tapped record from its
-                      // own cell row and find its position by identity instead.
-                      final sorted = stateManager.getSortedRecords().toList();
-                      final index = sorted.indexOf(record);
-                      if (index < 0) {
-                        return;
-                      }
-                      final records = sorted.map((e) => recordDirOf(pathInfo, source, e)).toList();
-                      CharaDetailPreviewDialog.show(ref.base, records, index);
+                  onLoaded: (TrinaGridOnLoadedEvent event) {
+                    stateManager = event.stateManager;
+                    _loaded = true;
+                    _appliedGrid = grid;
+                    event.stateManager.autoFitColumns();
+                    _snapshotColumnWidths();
+                    if (sortColumn != null) {
+                      event.stateManager.sortColumnByField(sortColumn!, sortOrder);
                     }
-                  } catch (error, stackTrace) {
-                    logger.e("Failed to handle cell selected. row=${event.row}, cell=${event.cell}", error, stackTrace);
-                    captureException(error, stackTrace);
-                  }
-                },
-                onSorted: (TrinaGridOnSortedEvent event) {
-                  if (event.column.sort == TrinaColumnSort.none) {
-                    sortColumn = null;
-                    sortOrder = TrinaColumnSort.none;
-                  } else {
-                    sortColumn = event.column.field;
-                    sortOrder = event.column.sort;
-                  }
-                  // A header-click sort reorders the frozen rows in place
-                  // (FilteredList.sort works on originalList), but unlike
-                  // _reconcile/onLoaded it doesn't rebuild the pinned index, so
-                  // rowWrapper's stripe/boundary would read stale positions.
-                  // toggleSortColumn fires this before its own notifyListeners,
-                  // so re-indexing here lands in the very next repaint.
-                  _indexPinnedRows();
-                },
+                    // Index the pinned block so frozen rows are styled on first
+                    // load; a later _pending reconcile reindexes (harmlessly).
+                    _indexPinnedRows();
+                    // A grid change may have arrived before the stateManager was
+                    // ready; apply the latest one now.
+                    if (_pending != null) {
+                      final pending = _pending!;
+                      _pending = null;
+                      _reconcile(pending);
+                    }
+                    // Seed the side preview's record tracker from whatever is current
+                    // after load (normally nothing, since auto-select is disabled).
+                    _currentRecordId.value = event.stateManager.currentRecord?.id;
+                  },
+                  // The side preview panel follows the grid's current record. This
+                  // fires on every current-cell change — user taps and the
+                  // programmatic restoreCurrentRecord in _navigateSidePreview alike
+                  // (setCurrentCell calls it even with notify:false) — so mirroring the
+                  // id here keeps the panel in sync without the panel storing its own.
+                  onActiveCellChanged: (_) => _currentRecordId.value = stateManager.currentRecord?.id,
+                  onRowSecondaryTap: (TrinaGridOnRowSecondaryTapEvent event) {
+                    // event.row (== getRowByIdx(rowIdx)) is unreliable once any
+                    // row is frozen (pinned): TrinaGrid renders frozen rows in a
+                    // separate block with positional indices that don't map back
+                    // through refRows, so it would return a different record.
+                    // The tapped cell's own row is always correct.
+                    final record = event.cell.row.getUserData<CharaDetailRecord>()!;
+                    final spec = event.cell.column.getUserData<ColumnSpec>();
+                    showPopup(context, ref, event.offset, record, spec!.cellAction?.tabIdx ?? 0);
+                  },
+                  onRowChecked: (TrinaGridOnRowCheckedEvent event) {
+                    // Recompute the whole checked set (covers single + select-all
+                    // toggles) so the toolbar's archive action reads a live set.
+                    final ids = stateManager.checkedRows
+                        .map((row) => row.getUserData<CharaDetailRecord>()?.id)
+                        .nonNulls
+                        .toSet();
+                    ref.read(selectedRecordIdsProvider.notifier).set(ids);
+                    // The amber overlay is drawn by rowWrapper, which only re-runs
+                    // when the row list repaints — not when a single checkbox cell
+                    // updates itself. Nudge the grid to repaint its rows (this
+                    // reuses the existing rows, so checked state is preserved).
+                    _afterFrame(() => stateManager.notifyListeners());
+                  },
+                  onSelected: (TrinaGridOnSelectedEvent event) {
+                    try {
+                      final data = event.cell?.getUserData<CellData>();
+                      if (!(data?.onSelected?.call(event) ?? false)) {
+                        final record = event.cell?.row.getUserData<CharaDetailRecord>();
+                        if (record == null) {
+                          return;
+                        }
+                        // While the side preview panel is open (and visible — not in
+                        // the narrow layout where it is hidden), a cell click only
+                        // picks which screen to show (the column's mode); the panel
+                        // follows the grid's current record (already set by the tap, via
+                        // onActiveCellChanged), so it isn't set here. Suppress the dialog.
+                        //
+                        // The breakpoint is re-evaluated here, not read from the
+                        // build-scope `narrow`: TrinaGrid captures this onSelected
+                        // closure once (at grid load) and never refreshes it, so a
+                        // captured `narrow` would stay frozen at its first-build value
+                        // and feed the hidden panel after the window shrinks.
+                        final sidePreview = ref.read(sidePreviewProvider);
+                        if (sidePreview != null && isSidePreviewAllowed(context)) {
+                          final action = event.cell?.column.getUserData<ColumnSpec>()?.cellAction;
+                          final mode = imageModeForColumnAction(action);
+                          if (mode != sidePreview.mode) {
+                            ref.read(sidePreviewProvider.notifier).set(SidePreviewState(mode: mode));
+                          }
+                          return;
+                        }
+                        final source = ref.read(recordSourceProvider);
+                        final pathInfo = ref.read(pathInfoProvider);
+                        // event.rowIdx is unreliable once any row is frozen
+                        // (pinned): frozen rows render in a separate block and
+                        // shift the scrollable rows' indices, so it no longer maps
+                        // to getSortedRecords. Resolve the tapped record from its
+                        // own cell row and find its position by identity instead.
+                        final sorted = stateManager.getSortedRecords().toList();
+                        final index = sorted.indexOf(record);
+                        if (index < 0) {
+                          return;
+                        }
+                        final records = sorted.map((e) => recordDirOf(pathInfo, source, e)).toList();
+                        CharaDetailPreviewDialog.show(ref.base, records, index);
+                      }
+                    } catch (error, stackTrace) {
+                      logger.e(
+                        "Failed to handle cell selected. row=${event.row}, cell=${event.cell}",
+                        error,
+                        stackTrace,
+                      );
+                      captureException(error, stackTrace);
+                    }
+                  },
+                  onSorted: (TrinaGridOnSortedEvent event) {
+                    if (event.column.sort == TrinaColumnSort.none) {
+                      sortColumn = null;
+                      sortOrder = TrinaColumnSort.none;
+                    } else {
+                      sortColumn = event.column.field;
+                      sortOrder = event.column.sort;
+                    }
+                    // A header-click sort reorders the frozen rows in place
+                    // (FilteredList.sort works on originalList), but unlike
+                    // _reconcile/onLoaded it doesn't rebuild the pinned index, so
+                    // rowWrapper's stripe/boundary would read stale positions.
+                    // toggleSortColumn fires this before its own notifyListeners,
+                    // so re-indexing here lands in the very next repaint.
+                    _indexPinnedRows();
+                  },
+                ),
               ),
             );
           },

--- a/lib/src/gui/settings.dart
+++ b/lib/src/gui/settings.dart
@@ -65,6 +65,11 @@ class DropdownButtonWidget<T> extends ConsumerWidget {
   final String title;
   final String description;
   final String Function(T) name;
+
+  /// Optional per-item tooltip shown on hover over each menu entry. Null (the
+  /// default) leaves the entries untooltipped.
+  final String Function(T)? tooltip;
+
   final ExclusiveItemsNotifierProvider<T> provider;
 
   const DropdownButtonWidget({
@@ -72,6 +77,7 @@ class DropdownButtonWidget<T> extends ConsumerWidget {
     required this.title,
     required this.description,
     required this.name,
+    this.tooltip,
     required this.provider,
   });
 
@@ -88,7 +94,16 @@ class DropdownButtonWidget<T> extends ConsumerWidget {
         tooltip: '',
         initialValue: current,
         itemBuilder: (BuildContext context) => <PopupMenuEntry<T>>[
-          for (final item in values) PopupMenuItem<T>(value: item, child: Text(name(item))),
+          for (final item in values)
+            PopupMenuItem<T>(
+              value: item,
+              child: tooltip == null
+                  ? Text(name(item))
+                  : Tooltip(
+                      message: tooltip!(item),
+                      child: SizedBox(width: double.infinity, child: Text(name(item))),
+                    ),
+            ),
         ],
         onSelected: (T item) => ref.read(provider.notifier).setValue(item),
         child: Container(

--- a/lib/src/gui/settings.dart
+++ b/lib/src/gui/settings.dart
@@ -127,6 +127,58 @@ class SwitchWidget extends ConsumerWidget {
   }
 }
 
+/// A compact −/value/+ stepper bound to an [IntNotifierProvider], clamped to
+/// [min]..[max] (the buttons disable at the bounds). Mirrors [SwitchWidget]'s
+/// shape for use in the same settings groups.
+class StepperWidget extends ConsumerWidget {
+  final Widget title;
+  final Widget description;
+  final IntNotifierProvider provider;
+  final int min;
+  final int max;
+
+  const StepperWidget({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.provider,
+    required this.min,
+    required this.max,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final value = ref.watch(provider);
+    final notifier = ref.read(provider.notifier);
+    return ListTile(
+      title: title,
+      subtitle: description,
+      trailing: Align(
+        widthFactor: 1,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Symbols.remove_rounded),
+              visualDensity: VisualDensity.compact,
+              onPressed: value <= min ? null : notifier.decrement,
+            ),
+            SizedBox(
+              width: 24,
+              child: Text("$value", textAlign: TextAlign.center, style: Theme.of(context).textTheme.titleMedium),
+            ),
+            IconButton(
+              icon: const Icon(Symbols.add_rounded),
+              visualDensity: VisualDensity.compact,
+              onPressed: value >= max ? null : notifier.increment,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _BrightnessWidget extends ConsumerWidget {
   static final _iconMap = <ThemeMode, Widget>{
     ThemeMode.light: Tooltip(

--- a/lib/src/preference/hive_adapter.dart
+++ b/lib/src/preference/hive_adapter.dart
@@ -2,6 +2,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_ce/hive.dart';
 
+import '/src/chara_detail/spec/base.dart';
 import '/src/chara_detail/storage.dart';
 import '/src/core/app_logger.dart';
 import '/src/core/clipboard_alt.dart';
@@ -42,4 +43,5 @@ void registerHiveAdapters() {
   Hive.registerAdapter(JsonAdapter<ThemeMode>(2));
   Hive.registerAdapter(JsonAdapter<CharaDetailRecordImageMode>(3));
   Hive.registerAdapter(JsonAdapter<ClipboardPasteImageMode>(4));
+  Hive.registerAdapter(JsonAdapter<RowHeightMode>(5));
 }

--- a/lib/src/preference/notifier.dart
+++ b/lib/src/preference/notifier.dart
@@ -75,3 +75,33 @@ class BooleanNotifier extends Notifier<bool> {
     set(!state);
   }
 }
+
+typedef IntNotifierProvider = NotifierProvider<IntNotifier, int>;
+
+class IntNotifier extends Notifier<int> {
+  final int _defaultValue;
+  final int min;
+  final int max;
+  final String? _entryKey;
+
+  StorageEntry<int>? _entry;
+
+  IntNotifier({required this._defaultValue, this.min = 0, this.max = 1 << 31, this._entryKey});
+
+  @override
+  int build() {
+    final key = _entryKey;
+    _entry = key == null ? null : StorageEntry<int>(box: ref.watch(storageBoxProvider), key: key);
+    return (_entry?.pull() ?? _defaultValue).clamp(min, max);
+  }
+
+  void set(int value) {
+    final clamped = value.clamp(min, max);
+    state = clamped;
+    _entry?.push(clamped);
+  }
+
+  void increment() => set(state + 1);
+
+  void decrement() => set(state - 1);
+}

--- a/lib/src/preference/settings_state.dart
+++ b/lib/src/preference/settings_state.dart
@@ -12,6 +12,7 @@ enum SettingsEntryKey {
   soundEffect,
   allowPostUserData,
   forceResizeMode,
+  autoRowHeight,
   sentryReportLastMonth,
   sentryReportTotalCount,
 }

--- a/lib/src/preference/settings_state.dart
+++ b/lib/src/preference/settings_state.dart
@@ -13,6 +13,8 @@ enum SettingsEntryKey {
   allowPostUserData,
   forceResizeMode,
   autoRowHeight,
+  rowHeightMode,
+  minRowLines,
   sentryReportLastMonth,
   sentryReportTotalCount,
 }

--- a/test/cell_text_test.dart
+++ b/test/cell_text_test.dart
@@ -1,0 +1,39 @@
+// Regression test for [CellText], the table cell text wrapper behind the
+// auto-row-height toggle.
+// Run: .fvm/flutter_sdk/bin/flutter test test/cell_text_test.dart
+//
+// When auto row height is off the cell must clamp to two lines and ellipsize
+// (so a narrowed column truncates cleanly instead of clipping its third line);
+// when on it must drop the line cap so the row can grow to show every line.
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/chara_detail/spec/base.dart';
+import 'package:umacapture/src/preference/notifier.dart';
+
+Future<Text> _pumpCellText(WidgetTester tester, {required bool expand}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        // entryKey null keeps the notifier off Hive, so the test needs no storage.
+        charaDetailAutoRowHeightProvider.overrideWith(() => BooleanNotifier(defaultValue: expand, entryKey: null)),
+      ],
+      child: const MaterialApp(home: Scaffold(body: CellText('long cell text'))),
+    ),
+  );
+  return tester.widget<Text>(find.text('long cell text'));
+}
+
+void main() {
+  testWidgets('clamps to two lines with ellipsis when auto height is off', (tester) async {
+    final text = await _pumpCellText(tester, expand: false);
+    expect(text.maxLines, 2);
+    expect(text.overflow, TextOverflow.ellipsis);
+  });
+
+  testWidgets('drops the line cap when auto height is on', (tester) async {
+    final text = await _pumpCellText(tester, expand: true);
+    expect(text.maxLines, isNull);
+    expect(text.overflow, isNull);
+  });
+}

--- a/test/cell_text_test.dart
+++ b/test/cell_text_test.dart
@@ -1,22 +1,27 @@
 // Regression test for [CellText], the table cell text wrapper behind the
-// auto-row-height toggle.
+// row-height mode setting.
 // Run: .fvm/flutter_sdk/bin/flutter test test/cell_text_test.dart
 //
-// When auto row height is off the cell must clamp to two lines and ellipsize
-// (so a narrowed column truncates cleanly instead of clipping its third line);
-// when on it must drop the line cap so the row can grow to show every line.
+// In wrap mode the cell must clamp to the minimum line count and ellipsize (so a
+// narrowed column truncates cleanly instead of clipping its overflow line); in
+// the auto modes it must drop the line cap so the row can grow to show every line.
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:umacapture/src/chara_detail/spec/base.dart';
 import 'package:umacapture/src/preference/notifier.dart';
 
-Future<Text> _pumpCellText(WidgetTester tester, {required bool expand}) async {
+Future<Text> _pumpCellText(WidgetTester tester, {required RowHeightMode mode, int minLines = 2}) async {
   await tester.pumpWidget(
     ProviderScope(
+      // entryKey null keeps the notifiers off Hive, so the test needs no storage.
       overrides: [
-        // entryKey null keeps the notifier off Hive, so the test needs no storage.
-        charaDetailAutoRowHeightProvider.overrideWith(() => BooleanNotifier(defaultValue: expand, entryKey: null)),
+        charaDetailRowHeightModeProvider.overrideWith(
+          () => ExclusiveItemsNotifier<RowHeightMode>(values: RowHeightMode.values, defaultValue: mode, entryKey: null),
+        ),
+        charaDetailMinRowLinesProvider.overrideWith(
+          () => IntNotifier(defaultValue: minLines, min: 1, max: 6, entryKey: null),
+        ),
       ],
       child: const MaterialApp(home: Scaffold(body: CellText('long cell text'))),
     ),
@@ -25,14 +30,20 @@ Future<Text> _pumpCellText(WidgetTester tester, {required bool expand}) async {
 }
 
 void main() {
-  testWidgets('clamps to two lines with ellipsis when auto height is off', (tester) async {
-    final text = await _pumpCellText(tester, expand: false);
-    expect(text.maxLines, 2);
+  testWidgets('clamps to the minimum lines with ellipsis in wrap mode', (tester) async {
+    final text = await _pumpCellText(tester, mode: RowHeightMode.wrap, minLines: 3);
+    expect(text.maxLines, 3);
     expect(text.overflow, TextOverflow.ellipsis);
   });
 
-  testWidgets('drops the line cap when auto height is on', (tester) async {
-    final text = await _pumpCellText(tester, expand: true);
+  testWidgets('drops the line cap in auto-per-row mode', (tester) async {
+    final text = await _pumpCellText(tester, mode: RowHeightMode.autoPerRow);
+    expect(text.maxLines, isNull);
+    expect(text.overflow, isNull);
+  });
+
+  testWidgets('drops the line cap in auto-uniform mode', (tester) async {
+    final text = await _pumpCellText(tester, mode: RowHeightMode.autoUniform);
     expect(text.maxLines, isNull);
     expect(text.overflow, isNull);
   });

--- a/test/column_spec_width_test.dart
+++ b/test/column_spec_width_test.dart
@@ -1,0 +1,103 @@
+// Regression test for the user-pinned column `width` added to every column spec.
+// Run: .fvm/flutter_sdk/bin/flutter test test/column_spec_width_test.dart
+//
+// The width is nullable (null == auto-fit to content, a value == user-pinned) and
+// every spec class is annotated `ignoreNull: true`, so a null width is omitted
+// from the encoded map. That is the backward-compat invariant: a pre-existing spec
+// saved before the field existed (hence lacking the key) decodes as auto width and
+// must never be flagged broken by isSpecMapIncomplete. A pinned width must instead
+// round-trip losslessly, and withWidth(null) must clear it back to absent.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/chara_detail/spec/base.dart';
+import 'package:umacapture/src/chara_detail/spec/chara_rank.dart';
+import 'package:umacapture/src/chara_detail/spec/logic.dart';
+import 'package:umacapture/src/chara_detail/spec/memo.dart';
+import 'package:umacapture/src/chara_detail/spec/parser.dart';
+import 'package:umacapture/src/chara_detail/spec/ranged_integer.dart';
+import 'package:umacapture/src/chara_detail/spec/rating.dart';
+import 'package:umacapture/src/chara_detail/spec/script.dart';
+import 'package:umacapture/src/core/mapper_init.dart';
+
+void main() {
+  setUpAll(initializeMappers);
+
+  // One leaf spec per construction shape, a container (logic), and an inherited
+  // subclass (chara rank extends ranged label), so the field is exercised across
+  // the spec hierarchy rather than a single representative.
+  final specs = <String, ColumnSpec Function({double? width})>{
+    'RatingColumnSpec': ({width}) => RatingColumnSpec(
+      id: 'rating-id',
+      title: 'レート',
+      parser: EvaluationValueParser(),
+      predicate: IsInRangeRatingPredicate(),
+      storageKey: 'rating-key',
+      width: width,
+    ),
+    'MemoColumnSpec': ({width}) => MemoColumnSpec(
+      id: 'memo-id',
+      title: 'メモ',
+      parser: EvaluationValueParser(),
+      predicate: RegExpPredicate(),
+      storageKey: 'memo-key',
+      width: width,
+    ),
+    'ScriptColumnSpec': ({width}) => ScriptColumnSpec(
+      id: 'script-id',
+      title: 'スクリプト',
+      source: 'bool filter(CharaRecord r) => true;\ndynamic display(CharaRecord r) => 0;',
+      width: width,
+    ),
+    'LogicColumnSpec': ({width}) => LogicColumnSpec(id: 'logic-id', title: '論理', logic: LogicMode.and, width: width),
+    'CharaRankColumnSpec': ({width}) => CharaRankColumnSpec(
+      id: 'chara-rank-id',
+      title: 'キャラランク',
+      parser: EvaluationValueParser(),
+      labelKey: 'chara-rank-key',
+      predicate: IsInRangeIntegerPredicate(),
+      width: width,
+    ),
+  };
+
+  for (final entry in specs.entries) {
+    final type = entry.key;
+    final make = entry.value;
+
+    test('$type without a width omits the key and is never flagged broken', () {
+      final spec = make();
+      expect(spec.width, isNull);
+      final map = spec.toMap();
+      // ignoreNull drops the null key, so legacy data (which never had it) and a
+      // freshly-encoded auto-width spec produce the same shape.
+      expect(map.containsKey('width'), isFalse);
+
+      final decoded = ColumnSpecMapper.fromMap(map);
+      // A pre-existing spec lacking `width` must decode and must not be reported
+      // as broken (which would prompt the user to review a healthy column).
+      expect(decoded.width, isNull);
+      expect(isSpecMapIncomplete(map, decoded.toMap()), isFalse);
+    });
+
+    test('$type round-trips a pinned width', () {
+      final spec = make(width: 287.5);
+      final map = spec.toMap();
+      expect(map['width'], 287.5);
+
+      final decoded = ColumnSpecMapper.fromMap(map);
+      expect(decoded.width, 287.5);
+      expect(isSpecMapIncomplete(map, decoded.toMap()), isFalse);
+    });
+
+    test('$type pins a width via withWidth', () {
+      final pinned = make().withWidth(240.0);
+      expect(pinned.width, 240.0);
+      expect(pinned.toMap()['width'], 240.0);
+    });
+
+    test('$type can clear its width back to auto via withWidth(null)', () {
+      final cleared = make(width: 300.0).withWidth(null);
+      expect(cleared.width, isNull);
+      // Cleared width must round-trip as absent, not as a sentinel value.
+      expect(cleared.toMap().containsKey('width'), isFalse);
+    });
+  }
+}

--- a/test/column_spec_width_test.dart
+++ b/test/column_spec_width_test.dart
@@ -99,5 +99,23 @@ void main() {
       // Cleared width must round-trip as absent, not as a sentinel value.
       expect(cleared.toMap().containsKey('width'), isFalse);
     });
+
+    // clampedWidth guards the value applied to the grid column: trina enforces
+    // minColumnWidth (80) only on interactive resize, not at construction, so a
+    // corrupted persisted value must be sanitized before it reaches the layout.
+    test('$type clampedWidth sanitizes corrupted persisted widths', () {
+      // Unpinned stays null (the column keeps auto-fitting).
+      expect(make().clampedWidth, isNull);
+      // A healthy pinned value passes through untouched.
+      expect(make(width: 287.5).clampedWidth, 287.5);
+      // Too small / negative snaps up to trina's minimum column width.
+      expect(make(width: -50.0).clampedWidth, 80.0);
+      expect(make(width: 0.0).clampedWidth, 80.0);
+      // Absurdly large snaps down to the pinned-width ceiling.
+      expect(make(width: 99999.0).clampedWidth, 2000.0);
+      // Non-finite values fall back to the default column width.
+      expect(make(width: double.nan).clampedWidth, 200.0);
+      expect(make(width: double.infinity).clampedWidth, 200.0);
+    });
   }
 }

--- a/test/refresh_column_renderers_test.dart
+++ b/test/refresh_column_renderers_test.dart
@@ -1,0 +1,68 @@
+// Regression test for [TrinaGridStateManagerExtension.refreshColumnRenderers],
+// the non-structural reconcile path used when a column's spec changes without
+// changing the column set (e.g. editing a skill column's display count).
+// Run: .fvm/flutter_sdk/bin/flutter test test/refresh_column_renderers_test.dart
+//
+// The bug: refreshColumnRenderers used to copy only the renderer and title, so
+// the live column kept a stale [ColumnSpec] in its user data. A later resize or
+// width reset reads that spec back off the live column and persists it, which
+// reverted the user's edit (the skill display count snapped back to its default).
+// The fix re-seats the rebuilt spec onto the live column; the checkbox column,
+// which carries no spec, must be left untouched.
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+import 'package:umacapture/src/chara_detail/spec/base.dart';
+import 'package:umacapture/src/chara_detail/spec/loader.dart';
+import 'package:umacapture/src/chara_detail/spec/parser.dart';
+import 'package:umacapture/src/chara_detail/spec/skill.dart';
+
+SkillColumnSpec _skillSpec({required int notationMax}) {
+  return SkillColumnSpec(
+    id: 'skill',
+    title: 'Skill',
+    parser: SkillParser(),
+    predicate: AggregateSkillPredicate(notation: SkillNotation(max: notationMax)),
+  );
+}
+
+TrinaColumn _column(String field, {ColumnSpec? spec}) {
+  final column = TrinaColumn(title: field, field: field, type: TrinaColumnType.text());
+  if (spec != null) {
+    column.setUserData(spec);
+  }
+  return column;
+}
+
+TrinaGridStateManager _stateManager(List<TrinaColumn> columns) {
+  return TrinaGridStateManager(
+    columns: columns,
+    rows: [],
+    gridFocusNode: FocusNode(),
+    scroll: TrinaGridScrollController(),
+  );
+}
+
+void main() {
+  test('re-seats the rebuilt spec onto the matching live column', () {
+    final liveSkill = _column('skill', spec: _skillSpec(notationMax: 3));
+    final manager = _stateManager([liveSkill]);
+
+    final nextSkill = _column('skill', spec: _skillSpec(notationMax: 5));
+    manager.refreshColumnRenderers([nextSkill]);
+
+    final spec = liveSkill.getUserData<ColumnSpec>();
+    expect(spec, isA<SkillColumnSpec>());
+    expect((spec! as SkillColumnSpec).predicate.notation.max, 5);
+  });
+
+  test('leaves a spec-less column (the checkbox column) untouched', () {
+    final liveCheck = _column(checkColumnField);
+    final manager = _stateManager([liveCheck]);
+
+    // The rebuilt checkbox column also carries no spec, so nothing is re-seated.
+    manager.refreshColumnRenderers([_column(checkColumnField)]);
+
+    expect(liveCheck.getUserData<ColumnSpec>(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

Adds user-controllable layout to the chara detail table: per-column resizable widths (pinned, overriding auto-fit), configurable row-height modes, and a regrouped table settings dialog. Also fixes several issues found along the way, including a spec-sync bug where a column edit could be reverted by a later resize.

## What's included

- **Resizable column widths** — drag a column edge to pin its width; a pinned width persists on the spec and survives data/layout changes, overriding auto-fit. Header context menu offers a "reset width" that returns the column to content-driven auto width.
- **Row-height modes** — wrap (clamp to a minimum line count with ellipsis), auto-per-row, and auto-uniform, plus a configurable minimum row line count. Wrapped-text row heights are measured to fit clamped/narrowed columns exactly.
- **Table settings dialog** — row-height mode and minimum lines moved into a regrouped settings dialog, with per-item tooltips on the mode dropdown.
- **Column header menu** — adds a sort submenu (ascending / descending / reset) alongside the width reset.
- **Spec width persistence** — every editable column spec gains an optional `width` field (null = auto-fit), with serialization, clamping, and round-trip handling. Legacy specs decode to auto-fit.

## Bug fixes

- **Display-count edit reverted by resize** — editing a column spec without changing the column set (e.g. a skill column's display count) took the non-structural reconcile path, where `refreshColumnRenderers` copied only the renderer and title and left a stale `ColumnSpec` on the live column. A later resize or width reset read that stale spec back and persisted it, snapping the edit back to its default. The rebuilt spec is now re-seated onto the live column (the spec-less checkbox column is guarded), keeping the live user data in sync with the loader.
- Grow rows for clamped columns and clamp pinned widths; resolve table review findings and a memo crash.

## Testing

- `.fvm/flutter_sdk/bin/flutter analyze` — clean on the touched files.
- `.fvm/flutter_sdk/bin/flutter test` — full suite green, including new tests:
  - `test/refresh_column_renderers_test.dart` — the spec re-seating fix (and that the checkbox column is left untouched).
  - `test/column_spec_width_test.dart` — width field null-omission, round-tripping, clamping.
  - `test/cell_text_test.dart` — row-height-mode line clamping behavior.
- Manual: verified in the running Windows app that changing a skill column's display count then resizing or resetting that column keeps the edited count, and that width pinning/reset and the row-height modes behave as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
