### PR TITLE
Per-column filter reset, addon copy-file-to-path action, side-preview image fix

### DIFF
--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -314,6 +314,10 @@
                         "label": "列を削除",
                         "tooltip": "この列をテーブルから削除"
                     },
+                    "reset_button": {
+                        "label": "列をリセット",
+                        "tooltip": "この列の絞り込み条件を既定に戻す"
+                    },
                     "close_button": {
                         "tooltip": "反映せずにキャンセル"
                     }

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -1190,6 +1190,8 @@
                 "copy_image_argument": "コピーする画像",
                 "copy_file_to_clipboard": "ファイルをクリップボードへコピー",
                 "copy_file_argument": "コピーするファイル",
+                "copy_file_to_path": "ファイルを指定パスにコピー",
+                "copy_file_to_path_destination": "コピー先パス（テンプレート）",
                 "play_sound": "サウンドを鳴らす",
                 "play_sound_argument": "サウンド種別",
                 "options": {

--- a/lib/src/addon/execution/builtin_actions.dart
+++ b/lib/src/addon/execution/builtin_actions.dart
@@ -11,9 +11,10 @@ import '/src/core/utils.dart';
 import '/src/gui/toast.dart';
 
 /// A function performing a built-in action. Receives the long-lived dispatcher
-/// [RefBase] (for reaching providers), the event [payload], and the optional
-/// user-configured [argument] (already declared by the descriptor).
-typedef BuiltinFn = Future<void> Function(RefBase ref, PayloadMap payload, String? argument);
+/// [RefBase] (for reaching providers), the event [payload], the optional
+/// user-configured [argument], and the optional [secondaryArgument] (both already
+/// declared by the descriptor; actions that take fewer simply ignore the rest).
+typedef BuiltinFn = Future<void> Function(RefBase ref, PayloadMap payload, String? argument, String? secondaryArgument);
 
 /// A selectable value for a built-in action argument, shown as a dropdown option
 /// in the edit dialog instead of a free-text field.
@@ -66,6 +67,26 @@ class BuiltinActionDescriptor {
   /// Default argument template for a freshly configured action.
   final String defaultArgument;
 
+  /// Whether this action takes a second free-form argument (e.g. a destination
+  /// path), shown as an additional text field below the first. Used by actions
+  /// that need two inputs at once, where the first is an options dropdown.
+  final bool usesSecondArgument;
+
+  /// Translation key for the second argument field's label (only used when
+  /// [usesSecondArgument]).
+  final String? secondaryArgumentLabelKey;
+
+  /// Translation key for the second argument field's helper text. Defaults to the
+  /// shared "placeholders are substituted" hint.
+  final String? secondaryArgumentHelperKey;
+
+  /// Whether the second argument accepts payload `{placeholders}` (and so shows
+  /// the placeholder dropdown beneath its field).
+  final bool secondaryArgumentUsesPlaceholders;
+
+  /// Default template for the second argument of a freshly configured action.
+  final String defaultSecondArgument;
+
   final BuiltinFn run;
 
   const BuiltinActionDescriptor({
@@ -79,6 +100,11 @@ class BuiltinActionDescriptor {
     this.argumentUsesPlaceholders = true,
     this.argumentOptions,
     this.defaultArgument = '',
+    this.usesSecondArgument = false,
+    this.secondaryArgumentLabelKey,
+    this.secondaryArgumentHelperKey,
+    this.secondaryArgumentUsesPlaceholders = true,
+    this.defaultSecondArgument = '',
   });
 }
 
@@ -114,7 +140,7 @@ final builtinActionRegistry = <String, BuiltinActionDescriptor>{
     usesArgument: true,
     argumentLabelKey: "$_trBuiltin.show_toast_argument",
     defaultArgument: "{event}",
-    run: (ref, payload, argument) async {
+    run: (ref, payload, argument, secondaryArgument) async {
       final text = substitutePayload(argument ?? "{event}", payload);
       Toaster.show(ToastData.info(description: text));
     },
@@ -125,7 +151,7 @@ final builtinActionRegistry = <String, BuiltinActionDescriptor>{
     usesArgument: true,
     argumentLabelKey: "$_trBuiltin.copy_payload_argument",
     defaultArgument: "{record_id}",
-    run: (ref, payload, argument) async {
+    run: (ref, payload, argument, secondaryArgument) async {
       final text = substitutePayload(argument ?? "{record_id}", payload);
       await Clipboard.setData(ClipboardData(text: text));
     },
@@ -139,7 +165,7 @@ final builtinActionRegistry = <String, BuiltinActionDescriptor>{
     argumentUsesPlaceholders: false,
     argumentOptions: _imageKindOptions("image"),
     defaultArgument: "trainee",
-    run: (ref, payload, argument) async {
+    run: (ref, payload, argument, secondaryArgument) async {
       final record = _requireRecord(ref, payload);
       // silent: the execution-history entry already reports the outcome, so an
       // automated/chained run shouldn't also pop a clipboard toast.
@@ -163,15 +189,40 @@ final builtinActionRegistry = <String, BuiltinActionDescriptor>{
       BuiltinArgumentOption("record_json", "$_trBuiltin.options.file_record"),
     ],
     defaultArgument: "trainee",
-    run: (ref, payload, argument) async {
+    run: (ref, payload, argument, secondaryArgument) async {
       final record = _requireRecord(ref, payload);
-      final storage = ref.read(charaDetailRecordStorageLoaderProvider.notifier);
-      final kind = (argument ?? "trainee").trim();
-      final path = kind == "record_json"
-          ? storage.recordPathOf(record).filePath(recordJsonName)
-          : _recordImagePath(ref, record, kind);
+      final path = _recordFilePath(ref, record, (argument ?? "trainee").trim());
       final ok = await ClipboardAlt.pasteFile(ref, path, silent: true);
       if (!ok) throw StateError("Failed to copy file to clipboard.");
+    },
+  ),
+  "copy_file_to_path": BuiltinActionDescriptor(
+    key: "copy_file_to_path",
+    labelKey: "$_trBuiltin.copy_file_to_path",
+    usesArgument: true,
+    requiresRecord: true,
+    argumentLabelKey: "$_trBuiltin.copy_file_argument",
+    argumentUsesPlaceholders: false,
+    argumentOptions: [
+      ..._imageKindOptions("file"),
+      BuiltinArgumentOption("record_json", "$_trBuiltin.options.file_record"),
+    ],
+    defaultArgument: "trainee",
+    usesSecondArgument: true,
+    secondaryArgumentLabelKey: "$_trBuiltin.copy_file_to_path_destination",
+    defaultSecondArgument: "",
+    run: (ref, payload, argument, secondaryArgument) async {
+      final record = _requireRecord(ref, payload);
+      final source = _recordFilePath(ref, record, (argument ?? "trainee").trim());
+      final destination = substitutePayload(secondaryArgument ?? "", payload).trim();
+      if (destination.isEmpty) {
+        throw StateError("No destination path configured for the copy-to-path action.");
+      }
+      final target = FilePath(destination);
+      // Create the destination's parent folders so a template pointing into a new
+      // subfolder works on the first run, then overwrite any existing file.
+      await target.parent.create(recursive: true);
+      await source.toFile().copy(target.path);
     },
   ),
   "play_sound": BuiltinActionDescriptor(
@@ -186,7 +237,7 @@ final builtinActionRegistry = <String, BuiltinActionDescriptor>{
       BuiltinArgumentOption("error", "$_trBuiltin.options.sound_error"),
     ],
     defaultArgument: "attention_normal",
-    run: (ref, payload, argument) async {
+    run: (ref, payload, argument, secondaryArgument) async {
       final type = switch ((argument ?? "attention_normal").trim()) {
         "attention_weak" => SoundType.attentionWeak,
         "error" => SoundType.error,
@@ -221,4 +272,15 @@ FilePath _recordImagePath(RefBase ref, CharaDetailRecord record, String kind) {
   final storage = ref.read(charaDetailRecordStorageLoaderProvider.notifier);
   final resolver = _recordImageKinds[kind] ?? _recordImageKinds["trainee"]!;
   return resolver(storage, record);
+}
+
+/// Resolves the file referenced by a `copy_file_*` action's [kind] keyword:
+/// `record_json` maps to the record's json file, every other keyword to an image
+/// via [_recordImagePath]. Shared by the clipboard and the copy-to-path actions.
+FilePath _recordFilePath(RefBase ref, CharaDetailRecord record, String kind) {
+  if (kind == "record_json") {
+    final storage = ref.read(charaDetailRecordStorageLoaderProvider.notifier);
+    return storage.recordPathOf(record).filePath(recordJsonName);
+  }
+  return _recordImagePath(ref, record, kind);
 }

--- a/lib/src/addon/execution/builtin_runner.dart
+++ b/lib/src/addon/execution/builtin_runner.dart
@@ -37,7 +37,9 @@ class BuiltinRunner implements ActionRunner {
         return;
       }
       try {
-        await descriptor.run(ref, payload, action.argument).timeout(ref.read(builtinTimeoutProvider));
+        await descriptor
+            .run(ref, payload, action.argument, action.secondaryArgument)
+            .timeout(ref.read(builtinTimeoutProvider));
         exec.finish((elapsed) => ExecutionResult(status: ExecutionStatus.success, duration: elapsed));
       } on TimeoutException {
         logger.w("Builtin action '${action.actionKey}' timed out.");

--- a/lib/src/addon/model/addon_action.dart
+++ b/lib/src/addon/model/addon_action.dart
@@ -123,8 +123,20 @@ class BuiltinAction extends AddonAction with BuiltinActionMappable {
   /// from the event payload. Null for actions that take no argument.
   final String? argument;
 
-  const BuiltinAction({required this.actionKey, this.argument});
+  /// Optional second argument for actions that need two inputs (e.g. the
+  /// copy-to-path action: [argument] selects which file, this carries the
+  /// destination path template). Placeholders are substituted the same way. Null
+  /// for actions that take at most one argument.
+  final String? secondaryArgument;
+
+  const BuiltinAction({required this.actionKey, this.argument, this.secondaryArgument});
 
   @override
-  String describe() => argument == null || argument!.isEmpty ? actionKey : '$actionKey: $argument';
+  String describe() {
+    if (argument == null || argument!.isEmpty) {
+      return actionKey;
+    }
+    final base = '$actionKey: $argument';
+    return secondaryArgument == null || secondaryArgument!.isEmpty ? base : '$base → $secondaryArgument';
+  }
 }

--- a/lib/src/addon/model/addon_action.mapper.dart
+++ b/lib/src/addon/model/addon_action.mapper.dart
@@ -277,11 +277,18 @@ class BuiltinActionMapper extends SubClassMapperBase<BuiltinAction> {
     _$argument,
     opt: true,
   );
+  static String? _$secondaryArgument(BuiltinAction v) => v.secondaryArgument;
+  static const Field<BuiltinAction, String> _f$secondaryArgument = Field(
+    'secondaryArgument',
+    _$secondaryArgument,
+    opt: true,
+  );
 
   @override
   final MappableFields<BuiltinAction> fields = const {
     #actionKey: _f$actionKey,
     #argument: _f$argument,
+    #secondaryArgument: _f$secondaryArgument,
   };
 
   @override
@@ -296,6 +303,7 @@ class BuiltinActionMapper extends SubClassMapperBase<BuiltinAction> {
     return BuiltinAction(
       actionKey: data.dec(_f$actionKey),
       argument: data.dec(_f$argument),
+      secondaryArgument: data.dec(_f$secondaryArgument),
     );
   }
 

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -151,6 +151,13 @@ abstract class ColumnBuilder {
 
   ColumnBuilderType get type => ColumnBuilderType.normal;
 
+  /// Stable identifier for a builder that produces a non-default filter, stamped
+  /// onto the spec it builds so the column can later regenerate its default filter
+  /// by re-running this builder (see `builderSpecOf`). Null for plain builders
+  /// whose default is "accept every row"; filter-bearing builders override it with
+  /// a stored value.
+  String? get builderId => null;
+
   /// Optional explanatory tooltip shown on the builder chip in the add-column
   /// dialog. Null means no tooltip (the default for data columns).
   String? get tooltip => null;
@@ -359,6 +366,34 @@ abstract class ColumnSpec<T> with ColumnSpecMappable<T> {
   /// undecodable placeholder, which is never editable, overrides this to a no-op.
   ColumnSpec withDescription(String? description) =>
       throw UnsupportedError('Concrete specs must override withDescription');
+
+  /// Whether this column carries a resettable row filter (predicate). Filtering
+  /// leaf columns override this to true so the column dialog offers a "reset
+  /// filter" button; containers (logic) and non-filtering columns leave it false
+  /// and the button stays hidden. Pairs with [withFilterReset].
+  bool get hasFilter => false;
+
+  /// Identifier of the column builder (the "add column" template) this column was
+  /// created from, or null when it carries no such origin (a plain column, or one
+  /// added before this field existed). Used by the dialog to regenerate the
+  /// column's default filter on reset (see `builderSpecOf` in builder.dart).
+  /// Builder-default-capable leaf specs override this with a stored field;
+  /// everything else has none.
+  String? get builderId => null;
+
+  /// Returns a copy of this spec with its filter (predicate) reset to its default,
+  /// preserving the display settings (title, width, hidden, description).
+  ///
+  /// [defaultSpec] is the freshly rebuilt spec for this column's [builderId]
+  /// (resolved by the caller via builder.dart's `builderSpecOf`), or null when the
+  /// column has no builder origin — in which case the default is "accept every
+  /// row". Filtering leaf columns override this and adopt `defaultSpec`'s predicate
+  /// when it is the same spec type, else fall back to accept-all. Unlike
+  /// [withHidden] the base default is a no-op (not a throw) so containers, the
+  /// script column, and the undecodable placeholder — none of which expose a
+  /// resettable filter — are safe to call unconditionally. The dialog only surfaces
+  /// the reset action when [hasFilter].
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) => this;
 
   /// Child specs nested under this column. Only container columns (logic columns)
   /// have children; leaf columns return an empty list. Used by the tree-aware

--- a/lib/src/chara_detail/spec/builder.dart
+++ b/lib/src/chara_detail/spec/builder.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -17,6 +18,7 @@ import '/src/chara_detail/spec/rating.dart';
 import '/src/chara_detail/spec/script.dart';
 import '/src/chara_detail/spec/simple_label.dart';
 import '/src/chara_detail/spec/skill.dart';
+import '/src/core/utils.dart';
 
 // ignore: constant_identifier_names
 const tr_columns = "pages.chara_detail.columns";
@@ -49,6 +51,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       category: ColumnCategory.trainee,
       parser: EvaluationValueParser(),
       max: 5,
+      builderId: "chara_rank_less_than_a",
     ),
     RangedIntegerColumnBuilder(
       title: "$tr_columns.status.speed.title".tr(),
@@ -141,6 +144,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       labelKey: LabelKeys.aptitude,
       parser: ShortRangeAptitudeParser(),
       min: 7,
+      builderId: "aptitude_short_range",
     ),
     RangedLabelColumnBuilder(
       title: "$tr_columns.aptitude.shortcuts.mile_range.title".tr(),
@@ -148,6 +152,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       labelKey: LabelKeys.aptitude,
       parser: MileRangeAptitudeParser(),
       min: 7,
+      builderId: "aptitude_mile_range",
     ),
     RangedLabelColumnBuilder(
       title: "$tr_columns.aptitude.shortcuts.middle_range.title".tr(),
@@ -155,6 +160,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       labelKey: LabelKeys.aptitude,
       parser: MiddleRangeAptitudeParser(),
       min: 7,
+      builderId: "aptitude_middle_range",
     ),
     RangedLabelColumnBuilder(
       title: "$tr_columns.aptitude.shortcuts.long_range.title".tr(),
@@ -162,6 +168,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       labelKey: LabelKeys.aptitude,
       parser: LongRangeAptitudeParser(),
       min: 7,
+      builderId: "aptitude_long_range",
     ),
     SkillColumnBuilder(title: "$tr_columns.skill.title".tr(), category: ColumnCategory.skill, parser: SkillParser()),
     FilteredSkillColumnBuilder(
@@ -171,6 +178,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       isFilterColumn: true,
       initialTags: {"skill_status_up"},
       initialIds: skillInfo.where((e) => e.tags.contains("skill_status_up")).map((e) => e.sid).toSet(),
+      builderId: "skill_status_up",
     ),
     FilteredSkillColumnBuilder(
       title: "$tr_columns.skill.shortcuts.consolidation.title".tr(),
@@ -178,6 +186,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       parser: SkillParser(),
       isFilterColumn: true,
       initialIds: {179},
+      builderId: "skill_consolidation",
     ),
     FactorColumnBuilder(
       title: "$tr_columns.factor.title".tr(),
@@ -192,6 +201,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       initialFactorTags: {"factor_status"},
       initialIds: factorInfo.where((e) => e.tags.contains("factor_status")).map((e) => e.sid).toSet(),
       initialStar: 1,
+      builderId: "factor_status",
     ),
     FilteredFactorColumnBuilder(
       title: "$tr_columns.factor.shortcuts.aptitude.title".tr(),
@@ -201,6 +211,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       initialFactorTags: {"factor_aptitude"},
       initialIds: factorInfo.where((e) => e.tags.contains("factor_aptitude")).map((e) => e.sid).toSet(),
       initialStar: 1,
+      builderId: "factor_aptitude",
     ),
     FilteredFactorColumnBuilder(
       title: "$tr_columns.factor.shortcuts.scenario.title".tr(),
@@ -210,6 +221,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       initialFactorTags: {"factor_scenario"},
       initialIds: factorInfo.where((e) => e.tags.contains("factor_scenario")).map((e) => e.sid).toSet(),
       initialStar: 1,
+      builderId: "factor_scenario",
     ),
     FilteredFactorColumnBuilder(
       title: "$tr_columns.factor.shortcuts.short_range.title".tr(),
@@ -219,6 +231,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       initialFactorTags: {"factor_aptitude"},
       initialIds: {66},
       initialStar: 1,
+      builderId: "factor_short_range",
     ),
     FilteredFactorColumnBuilder(
       title: "$tr_columns.factor.shortcuts.mile_range.title".tr(),
@@ -228,6 +241,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       initialFactorTags: {"factor_aptitude"},
       initialIds: {27},
       initialStar: 1,
+      builderId: "factor_mile_range",
     ),
     FilteredFactorColumnBuilder(
       title: "$tr_columns.factor.shortcuts.middle_range.title".tr(),
@@ -237,6 +251,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       initialFactorTags: {"factor_aptitude"},
       initialIds: {73},
       initialStar: 1,
+      builderId: "factor_middle_range",
     ),
     FilteredFactorColumnBuilder(
       title: "$tr_columns.factor.shortcuts.long_range.title".tr(),
@@ -246,6 +261,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       initialFactorTags: {"factor_aptitude"},
       initialIds: {142},
       initialStar: 1,
+      builderId: "factor_long_range",
     ),
     RangedIntegerColumnBuilder(
       title: "$tr_columns.fans.title".tr(),
@@ -301,6 +317,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
         labelKey: LabelKeys.raceStrategy,
         parser: RaceStrategyParser(),
         rejects: strategies.where((e) => e.$1 != strategy.$1).map((e) => e.$1).toSet(),
+        builderId: "race_strategy_${strategy.$1}",
       ),
     if (ratingStorages.isEmpty)
       RatingColumnBuilder(
@@ -365,3 +382,21 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
     LogicColumnBuilder(title: "$tr_columns.logic.xnor.title".tr(), logic: LogicMode.xnor),
   ];
 });
+
+/// Rebuilds the default spec that [spec] was created from, or null when it carries
+/// no [ColumnSpec.builderId] (a plain column, or one added before the field
+/// existed) or its builder no longer exists.
+///
+/// Used by the column dialog's "reset filter" action: re-running the matching
+/// builder reproduces the column's default predicate — including builders whose
+/// ids derive from current game data — without storing it on the spec. The caller
+/// adopts only the predicate (via [ColumnSpec.withFilterReset]); the fresh
+/// id/title are discarded.
+ColumnSpec? builderSpecOf(RefBase ref, ColumnSpec spec) {
+  final id = spec.builderId;
+  if (id == null) {
+    return null;
+  }
+  final builder = ref.read(columnBuilderProvider).firstWhereOrNull((b) => b.builderId == id);
+  return builder?.build(ref);
+}

--- a/lib/src/chara_detail/spec/chara_rank.dart
+++ b/lib/src/chara_detail/spec/chara_rank.dart
@@ -26,6 +26,7 @@ class CharaRankColumnSpec extends RangedLabelColumnSpec with CharaRankColumnSpec
     super.hidden,
     super.description,
     super.width,
+    super.builderId,
   });
 
   @override
@@ -52,6 +53,7 @@ class CharaRankColumnSpec extends RangedLabelColumnSpec with CharaRankColumnSpec
     bool? hidden,
     Object? description = _unset,
     Object? width = _unset,
+    String? builderId,
   }) {
     return CharaRankColumnSpec(
       id: id ?? this.id,
@@ -62,6 +64,7 @@ class CharaRankColumnSpec extends RangedLabelColumnSpec with CharaRankColumnSpec
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
       width: identical(width, _unset) ? this.width : width as double?,
+      builderId: builderId ?? this.builderId,
     );
   }
 }
@@ -80,8 +83,17 @@ class CharaRankColumnBuilder extends ColumnBuilder {
   @override
   final ColumnBuilderType type;
 
-  CharaRankColumnBuilder({required this.title, required this.category, required this.parser, this.min, this.max})
-    : type = (min != null || max != null) ? ColumnBuilderType.filter : ColumnBuilderType.normal;
+  @override
+  final String? builderId;
+
+  CharaRankColumnBuilder({
+    required this.title,
+    required this.category,
+    required this.parser,
+    this.min,
+    this.max,
+    this.builderId,
+  }) : type = (min != null || max != null) ? ColumnBuilderType.filter : ColumnBuilderType.normal;
 
   @override
   CharaRankColumnSpec build(RefBase ref) {
@@ -90,6 +102,7 @@ class CharaRankColumnBuilder extends ColumnBuilder {
       title: title,
       parser: parser,
       labelKey: LabelKeys.charaRank,
+      builderId: builderId,
       predicate: IsInRangeIntegerPredicate(min: min, max: max),
     );
   }

--- a/lib/src/chara_detail/spec/chara_rank.mapper.dart
+++ b/lib/src/chara_detail/spec/chara_rank.mapper.dart
@@ -65,6 +65,12 @@ class CharaRankColumnSpecMapper
     _$width,
     opt: true,
   );
+  static String? _$builderId(CharaRankColumnSpec v) => v.builderId;
+  static const Field<CharaRankColumnSpec, String> _f$builderId = Field(
+    'builderId',
+    _$builderId,
+    opt: true,
+  );
   static ColumnSpecCellAction _$cellAction(CharaRankColumnSpec v) =>
       v.cellAction;
   static const Field<CharaRankColumnSpec, ColumnSpecCellAction> _f$cellAction =
@@ -80,6 +86,7 @@ class CharaRankColumnSpecMapper
     #hidden: _f$hidden,
     #description: _f$description,
     #width: _f$width,
+    #builderId: _f$builderId,
     #cellAction: _f$cellAction,
   };
   @override
@@ -103,6 +110,7 @@ class CharaRankColumnSpecMapper
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
       width: data.dec(_f$width),
+      builderId: data.dec(_f$builderId),
     );
   }
 

--- a/lib/src/chara_detail/spec/character.dart
+++ b/lib/src/chara_detail/spec/character.dart
@@ -99,6 +99,12 @@ class CharacterCardColumnSpec extends ColumnSpec<int> with CharacterCardColumnSp
   @override
   ColumnSpec withWidth(double? width) => copyWith(width: width);
 
+  @override
+  bool get hasFilter => true;
+
+  @override
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) => copyWith(predicate: CharacterCardPredicate.any());
+
   CharacterCardColumnSpec copyWith({
     String? id,
     String? title,

--- a/lib/src/chara_detail/spec/datetime.dart
+++ b/lib/src/chara_detail/spec/datetime.dart
@@ -105,6 +105,12 @@ class DateTimeColumnSpec extends ColumnSpec<DateTime> with DateTimeColumnSpecMap
   @override
   ColumnSpec withWidth(double? width) => copyWith(width: width);
 
+  @override
+  bool get hasFilter => true;
+
+  @override
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) => copyWith(predicate: IsInRangeDateTimePredicate());
+
   DateTimeColumnSpec copyWith({
     String? id,
     String? title,

--- a/lib/src/chara_detail/spec/factor.dart
+++ b/lib/src/chara_detail/spec/factor.dart
@@ -266,6 +266,9 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
   final double? width;
 
   @override
+  final String? builderId;
+
+  @override
   ColumnSpecCellAction get cellAction => ColumnSpecCellAction.openFactorPreview;
 
   FactorColumnSpec({
@@ -279,6 +282,7 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
     this.hidden = false,
     this.description,
     this.width,
+    this.builderId,
   });
 
   @override
@@ -289,6 +293,13 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
 
   @override
   ColumnSpec withWidth(double? width) => copyWith(width: width);
+
+  @override
+  bool get hasFilter => true;
+
+  @override
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) =>
+      copyWith(predicate: defaultSpec is FactorColumnSpec ? defaultSpec.predicate : AggregateFactorSetPredicate.any());
 
   FactorColumnSpec copyWith({
     String? id,
@@ -301,6 +312,7 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
     bool? hidden,
     Object? description = _unset,
     Object? width = _unset,
+    String? builderId,
   }) {
     return FactorColumnSpec(
       id: id ?? this.id,
@@ -313,6 +325,7 @@ class FactorColumnSpec extends ColumnSpec<FactorSet> with FactorColumnSpecMappab
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
       width: identical(width, _unset) ? this.width : width as double?,
+      builderId: builderId ?? this.builderId,
     );
   }
 
@@ -837,6 +850,9 @@ class FilteredFactorColumnBuilder extends ColumnBuilder {
   @override
   final ColumnBuilderType type;
 
+  @override
+  final String? builderId;
+
   FilteredFactorColumnBuilder({
     required this.title,
     required this.category,
@@ -846,6 +862,7 @@ class FilteredFactorColumnBuilder extends ColumnBuilder {
     this.initialSkillTags = const {},
     required this.initialIds,
     required this.initialStar,
+    this.builderId,
   }) : type = isFilterColumn ? ColumnBuilderType.filter : ColumnBuilderType.normal;
 
   @override
@@ -854,6 +871,7 @@ class FilteredFactorColumnBuilder extends ColumnBuilder {
       id: const Uuid().v4(),
       title: title,
       parser: parser,
+      builderId: builderId,
       predicate: AggregateFactorSetPredicate(
         query: initialIds,
         logic: FactorSetLogicMode.mixed,

--- a/lib/src/chara_detail/spec/factor.mapper.dart
+++ b/lib/src/chara_detail/spec/factor.mapper.dart
@@ -561,6 +561,12 @@ class FactorColumnSpecMapper extends SubClassMapperBase<FactorColumnSpec> {
     _$width,
     opt: true,
   );
+  static String? _$builderId(FactorColumnSpec v) => v.builderId;
+  static const Field<FactorColumnSpec, String> _f$builderId = Field(
+    'builderId',
+    _$builderId,
+    opt: true,
+  );
   static String _$labelKey(FactorColumnSpec v) => v.labelKey;
   static const Field<FactorColumnSpec, String> _f$labelKey = Field(
     'labelKey',
@@ -580,6 +586,7 @@ class FactorColumnSpecMapper extends SubClassMapperBase<FactorColumnSpec> {
     #hidden: _f$hidden,
     #description: _f$description,
     #width: _f$width,
+    #builderId: _f$builderId,
     #labelKey: _f$labelKey,
   };
   @override
@@ -609,6 +616,7 @@ class FactorColumnSpecMapper extends SubClassMapperBase<FactorColumnSpec> {
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
       width: data.dec(_f$width),
+      builderId: data.dec(_f$builderId),
     );
   }
 

--- a/lib/src/chara_detail/spec/family_registration.dart
+++ b/lib/src/chara_detail/spec/family_registration.dart
@@ -170,6 +170,12 @@ class FamilyRegistrationColumnSpec extends ColumnSpec<FamilyRegistrationStatus>
   @override
   ColumnSpec withWidth(double? width) => copyWith(width: width);
 
+  @override
+  bool get hasFilter => true;
+
+  @override
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) => copyWith(predicate: FamilyRegistrationPredicate.any());
+
   FamilyRegistrationColumnSpec copyWith({
     String? id,
     String? title,

--- a/lib/src/chara_detail/spec/memo.dart
+++ b/lib/src/chara_detail/spec/memo.dart
@@ -104,6 +104,12 @@ class MemoColumnSpec extends ColumnSpec<String?> with MemoColumnSpecMappable {
   ColumnSpec withWidth(double? width) => copyWith(width: width);
 
   @override
+  bool get hasFilter => true;
+
+  @override
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) => copyWith(predicate: RegExpPredicate());
+
+  @override
   String measuredText(TrinaCell? cell, String formatted) =>
       cell?.getUserData<MemoCellData>()?.value == null ? "$tr_memo.cell.description".tr() : formatted;
 

--- a/lib/src/chara_detail/spec/ranged_integer.dart
+++ b/lib/src/chara_detail/spec/ranged_integer.dart
@@ -93,6 +93,12 @@ class RangedIntegerColumnSpec extends ColumnSpec<int> with RangedIntegerColumnSp
   @override
   ColumnSpec withWidth(double? width) => copyWith(width: width);
 
+  @override
+  bool get hasFilter => true;
+
+  @override
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) => copyWith(predicate: IsInRangeIntegerPredicate());
+
   RangedIntegerColumnSpec copyWith({
     String? id,
     String? title,

--- a/lib/src/chara_detail/spec/ranged_label.dart
+++ b/lib/src/chara_detail/spec/ranged_label.dart
@@ -60,6 +60,9 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
   @override
   final double? width;
 
+  @override
+  final String? builderId;
+
   RangedLabelColumnSpec({
     required this.id,
     required this.title,
@@ -70,6 +73,7 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
     this.hidden = false,
     this.description,
     this.width,
+    this.builderId,
   }) : cellAction = cellAction ?? ColumnSpecCellAction.openSkillPreview;
 
   @override
@@ -81,6 +85,13 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
   @override
   ColumnSpec withWidth(double? width) => copyWith(width: width);
 
+  @override
+  bool get hasFilter => true;
+
+  @override
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) =>
+      copyWith(predicate: defaultSpec is RangedLabelColumnSpec ? defaultSpec.predicate : IsInRangeIntegerPredicate());
+
   RangedLabelColumnSpec copyWith({
     String? id,
     String? title,
@@ -90,6 +101,7 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
     bool? hidden,
     Object? description = _unset,
     Object? width = _unset,
+    String? builderId,
   }) {
     return RangedLabelColumnSpec(
       id: id ?? this.id,
@@ -100,6 +112,7 @@ class RangedLabelColumnSpec extends ColumnSpec<int> with RangedLabelColumnSpecMa
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
       width: identical(width, _unset) ? this.width : width as double?,
+      builderId: builderId ?? this.builderId,
     );
   }
 
@@ -289,6 +302,9 @@ class RangedLabelColumnBuilder extends ColumnBuilder {
   @override
   final ColumnBuilderType type;
 
+  @override
+  final String? builderId;
+
   RangedLabelColumnBuilder({
     required this.title,
     required this.category,
@@ -296,6 +312,7 @@ class RangedLabelColumnBuilder extends ColumnBuilder {
     required this.parser,
     this.cellAction,
     this.min,
+    this.builderId,
   }) : type = min != null ? ColumnBuilderType.filter : ColumnBuilderType.normal;
 
   @override
@@ -306,6 +323,7 @@ class RangedLabelColumnBuilder extends ColumnBuilder {
       parser: parser,
       labelKey: labelKey,
       cellAction: cellAction,
+      builderId: builderId,
       predicate: IsInRangeIntegerPredicate(min: min),
     );
   }

--- a/lib/src/chara_detail/spec/ranged_label.mapper.dart
+++ b/lib/src/chara_detail/spec/ranged_label.mapper.dart
@@ -70,6 +70,12 @@ class RangedLabelColumnSpecMapper
     _$width,
     opt: true,
   );
+  static String? _$builderId(RangedLabelColumnSpec v) => v.builderId;
+  static const Field<RangedLabelColumnSpec, String> _f$builderId = Field(
+    'builderId',
+    _$builderId,
+    opt: true,
+  );
 
   @override
   final MappableFields<RangedLabelColumnSpec> fields = const {
@@ -82,6 +88,7 @@ class RangedLabelColumnSpecMapper
     #hidden: _f$hidden,
     #description: _f$description,
     #width: _f$width,
+    #builderId: _f$builderId,
   };
   @override
   final bool ignoreNull = true;
@@ -109,6 +116,7 @@ class RangedLabelColumnSpecMapper
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
       width: data.dec(_f$width),
+      builderId: data.dec(_f$builderId),
     );
   }
 

--- a/lib/src/chara_detail/spec/rating.dart
+++ b/lib/src/chara_detail/spec/rating.dart
@@ -115,6 +115,12 @@ class RatingColumnSpec extends ColumnSpec<double?> with RatingColumnSpecMappable
   @override
   ColumnSpec withWidth(double? width) => copyWith(width: width);
 
+  @override
+  bool get hasFilter => true;
+
+  @override
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) => copyWith(predicate: IsInRangeRatingPredicate());
+
   RatingColumnSpec copyWith({
     String? id,
     String? title,

--- a/lib/src/chara_detail/spec/simple_label.dart
+++ b/lib/src/chara_detail/spec/simple_label.dart
@@ -71,6 +71,9 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
   @override
   final double? width;
 
+  @override
+  final String? builderId;
+
   SimpleLabelColumnSpec({
     required this.id,
     required this.title,
@@ -81,6 +84,7 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
     this.hidden = false,
     this.description,
     this.width,
+    this.builderId,
   }) : cellAction = cellAction ?? ColumnSpecCellAction.openSkillPreview;
 
   @override
@@ -92,6 +96,13 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
   @override
   ColumnSpec withWidth(double? width) => copyWith(width: width);
 
+  @override
+  bool get hasFilter => true;
+
+  @override
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) =>
+      copyWith(predicate: defaultSpec is SimpleLabelColumnSpec ? defaultSpec.predicate : SimpleLabelPredicate.any());
+
   SimpleLabelColumnSpec copyWith({
     String? id,
     String? title,
@@ -101,6 +112,7 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
     bool? hidden,
     Object? description = _unset,
     Object? width = _unset,
+    String? builderId,
   }) {
     return SimpleLabelColumnSpec(
       id: id ?? this.id,
@@ -111,6 +123,7 @@ class SimpleLabelColumnSpec extends ColumnSpec<int> with SimpleLabelColumnSpecMa
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
       width: identical(width, _unset) ? this.width : width as double?,
+      builderId: builderId ?? this.builderId,
     );
   }
 
@@ -314,6 +327,9 @@ class SimpleLabelColumnBuilder extends ColumnBuilder {
   @override
   final ColumnBuilderType type;
 
+  @override
+  final String? builderId;
+
   SimpleLabelColumnBuilder({
     required this.title,
     required this.category,
@@ -321,6 +337,7 @@ class SimpleLabelColumnBuilder extends ColumnBuilder {
     required this.parser,
     this.rejects,
     this.cellAction,
+    this.builderId,
   }) : type = rejects != null ? ColumnBuilderType.filter : ColumnBuilderType.normal;
 
   @override
@@ -332,6 +349,7 @@ class SimpleLabelColumnBuilder extends ColumnBuilder {
       labelKey: labelKey,
       predicate: rejects == null ? SimpleLabelPredicate.any() : SimpleLabelPredicate(rejects: rejects!),
       cellAction: cellAction,
+      builderId: builderId,
     );
   }
 }

--- a/lib/src/chara_detail/spec/simple_label.mapper.dart
+++ b/lib/src/chara_detail/spec/simple_label.mapper.dart
@@ -125,6 +125,12 @@ class SimpleLabelColumnSpecMapper
     _$width,
     opt: true,
   );
+  static String? _$builderId(SimpleLabelColumnSpec v) => v.builderId;
+  static const Field<SimpleLabelColumnSpec, String> _f$builderId = Field(
+    'builderId',
+    _$builderId,
+    opt: true,
+  );
 
   @override
   final MappableFields<SimpleLabelColumnSpec> fields = const {
@@ -137,6 +143,7 @@ class SimpleLabelColumnSpecMapper
     #hidden: _f$hidden,
     #description: _f$description,
     #width: _f$width,
+    #builderId: _f$builderId,
   };
   @override
   final bool ignoreNull = true;
@@ -164,6 +171,7 @@ class SimpleLabelColumnSpecMapper
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
       width: data.dec(_f$width),
+      builderId: data.dec(_f$builderId),
     );
   }
 

--- a/lib/src/chara_detail/spec/skill.dart
+++ b/lib/src/chara_detail/spec/skill.dart
@@ -145,6 +145,9 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
   final double? width;
 
   @override
+  final String? builderId;
+
+  @override
   ColumnSpecCellAction get cellAction => ColumnSpecCellAction.openSkillPreview;
 
   SkillColumnSpec({
@@ -158,6 +161,7 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
     this.hidden = false,
     this.description,
     this.width,
+    this.builderId,
   });
 
   @override
@@ -168,6 +172,13 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
 
   @override
   ColumnSpec withWidth(double? width) => copyWith(width: width);
+
+  @override
+  bool get hasFilter => true;
+
+  @override
+  ColumnSpec withFilterReset(ColumnSpec? defaultSpec) =>
+      copyWith(predicate: defaultSpec is SkillColumnSpec ? defaultSpec.predicate : AggregateSkillPredicate.any());
 
   SkillColumnSpec copyWith({
     String? id,
@@ -180,6 +191,7 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
     bool? hidden,
     Object? description = _unset,
     Object? width = _unset,
+    String? builderId,
   }) {
     return SkillColumnSpec(
       id: id ?? this.id,
@@ -192,6 +204,7 @@ class SkillColumnSpec extends ColumnSpec<List<Skill>> with SkillColumnSpecMappab
       hidden: hidden ?? this.hidden,
       description: identical(description, _unset) ? this.description : description as String?,
       width: identical(width, _unset) ? this.width : width as double?,
+      builderId: builderId ?? this.builderId,
     );
   }
 
@@ -561,6 +574,9 @@ class FilteredSkillColumnBuilder extends ColumnBuilder {
   final Set<int> initialIds;
 
   @override
+  final String? builderId;
+
+  @override
   final String title;
 
   @override
@@ -576,6 +592,7 @@ class FilteredSkillColumnBuilder extends ColumnBuilder {
     bool isFilterColumn = true,
     this.initialTags = const {},
     required this.initialIds,
+    this.builderId,
   }) : type = isFilterColumn ? ColumnBuilderType.filter : ColumnBuilderType.normal;
 
   @override
@@ -584,6 +601,7 @@ class FilteredSkillColumnBuilder extends ColumnBuilder {
       id: const Uuid().v4(),
       title: title,
       parser: parser,
+      builderId: builderId,
       predicate: AggregateSkillPredicate(
         query: initialIds,
         logic: SkillSetLogicMode.anyOf,

--- a/lib/src/chara_detail/spec/skill.mapper.dart
+++ b/lib/src/chara_detail/spec/skill.mapper.dart
@@ -332,6 +332,12 @@ class SkillColumnSpecMapper extends SubClassMapperBase<SkillColumnSpec> {
     _$width,
     opt: true,
   );
+  static String? _$builderId(SkillColumnSpec v) => v.builderId;
+  static const Field<SkillColumnSpec, String> _f$builderId = Field(
+    'builderId',
+    _$builderId,
+    opt: true,
+  );
   static String _$labelKey(SkillColumnSpec v) => v.labelKey;
   static const Field<SkillColumnSpec, String> _f$labelKey = Field(
     'labelKey',
@@ -351,6 +357,7 @@ class SkillColumnSpecMapper extends SubClassMapperBase<SkillColumnSpec> {
     #hidden: _f$hidden,
     #description: _f$description,
     #width: _f$width,
+    #builderId: _f$builderId,
     #labelKey: _f$labelKey,
   };
   @override
@@ -380,6 +387,7 @@ class SkillColumnSpecMapper extends SubClassMapperBase<SkillColumnSpec> {
       hidden: data.dec(_f$hidden),
       description: data.dec(_f$description),
       width: data.dec(_f$width),
+      builderId: data.dec(_f$builderId),
     );
   }
 

--- a/lib/src/gui/addon/task_dialog.dart
+++ b/lib/src/gui/addon/task_dialog.dart
@@ -82,6 +82,7 @@ class _ActionFields {
   // is required); an existing action overwrites it in seed().
   final webhookTimeout = TextEditingController(text: "${WebhookAction.defaultTimeoutSeconds}");
   final builtinArg = TextEditingController();
+  final builtinArg2 = TextEditingController();
   bool runInShell = false;
   String builtinKey = builtinActionRegistry.keys.first;
   String webhookMethod = _webhookMethods.first;
@@ -111,8 +112,10 @@ class _ActionFields {
         // the key dropdown's assert, so fall back to the first registry entry.
         builtinKey = builtinActionRegistry.containsKey(a.actionKey) ? a.actionKey : builtinActionRegistry.keys.first;
         builtinArg.text = a.argument ?? builtinActionRegistry[builtinKey]?.defaultArgument ?? "";
+        builtinArg2.text = a.secondaryArgument ?? builtinActionRegistry[builtinKey]?.defaultSecondArgument ?? "";
       default:
         builtinArg.text = builtinActionRegistry[builtinKey]?.defaultArgument ?? "";
+        builtinArg2.text = builtinActionRegistry[builtinKey]?.defaultSecondArgument ?? "";
     }
   }
 
@@ -125,6 +128,7 @@ class _ActionFields {
     body.dispose();
     webhookTimeout.dispose();
     builtinArg.dispose();
+    builtinArg2.dispose();
   }
 
   bool isValid(_ActionKind kind, TriggerEvent trigger) {
@@ -166,7 +170,11 @@ class _ActionFields {
         final argument = (options != null && !options.any((o) => o.value == builtinArg.text))
             ? descriptor!.defaultArgument
             : builtinArg.text;
-        return BuiltinAction(actionKey: builtinKey, argument: descriptor?.usesArgument == true ? argument : null);
+        return BuiltinAction(
+          actionKey: builtinKey,
+          argument: descriptor?.usesArgument == true ? argument : null,
+          secondaryArgument: descriptor?.usesSecondArgument == true ? builtinArg2.text : null,
+        );
     }
   }
 }
@@ -512,6 +520,13 @@ List<Widget> _builtinFields(_ActionFields f, TriggerEvent trigger, VoidCallback 
     if (f.builtinArg.text.isEmpty || f.builtinArg.text == previousDefault || invalidForOptions) {
       f.builtinArg.text = next?.defaultArgument ?? "";
     }
+    // Reset the second argument the same way: only when it is empty or still the
+    // previous action's default, so a value the user actually typed survives a
+    // key switch.
+    final previousSecondDefault = builtinActionRegistry[f.builtinKey]?.defaultSecondArgument ?? "";
+    if (f.builtinArg2.text.isEmpty || f.builtinArg2.text == previousSecondDefault) {
+      f.builtinArg2.text = next?.defaultSecondArgument ?? "";
+    }
     f.builtinKey = key;
     onChanged();
   }
@@ -537,6 +552,20 @@ List<Widget> _builtinFields(_ActionFields f, TriggerEvent trigger, VoidCallback 
           ),
         ),
         if (descriptor.argumentUsesPlaceholders) ...[const SizedBox(height: 8), _PlaceholderDropdown(trigger: trigger)],
+      ],
+    ],
+    if (descriptor?.usesSecondArgument == true) ...[
+      const SizedBox(height: 16),
+      TextField(
+        controller: f.builtinArg2,
+        decoration: InputDecoration(
+          labelText: (descriptor!.secondaryArgumentLabelKey ?? "$tr_addon.dialog.builtin.argument").tr(),
+          helperText: (descriptor.secondaryArgumentHelperKey ?? "$tr_addon.dialog.arguments.helper").tr(),
+        ),
+      ),
+      if (descriptor.secondaryArgumentUsesPlaceholders) ...[
+        const SizedBox(height: 8),
+        _PlaceholderDropdown(trigger: trigger),
       ],
     ],
   ];

--- a/lib/src/gui/addon/task_dialog.dart
+++ b/lib/src/gui/addon/task_dialog.dart
@@ -138,7 +138,9 @@ class _ActionFields {
         url.text.trim().isNotEmpty &&
             urlErrorKey(url.text) == null &&
             timeoutErrorKey(webhookTimeout.text, required: true) == null,
-      _ActionKind.builtin => !builtinNeedsUnavailableRecord(builtinKey, trigger),
+      _ActionKind.builtin =>
+        !builtinNeedsUnavailableRecord(builtinKey, trigger) &&
+            (builtinActionRegistry[builtinKey]?.usesSecondArgument != true || builtinArg2.text.trim().isNotEmpty),
     };
   }
 

--- a/lib/src/gui/chara_detail/column_spec_dialog.dart
+++ b/lib/src/gui/chara_detail/column_spec_dialog.dart
@@ -4,6 +4,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/chara_detail/spec/base.dart';
+import '/src/chara_detail/spec/builder.dart';
 import '/src/chara_detail/spec/loader.dart';
 import '/src/core/callback.dart';
 import '/src/core/utils.dart';
@@ -204,6 +205,13 @@ class _ColumnSpecDialogState extends ConsumerState<ColumnSpecDialog> {
   // disposed when the dialog closes, instead of leaking a fresh one per build.
   final PlainChangeNotifier _onDecided = PlainChangeNotifier();
 
+  // Bumped by the reset button to force the selector subtree to rebuild from the
+  // (just-reset) clone. Selector fields keep local widget state — a slider's
+  // position, a text field's controller — that does not resync when the clone's
+  // predicate is replaced externally, so resetting the clone alone leaves the UI
+  // stale. Re-keying the subtree re-seeds every field from the clone.
+  int _resetEpoch = 0;
+
   @override
   void dispose() {
     _onDecided.dispose();
@@ -214,26 +222,60 @@ class _ColumnSpecDialogState extends ConsumerState<ColumnSpecDialog> {
   Widget build(BuildContext context) {
     final specId = widget.spec.id;
     // Ensure that the cloned spec will not be disposed while the dialog is still open.
-    ref.watch(specCloneProvider(specId));
+    // Watching it also re-renders the bottom bar when the filter is reset, so the
+    // reset button can hide once there is nothing left to clear.
+    final clone = ref.watch(specCloneProvider(specId));
     final saveEnabled = ref.watch(columnSpecSaveEnabledProvider(specId));
 
     return CardDialog(
       dialogTitle: "$tr_chara_detail.column_predicate.dialog.title".tr(),
       closeButtonTooltip: "$tr_chara_detail.column_predicate.dialog.close_button.tooltip".tr(),
-      content: widget.spec.selector(_onDecided),
+      content: KeyedSubtree(key: ValueKey(_resetEpoch), child: widget.spec.selector(_onDecided)),
       bottom: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Tooltip(
-            message: "$tr_chara_detail.column_predicate.dialog.delete_button.tooltip".tr(),
-            child: OutlinedButton.icon(
-              icon: const Icon(Symbols.delete_forever_rounded),
-              label: Text("$tr_chara_detail.column_predicate.dialog.delete_button.label".tr()),
-              onPressed: () {
-                ref.read(currentColumnSpecsLoaderProvider.notifier).removeIfExists(specId);
-                CardDialog.dismiss(ref.base);
-              },
-            ),
+          // Left group: destructive delete, then the filter reset right beside it.
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Tooltip(
+                message: "$tr_chara_detail.column_predicate.dialog.delete_button.tooltip".tr(),
+                child: OutlinedButton.icon(
+                  icon: const Icon(Symbols.delete_forever_rounded),
+                  label: Text("$tr_chara_detail.column_predicate.dialog.delete_button.label".tr()),
+                  onPressed: () {
+                    ref.read(currentColumnSpecsLoaderProvider.notifier).removeIfExists(specId);
+                    CardDialog.dismiss(ref.base);
+                  },
+                ),
+              ),
+              // Reset the column's filter (predicate) to its default, keeping the other
+              // settings. For a preset column the default is the preset (rebuilt via
+              // builderSpecOf); otherwise it is "accept every row". Edits the clone only,
+              // so it is committed by OK and discarded by Cancel like every other field.
+              // Hidden for columns that carry no resettable filter (containers, script).
+              if (clone.hasFilter) ...[
+                const SizedBox(width: 8),
+                Tooltip(
+                  message: "$tr_chara_detail.column_predicate.dialog.reset_button.tooltip".tr(),
+                  child: OutlinedButton.icon(
+                    icon: const Icon(Symbols.filter_alt_off_rounded),
+                    label: Text("$tr_chara_detail.column_predicate.dialog.reset_button.label".tr()),
+                    onPressed: () {
+                      // Flush the deferred fields (title/visibility/description) into the
+                      // clone first so the upcoming rebuild re-seeds them from their
+                      // current UI values, not the stale originals.
+                      _onDecided.notifyListeners();
+                      final defaultSpec = builderSpecOf(ref.base, ref.read(specCloneProvider(specId)));
+                      ref.read(specCloneProvider(specId).notifier).update((spec) => spec.withFilterReset(defaultSpec));
+                      // Re-key the selector subtree so its fields re-seed from the reset
+                      // clone; the user can then tweak the reset value and OK commits it.
+                      setState(() => _resetEpoch++);
+                    },
+                  ),
+                ),
+              ],
+            ],
           ),
           Tooltip(
             message: saveEnabled

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -869,7 +869,25 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                   // programmatic restoreCurrentRecord in _navigateSidePreview alike
                   // (setCurrentCell calls it even with notify:false) — so mirroring the
                   // id here keeps the panel in sync without the panel storing its own.
-                  onActiveCellChanged: (_) => _currentRecordId.value = stateManager.currentRecord?.id,
+                  onActiveCellChanged: (_) {
+                    _currentRecordId.value = stateManager.currentRecord?.id;
+                    // Keep the shown image (mode) following the focused column on every
+                    // current-cell change — keyboard moves and the programmatic
+                    // restoreCurrentRecord alike, not just mouse clicks (which also pass
+                    // through onSelected). The panel only tracks the record id; the mode
+                    // is re-derived here from the focused column's cell action so the
+                    // image always matches the column in focus. The breakpoint is
+                    // re-checked (not read from the captured `narrow`) for the same
+                    // reason onSelected does: this closure is captured once at grid load.
+                    final sidePreview = ref.read(sidePreviewProvider);
+                    if (sidePreview != null && isSidePreviewAllowed(context)) {
+                      final action = stateManager.currentCell?.column.getUserData<ColumnSpec>()?.cellAction;
+                      final mode = imageModeForColumnAction(action);
+                      if (mode != sidePreview.mode) {
+                        ref.read(sidePreviewProvider.notifier).set(SidePreviewState(mode: mode));
+                      }
+                    }
+                  },
                   onRowSecondaryTap: (TrinaGridOnRowSecondaryTapEvent event) {
                     // event.row (== getRowByIdx(rowIdx)) is unreliable once any
                     // row is frozen (pinned): TrinaGrid renders frozen rows in a
@@ -906,23 +924,18 @@ class _CharaDetailDataTableWidgetState extends ConsumerState<_CharaDetailDataTab
                           return;
                         }
                         // While the side preview panel is open (and visible — not in
-                        // the narrow layout where it is hidden), a cell click only
-                        // picks which screen to show (the column's mode); the panel
-                        // follows the grid's current record (already set by the tap, via
-                        // onActiveCellChanged), so it isn't set here. Suppress the dialog.
+                        // the narrow layout where it is hidden), a cell click only moves
+                        // the focus: the panel follows the grid's current record and the
+                        // shown image is re-derived from the focused column, both in
+                        // onActiveCellChanged (which the tap also fires). So here we only
+                        // suppress the dialog.
                         //
                         // The breakpoint is re-evaluated here, not read from the
                         // build-scope `narrow`: TrinaGrid captures this onSelected
                         // closure once (at grid load) and never refreshes it, so a
                         // captured `narrow` would stay frozen at its first-build value
                         // and feed the hidden panel after the window shrinks.
-                        final sidePreview = ref.read(sidePreviewProvider);
-                        if (sidePreview != null && isSidePreviewAllowed(context)) {
-                          final action = event.cell?.column.getUserData<ColumnSpec>()?.cellAction;
-                          final mode = imageModeForColumnAction(action);
-                          if (mode != sidePreview.mode) {
-                            ref.read(sidePreviewProvider.notifier).set(SidePreviewState(mode: mode));
-                          }
+                        if (ref.read(sidePreviewProvider) != null && isSidePreviewAllowed(context)) {
                           return;
                         }
                         final source = ref.read(recordSourceProvider);

--- a/test/addon_execution_test.dart
+++ b/test/addon_execution_test.dart
@@ -51,6 +51,7 @@ void main() {
         timeoutSeconds: 10,
       ),
       BuiltinAction(actionKey: 'show_toast', argument: '{event}'),
+      BuiltinAction(actionKey: 'copy_file_to_path', argument: 'skill', secondaryArgument: r'D:\out\{record_id}.png'),
     ];
 
     for (final action in actions) {
@@ -371,8 +372,18 @@ void main() {
     test('record-dependent builtins are flagged requiresRecord', () {
       expect(builtinActionRegistry['copy_image_to_clipboard']!.requiresRecord, isTrue);
       expect(builtinActionRegistry['copy_file_to_clipboard']!.requiresRecord, isTrue);
+      expect(builtinActionRegistry['copy_file_to_path']!.requiresRecord, isTrue);
       expect(builtinActionRegistry['show_toast']!.requiresRecord, isFalse);
       expect(builtinActionRegistry['play_sound']!.requiresRecord, isFalse);
+    });
+
+    test('copy_file_to_path takes a destination as its second argument', () {
+      final descriptor = builtinActionRegistry['copy_file_to_path']!;
+      expect(descriptor.usesArgument, isTrue);
+      expect(descriptor.usesSecondArgument, isTrue);
+      // The destination is a free-text path template, so it accepts placeholders
+      // (unlike the keyword first argument).
+      expect(descriptor.secondaryArgumentUsesPlaceholders, isTrue);
     });
 
     test('only record-bearing triggers expose record_id', () {
@@ -407,8 +418,11 @@ void main() {
       // silently copy the wrong image).
       final imageKeys = builtinActionRegistry['copy_image_to_clipboard']!.argumentOptions!.map((o) => o.value);
       final fileKeys = builtinActionRegistry['copy_file_to_clipboard']!.argumentOptions!.map((o) => o.value);
+      final pathKeys = builtinActionRegistry['copy_file_to_path']!.argumentOptions!.map((o) => o.value);
       expect(imageKeys, ['trainee', 'skill', 'factor', 'campaign']);
       expect(fileKeys, ['trainee', 'skill', 'factor', 'campaign', 'record_json']);
+      // The copy-to-path action offers the same source set as copy-to-clipboard.
+      expect(pathKeys, ['trainee', 'skill', 'factor', 'campaign', 'record_json']);
     });
   });
 

--- a/test/addon_tasks_test.dart
+++ b/test/addon_tasks_test.dart
@@ -259,8 +259,11 @@ void main() {
       expect(result.status, ExecutionStatus.success);
     });
 
-    BuiltinActionDescriptor neverCompleting(String key) =>
-        BuiltinActionDescriptor(key: key, labelKey: key, run: (ref, payload, argument) => Completer<void>().future);
+    BuiltinActionDescriptor neverCompleting(String key) => BuiltinActionDescriptor(
+      key: key,
+      labelKey: key,
+      run: (ref, payload, argument, secondaryArgument) => Completer<void>().future,
+    );
 
     test('a builtin that never completes is bounded by the timeout', () async {
       builtinActionRegistry['stuck_timeout'] = neverCompleting('stuck_timeout');
@@ -282,7 +285,7 @@ void main() {
       builtinActionRegistry['stuck_cancel'] = BuiltinActionDescriptor(
         key: 'stuck_cancel',
         labelKey: 'stuck_cancel',
-        run: (ref, payload, argument) => completer.future,
+        run: (ref, payload, argument, secondaryArgument) => completer.future,
       );
       addTearDown(() => builtinActionRegistry.remove('stuck_cancel'));
 

--- a/test/column_spec_filter_clear_test.dart
+++ b/test/column_spec_filter_clear_test.dart
@@ -1,0 +1,195 @@
+// Regression test for the per-column "reset filter" action (approach B):
+// withFilterReset restores a column's DEFAULT filter — the preset for a
+// preset-built column (rebuilt via builderSpecOf), or "accept every row" otherwise
+// — while preserving the display settings (title, width, hidden, description).
+// Run: .fvm/flutter_sdk/bin/flutter test test/column_spec_filter_clear_test.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/chara_detail/spec/base.dart';
+import 'package:umacapture/src/chara_detail/spec/builder.dart';
+import 'package:umacapture/src/chara_detail/spec/factor.dart';
+import 'package:umacapture/src/chara_detail/spec/logic.dart';
+import 'package:umacapture/src/chara_detail/spec/parser.dart';
+import 'package:umacapture/src/chara_detail/spec/ranged_label.dart';
+import 'package:umacapture/src/chara_detail/spec/ranged_integer.dart';
+import 'package:umacapture/src/chara_detail/spec/script.dart';
+import 'package:umacapture/src/chara_detail/spec/simple_label.dart';
+import 'package:umacapture/src/core/mapper_init.dart';
+import 'package:umacapture/src/core/utils.dart';
+
+/// Exposes a [RefBase] so `builderSpecOf` (which takes one) can run in tests.
+final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+
+void main() {
+  setUpAll(initializeMappers);
+
+  group('preset columns reset to their rebuilt preset (approach B)', () {
+    test('a ranged-label preset restores its min, keeping display settings', () {
+      // Stub the builder catalog with a single preset builder; its build() needs
+      // no providers, so no label/game data env is required.
+      final container = ProviderContainer.test(
+        overrides: [
+          columnBuilderProvider.overrideWithValue([
+            RangedLabelColumnBuilder(
+              title: 'apt',
+              category: ColumnCategory.aptitude,
+              labelKey: LabelKeys.aptitude,
+              parser: EvaluationValueParser(),
+              min: 7,
+              builderId: 'apt_mid',
+            ),
+          ]),
+        ],
+      );
+      addTearDown(container.dispose);
+      final ref = container.read(_refBaseProvider);
+
+      // A column created from that preset, but with the filter edited away.
+      final spec = RangedLabelColumnSpec(
+        id: 'id-1',
+        title: '中距離',
+        parser: EvaluationValueParser(),
+        labelKey: LabelKeys.aptitude,
+        predicate: IsInRangeIntegerPredicate(min: 2),
+        hidden: true,
+        description: 'note',
+        width: 240.0,
+        builderId: 'apt_mid',
+      );
+
+      final preset = builderSpecOf(ref, spec);
+      final reset = spec.withFilterReset(preset) as RangedLabelColumnSpec;
+      expect(reset.predicate.min, 7); // restored to the preset, not accept-all
+      // Display settings + the preset link survive the reset.
+      expect(reset.title, '中距離');
+      expect(reset.hidden, isTrue);
+      expect(reset.description, 'note');
+      expect(reset.width, 240.0);
+      expect(reset.builderId, 'apt_mid');
+    });
+
+    test('a factor preset restores its query (dynamic ids rebuilt from the builder)', () {
+      final container = ProviderContainer.test(
+        overrides: [
+          columnBuilderProvider.overrideWithValue([
+            FilteredFactorColumnBuilder(
+              title: 'f',
+              category: ColumnCategory.factor,
+              parser: FactorSetParser(),
+              initialIds: {1, 2},
+              initialStar: 1,
+              builderId: 'factor_x',
+            ),
+          ]),
+        ],
+      );
+      addTearDown(container.dispose);
+      final ref = container.read(_refBaseProvider);
+
+      final spec = FactorColumnSpec(
+        id: 'id-2',
+        title: '青因子',
+        parser: FactorSetParser(),
+        predicate: AggregateFactorSetPredicate.any(),
+        builderId: 'factor_x',
+      );
+
+      final reset = spec.withFilterReset(builderSpecOf(ref, spec)) as FactorColumnSpec;
+      expect(reset.predicate.query, unorderedEquals({1, 2}));
+    });
+
+    test('an unknown builderId falls back to accept-all', () {
+      final container = ProviderContainer.test(overrides: [columnBuilderProvider.overrideWithValue([])]);
+      addTearDown(container.dispose);
+      final ref = container.read(_refBaseProvider);
+
+      final spec = RangedLabelColumnSpec(
+        id: 'id-3',
+        title: 'x',
+        parser: EvaluationValueParser(),
+        labelKey: LabelKeys.aptitude,
+        predicate: IsInRangeIntegerPredicate(min: 3),
+        builderId: 'gone',
+      );
+      // builderSpecOf returns null (no matching builder) → accept-all.
+      expect(builderSpecOf(ref, spec), isNull);
+      final reset = spec.withFilterReset(null) as RangedLabelColumnSpec;
+      expect(reset.predicate.min, isNull);
+    });
+  });
+
+  group('non-preset filters reset to accept-all', () {
+    test('a column with builderId=null resets to accept-all', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+      final ref = container.read(_refBaseProvider);
+
+      final spec = SimpleLabelColumnSpec(
+        id: 'id-4',
+        title: 's',
+        parser: EvaluationValueParser(),
+        labelKey: LabelKeys.raceStrategy,
+        predicate: SimpleLabelPredicate(rejects: {1, 2}),
+      );
+      expect(spec.builderId, isNull);
+      expect(builderSpecOf(ref, spec), isNull); // no builderId → no rebuild
+      final reset = spec.withFilterReset(null) as SimpleLabelColumnSpec;
+      expect(reset.predicate.rejects, isEmpty);
+    });
+
+    test('RangedIntegerColumnSpec (no preset support) resets to accept-all', () {
+      final spec = RangedIntegerColumnSpec(
+        id: 'id-5',
+        title: 'i',
+        parser: EvaluationValueParser(),
+        predicate: IsInRangeIntegerPredicate(min: 5, max: 9),
+      );
+      expect(spec.hasFilter, isTrue);
+      final reset = spec.withFilterReset(null) as RangedIntegerColumnSpec;
+      expect(reset.predicate.min, isNull);
+      expect(reset.predicate.max, isNull);
+    });
+  });
+
+  group('non-filtering specs expose no filter to reset', () {
+    test('LogicColumnSpec has no filter and withFilterReset is a no-op', () {
+      final spec = LogicColumnSpec(id: 'logic-id', title: '論理', logic: LogicMode.and);
+      expect(spec.hasFilter, isFalse);
+      expect(identical(spec, spec.withFilterReset(null)), isTrue);
+    });
+
+    test('ScriptColumnSpec has no filter and withFilterReset is a no-op', () {
+      final spec = ScriptColumnSpec(
+        id: 'script-id',
+        title: 'スクリプト',
+        source: 'bool filter(CharaRecord r) => true;\ndynamic display(CharaRecord r) => 0;',
+      );
+      expect(spec.hasFilter, isFalse);
+      expect(identical(spec, spec.withFilterReset(null)), isTrue);
+    });
+  });
+
+  group('builderId round-trips through the mapper', () {
+    test('a preset column keeps its builderId; a plain one omits it', () {
+      final preset = FactorColumnSpec(
+        id: 'id-6',
+        title: 'p',
+        parser: FactorSetParser(),
+        predicate: AggregateFactorSetPredicate.any(),
+        builderId: 'factor_x',
+      );
+      final restored = ColumnSpecMapper.fromMap(preset.toMap()) as FactorColumnSpec;
+      expect(restored.builderId, 'factor_x');
+
+      final plain = FactorColumnSpec(
+        id: 'id-7',
+        title: 'q',
+        parser: FactorSetParser(),
+        predicate: AggregateFactorSetPredicate.any(),
+      );
+      // ignoreNull drops the key, so a plain column decodes (and stays) null.
+      expect(plain.toMap().containsKey('builderId'), isFalse);
+      expect((ColumnSpecMapper.fromMap(plain.toMap()) as FactorColumnSpec).builderId, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Three independent changes, one commit each:

### `feat(chara_detail)`: per-column filter reset to the column's default
Adds a **"reset filter"** button to the column edit dialog (next to *delete*).
Resetting restores the column's **default** filter rather than a blanket
"accept all":

- A column records the id of the "add column" builder it was created from
  (`builderId`). The reset re-runs that builder via `builderSpecOf` to
  regenerate its default predicate, so preset-style columns (e.g. the
  blue-factor / middle-distance shortcuts) return to their preset — including
  builders whose ids derive from current game data — while plain columns fall
  back to accept-all.
- The button is hidden for columns with no resettable filter (logic
  containers, the script column).
- Pressing reset flushes the deferred fields into the dialog's working copy,
  resets its predicate, and re-keys the selector subtree so the dialog UI
  follows the reset and subsequent edits still commit on OK.

### `feat(addon)`: add `copy_file_to_path` built-in action
Copies a record file (trainee/skill/factor/campaign image or `record.json`) to
a destination path template. `BuiltinAction` / `BuiltinActionDescriptor` / the
`BuiltinFn` signature gain an optional second argument so an action can pair a
source-kind dropdown with a free-text, placeholder-expanded destination; the
task dialog renders both fields. The destination's parent folders are created
before the copy.

### `fix(chara_detail)`: side preview image follows the focused column
The side preview's image mode was re-derived from the column only on a mouse
cell-click; keyboard navigation and the prev/next moves left the previous mode
in place, showing the wrong screen for the focused record. The mode is now
re-derived from the focused column on every active-cell change, so the image
always follows the current column.

## Known limitation

**Columns registered in an earlier version cannot all be reset correctly.**
Such columns have no stored `builderId`, so the reset cannot regenerate their
preset default and falls back to **accept-all** (the filter is cleared) instead
of returning to the preset.

- Affected: legacy columns created from a preset/shortcut (e.g. blue factor,
  middle distance, aptitude ◎+, status-up skills, race strategy, rank < A).
- Not affected: legacy plain columns with a manually-applied filter (their
  correct default *is* accept-all), and any column added after this change.
- The button still works (no crash); it only clears the filter for these
  legacy preset columns. Re-adding such a column from the add-column dialog
  stamps a `builderId` and restores correct reset behavior.

A migration to back-fill `builderId` onto legacy columns was considered and
intentionally skipped.

## Notes
- `builderId` (and the addon action's second argument) are omitted from the
  serialized map when null, so existing presets decode cleanly.
- Model changes regenerate `dart_mappable` outputs.

## Test
- `flutter test` — new `test/column_spec_filter_clear_test.dart` plus the
  updated addon and column-spec suites pass.
- `flutter analyze` clean.
- Manually verified in the running Windows app: preset columns reset to their
  preset and plain columns to accept-all; the dialog UI follows the reset and
  edits commit on OK; the addon action writes files to a templated path; the
  side preview follows the focused column under keyboard navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
