### PR TITLE
fix(sentry): disable error reporting in debug builds

### DIFF
--- a/.claude/skills/sentry-issues/SKILL.md
+++ b/.claude/skills/sentry-issues/SKILL.md
@@ -6,9 +6,9 @@ description: >-
   pull umacapture's Sentry issues, crash reports, or error logs — e.g. "check
   Sentry", "what errors are users hitting", "show the latest crashes", "is there
   anything new on release X", or when they want the full stack trace / tags /
-  context of a specific issue. Covers the production and debug projects, the
-  release-version filter, and the difference between readable Dart exceptions and
-  unsymbolicated native crashes.
+  context of a specific issue. Covers the production project (the debug project
+  no longer receives events), the release-version filter, and the difference
+  between readable Dart exceptions and unsymbolicated native crashes.
 ---
 
 # Inspecting umacapture's Sentry issues
@@ -27,10 +27,13 @@ These are baked into the helper script, but keep them visible for ad-hoc calls:
 | Region | `sentry.io` (US) |
 | Org id | `1367286` |
 | **release** project (production, `kReleaseMode`) | `6670477` |
-| **debug** project (`kDebugMode`) | `6668087` |
+| **debug** project (legacy, no longer reported to) | `6668087` |
 
 The numeric ids work directly in API paths, so no org/project *slug* lookup is
 needed. Default to the **release** project — that's where real users' errors land.
+As of the "disable error reporting in debug builds" change, debug builds skip
+Sentry initialization entirely, so the debug project receives no new events; only
+its historical issues remain.
 
 ## Default scope: latest release build only
 

--- a/.claude/skills/sentry-issues/scripts/sentry_issues.py
+++ b/.claude/skills/sentry-issues/scripts/sentry_issues.py
@@ -31,7 +31,7 @@ from pathlib import Path
 ORG_ID = "1367286"
 PROJECTS = {
     "release": "6670477",  # production build (kReleaseMode)
-    "debug": "6668087",  # kDebugMode build
+    "debug": "6668087",  # legacy: debug builds no longer init Sentry; historical events only
 }
 DEFAULT_TOKEN_PATH = "~/.sentry_token"
 BASE = "https://sentry.io/api/0"

--- a/lib/src/core/sentry_util.dart
+++ b/lib/src/core/sentry_util.dart
@@ -468,12 +468,10 @@ Future<void> _runWithSentry(AppRunner runner) async {
     await Directory(nativeDatabasePath).create(recursive: true);
     await SentryFlutter.init((SentryFlutterOptions options) {
       options.nativeDatabasePath = nativeDatabasePath;
-      if (kDebugMode) {
-        options.dsn = "https://6ccc0a047e5c42c788f907599f0d4e97@o1367286.ingest.sentry.io/6668087";
-      } else {
-        options.dsn = "https://6f9ab436b1ad46e2b1be72d8f44f03e0@o1367286.ingest.sentry.io/6670477";
-      }
-      options.release = appVersion.toString() + (kDebugMode ? "-debug" : "");
+      // Debug builds never reach here (see runWithSentry), so only the release
+      // project DSN remains.
+      options.dsn = "https://6f9ab436b1ad46e2b1be72d8f44f03e0@o1367286.ingest.sentry.io/6670477";
+      options.release = appVersion.toString();
       options.enablePrintBreadcrumbs = false;
       options.beforeSend = (SentryEvent event, Hint hint) async {
         final customHint = CustomHint.from(hint);
@@ -498,7 +496,10 @@ Future<void> _runWithSentry(AppRunner runner) async {
 }
 
 Future<void> runWithSentry(AppRunner runner) async {
-  if (allowPostUserData() == PostUserData.deny) {
+  // Never initialize Sentry in debug builds: developer-side errors must not be
+  // reported. Skipping init leaves HubAdapter disabled, so every captureXxx
+  // helper and the log breadcrumbs become no-ops.
+  if (kDebugMode || allowPostUserData() == PostUserData.deny) {
     logger.i("Error logging is disabled.");
     runner();
   } else {


### PR DESCRIPTION
## Summary

Debug builds previously initialized Sentry against a separate debug project (`6668087`), so developer-side errors were still transmitted while debugging. This skips Sentry initialization entirely in debug builds: `HubAdapter` stays disabled, so every `captureXxx` helper and the log breadcrumbs become no-ops and nothing is sent. Release builds are untouched and keep reporting suspected bugs as before.

## What changed

- `runWithSentry` now returns early (no Sentry init) when `kDebugMode` is set, in addition to the existing privacy opt-out gate.
- Since debug never reaches `_runWithSentry` anymore, the debug-only DSN and the `-debug` release suffix are removed, leaving only the release DSN.
- Update the `sentry-issues` skill (description, coordinates table, script `PROJECTS` map) to mark the debug project as legacy — it receives no new events, only historical ones. The `--project debug` option is kept for browsing those.

## Behavior

- **Debug**: Sentry disabled — nothing is reported.
- **Release**: unchanged. `SentryFlutter.init` still hooks uncaught framework/async errors and `beforeSend` drops nothing, so suspected bugs are reported rather than swallowed.

## Testing

- `dart format` / `dart analyze` clean on the changed `lib` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
