### PR TITLE
style(chara-detail): refine column dialog, chips, and shared error view

### DIFF
--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -291,10 +291,7 @@
                 "aptitude": "適性",
                 "skill": "スキル",
                 "factor": "因子",
-                "support_card": "サポートカード",
-                "family": "継承ウマ",
                 "campaign": "戦績",
-                "race": "出走履歴",
                 "metadata": "メタデータ",
                 "script": "スクリプト",
                 "logic": "論理"
@@ -1515,6 +1512,10 @@
     },
     "common": {
         "under_construction": "開発中",
-        "experimental_warning": "この機能は実験的です。保存した内容は今後のバージョンアップで利用できなくなる可能性があります。"
+        "experimental_warning": "この機能は実験的です。保存した内容は今後のバージョンアップで利用できなくなる可能性があります。",
+        "error_log": {
+            "copy_tooltip": "エラー内容をクリップボードにコピー",
+            "copied": "エラー内容をコピーしました。"
+        }
     }
 }

--- a/lib/src/chara_detail/spec/base.dart
+++ b/lib/src/chara_detail/spec/base.dart
@@ -111,20 +111,7 @@ class CellText extends ConsumerWidget {
   }
 }
 
-enum ColumnCategory {
-  trainee,
-  status,
-  aptitude,
-  skill,
-  factor,
-  supportCard,
-  family,
-  campaign,
-  race,
-  metadata,
-  script,
-  logic,
-}
+enum ColumnCategory { trainee, status, aptitude, skill, factor, campaign, metadata, script, logic }
 
 class LabelKeys {
   static String get aptitude => "aptitude.name";

--- a/lib/src/chara_detail/spec/builder.dart
+++ b/lib/src/chara_detail/spec/builder.dart
@@ -196,6 +196,7 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       category: ColumnCategory.skill,
       parser: SkillParser(),
       builderId: "skill_tag_driven",
+      type: ColumnBuilderType.filter,
     ),
     FactorColumnBuilder(
       title: "$tr_columns.factor.title".tr(),
@@ -277,6 +278,20 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       category: ColumnCategory.factor,
       parser: FactorSetParser(),
       builderId: "factor_tag_driven",
+      type: ColumnBuilderType.filter,
+    ),
+    // Race results (formerly their own "race" group) are folded into campaign,
+    // listed before fans so the order reads winning counts -> fans.
+    RangedIntegerColumnBuilder(
+      title: "$tr_columns.race_winning_count.title".tr(),
+      category: ColumnCategory.campaign,
+      parser: RaceWinningCountParser(),
+      cellAction: ColumnSpecCellAction.openCampaignPreview,
+    ),
+    RaceGradeWinningCountColumnBuilder(
+      title: "$tr_columns.race_winning_count_g1.title".tr(),
+      category: ColumnCategory.campaign,
+      grade: "grade_g1",
     ),
     RangedIntegerColumnBuilder(
       title: "$tr_columns.fans.title".tr(),
@@ -302,17 +317,6 @@ final columnBuilderProvider = Provider<List<ColumnBuilder>>((ref) {
       title: "$tr_columns.trained_date.title".tr(),
       category: ColumnCategory.campaign,
       parser: TrainedDateParser(),
-    ),
-    RangedIntegerColumnBuilder(
-      title: "$tr_columns.race_winning_count.title".tr(),
-      category: ColumnCategory.race,
-      parser: RaceWinningCountParser(),
-      cellAction: ColumnSpecCellAction.openCampaignPreview,
-    ),
-    RaceGradeWinningCountColumnBuilder(
-      title: "$tr_columns.race_winning_count_g1.title".tr(),
-      category: ColumnCategory.race,
-      grade: "grade_g1",
     ),
     SimpleLabelColumnBuilder(
       title: "$tr_columns.record_type.title".tr(),

--- a/lib/src/chara_detail/spec/factor.dart
+++ b/lib/src/chara_detail/spec/factor.dart
@@ -1011,9 +1011,18 @@ class TagDrivenFactorColumnBuilder extends ColumnBuilder {
   final ColumnCategory category;
 
   @override
+  final ColumnBuilderType type;
+
+  @override
   final String? builderId;
 
-  TagDrivenFactorColumnBuilder({required this.title, required this.category, required this.parser, this.builderId});
+  TagDrivenFactorColumnBuilder({
+    required this.title,
+    required this.category,
+    required this.parser,
+    this.builderId,
+    this.type = ColumnBuilderType.normal,
+  });
 
   @override
   ColumnSpec<FactorSet> build(RefBase ref) {

--- a/lib/src/gui/app_widget.dart
+++ b/lib/src/gui/app_widget.dart
@@ -286,17 +286,18 @@ class ApplicationWidgetState extends ConsumerState<ApplicationWidget> {
         waitDuration: const Duration(milliseconds: 100),
         showDuration: Duration.zero,
       ),
-      // Chips are borderless app-wide and default to a single neutral tone
-      // (surfaceContainerHigh). `side` is forced off because FilterChip/
-      // ChoiceChip otherwise paint the Material 3 state-dependent outline
-      // (unselected), which overrides `shape.side`. Per-chip `backgroundColor` /
-      // `shape` still override these (e.g. primaryContainer action chips, the
-      // circular add button, selected filter chips).
+      // Chips carry a subtle outlineVariant border app-wide and default to a
+      // single neutral tone (surfaceContainerHigh). `side` is set explicitly
+      // because FilterChip/ChoiceChip otherwise paint the Material 3
+      // state-dependent outline (unselected), which overrides `shape.side`.
+      // Per-chip `backgroundColor` / `shape` still override these (e.g.
+      // primaryContainer action chips, the circular add button, selected filter
+      // chips).
       chipTheme: base.chipTheme.copyWith(
         labelStyle: modifyFontWeight(base.chipTheme.labelStyle, offset),
         backgroundColor: base.colorScheme.surfaceContainerHigh,
         selectedColor: base.colorScheme.primaryContainer,
-        side: BorderSide.none,
+        side: BorderSide(color: base.colorScheme.outlineVariant, width: 0.5),
         shape: const StadiumBorder(),
       ),
       // Cards sit on the base surface role app-wide; raised accents (e.g. the

--- a/lib/src/gui/capture.dart
+++ b/lib/src/gui/capture.dart
@@ -507,24 +507,9 @@ class _CapturePageLoaderLayer extends ConsumerWidget {
     );
   }
 
-  Widget error(Object? errorMessage, Object? stackTrace, ThemeData theme) {
+  Widget error(Object? errorMessage, Object? stackTrace) {
     return SingleTileWidget(
-      child: Center(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Text(
-              "$tr_capture.loading_error".tr(),
-              style: TextStyle(color: theme.colorScheme.error),
-              textAlign: TextAlign.center,
-            ),
-            const Divider(),
-            Text(errorMessage.toString()),
-            const Divider(),
-            Text(stackTrace.toString()),
-          ],
-        ),
-      ),
+      child: ErrorLogView(title: "$tr_capture.loading_error".tr(), message: errorMessage, stackTrace: stackTrace),
     );
   }
 
@@ -534,11 +519,10 @@ class _CapturePageLoaderLayer extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
     final loader = ref.watch(platformControllerLoader);
     return loader.when(
       loading: () => loading(),
-      error: (errorMessage, stackTrace) => error(errorMessage, stackTrace, theme),
+      error: (errorMessage, stackTrace) => error(errorMessage, stackTrace),
       data: (_) => data(context, ref),
     );
   }

--- a/lib/src/gui/chara_detail/column_builder_dialog.dart
+++ b/lib/src/gui/chara_detail/column_builder_dialog.dart
@@ -130,13 +130,24 @@ class ColumnBuilderDialog extends ConsumerWidget {
     return chip;
   }
 
-  Widget builderChipCategory(BuildContext context, WidgetRef ref, List<ColumnBuilder> targets) {
+  /// Categories whose chips are homogeneous enough that bulk-adding them all at
+  /// once is useful. Other categories (skills, factors, etc.) mix many unrelated
+  /// presets, so the "add all" shortcut is omitted there.
+  static const _addAllCategories = {ColumnCategory.trainee, ColumnCategory.status, ColumnCategory.aptitude};
+
+  Widget builderChipCategory(
+    BuildContext context,
+    WidgetRef ref,
+    ColumnCategory category,
+    List<ColumnBuilder> targets,
+  ) {
     final theme = Theme.of(context);
     final groups = targets.groupListsBy((e) => e.type);
     final normalBuilders = groups[ColumnBuilderType.normal] ?? [];
     final filterBuilders = groups[ColumnBuilderType.filter] ?? [];
     final addBuilders = groups[ColumnBuilderType.add] ?? [];
     final addAllTargets = normalBuilders.where((e) => e.includeInAddAll).toList();
+    final showAddAll = _addAllCategories.contains(category) && addAllTargets.length >= 2;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -145,7 +156,7 @@ class ColumnBuilderDialog extends ConsumerWidget {
           runSpacing: 16,
           crossAxisAlignment: WrapCrossAlignment.center,
           children: [
-            if (addAllTargets.length >= 2) addAllChipWidget(context, ref, addAllTargets),
+            if (showAddAll) addAllChipWidget(context, ref, addAllTargets),
             for (final builder in normalBuilders) builderChip(context, ref, builder),
           ],
         ),
@@ -231,7 +242,7 @@ class ColumnBuilderDialog extends ConsumerWidget {
               Padding(padding: const EdgeInsets.fromLTRB(16, 8, 16, 0), child: _HintLine(description)),
             Padding(
               padding: const EdgeInsets.all(16),
-              child: builderChipCategory(context, ref, buildersMap[cat] ?? []),
+              child: builderChipCategory(context, ref, cat, buildersMap[cat] ?? []),
             ),
           ],
         ],

--- a/lib/src/gui/chara_detail/data_table_widget.dart
+++ b/lib/src/gui/chara_detail/data_table_widget.dart
@@ -1504,23 +1504,8 @@ class CharaDetailDataTableLoaderLayer extends ConsumerWidget {
     );
   }
 
-  Widget error(Object? errorMessage, Object? stackTrace, ThemeData theme) {
-    return Center(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Text(
-            "$tr_chara_detail.loading_error".tr(),
-            style: TextStyle(color: theme.colorScheme.error),
-            textAlign: TextAlign.center,
-          ),
-          const Divider(),
-          Text(errorMessage.toString()),
-          const Divider(),
-          Text(stackTrace.toString()),
-        ],
-      ),
-    );
+  Widget error(Object? errorMessage, Object? stackTrace) {
+    return ErrorLogView(title: "$tr_chara_detail.loading_error".tr(), message: errorMessage, stackTrace: stackTrace);
   }
 
   Widget data(BuildContext context, WidgetRef ref) {
@@ -1536,7 +1521,6 @@ class CharaDetailDataTableLoaderLayer extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
     final loader = ref.watch(charaDetailInitialDataLoader);
     return loader.when(
       // A background reload of an upstream loader (path/module/record storage)
@@ -1546,7 +1530,7 @@ class CharaDetailDataTableLoaderLayer extends ConsumerWidget {
       // spinner (no previous value to keep).
       skipLoadingOnReload: true,
       loading: () => loading(),
-      error: (errorMessage, stackTrace) => error(errorMessage, stackTrace, theme),
+      error: (errorMessage, stackTrace) => error(errorMessage, stackTrace),
       data: (_) => data(context, ref),
     );
   }

--- a/lib/src/gui/chara_detail/side_preview.dart
+++ b/lib/src/gui/chara_detail/side_preview.dart
@@ -144,7 +144,7 @@ class SidePreviewToggleButton extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 3),
       child: IconButton(
-        icon: Icon(Symbols.dock_to_right_rounded, size: 22, fill: open ? 1 : 0),
+        icon: Icon(Symbols.dock_to_left_rounded, size: 22, fill: open ? 1 : 0),
         tooltip: "$tr_side_panel.toggle.${open ? "close" : "open"}_tooltip".tr(),
         onPressed: () => ref.read(sidePreviewProvider.notifier).set(open ? null : const SidePreviewState()),
         visualDensity: VisualDensity.compact,

--- a/lib/src/gui/common.dart
+++ b/lib/src/gui/common.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '/src/core/sentry_util.dart';
 import '/src/core/utils.dart';
+import '/src/gui/toast.dart';
 
 class ListCard extends StatelessWidget {
   final String? title;
@@ -193,6 +194,52 @@ class ErrorMessageWidget extends StatelessWidget {
               ),
             ),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+/// An in-app error display showing a [title], the error [message], and its
+/// [stackTrace], with a button that copies the full message + stack trace to the
+/// clipboard so users can paste it into a bug report.
+///
+/// Shared by the page loaders (capture, chara detail) so their error views — and
+/// the copy affordance — stay identical.
+class ErrorLogView extends StatelessWidget {
+  final String title;
+  final Object? message;
+  final Object? stackTrace;
+
+  const ErrorLogView({super.key, required this.title, required this.message, required this.stackTrace});
+
+  void _copy() {
+    Clipboard.setData(ClipboardData(text: "$message\n\n$stackTrace"));
+    Toaster.show(ToastData.success(description: "common.error_log.copied".tr()));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(
+            title,
+            style: TextStyle(color: theme.colorScheme.error),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            onPressed: _copy,
+            icon: const Icon(Symbols.content_copy_rounded, size: 18),
+            label: Text("common.error_log.copy_tooltip".tr()),
+          ),
+          const Divider(),
+          Text(message.toString()),
+          const Divider(),
+          Text(stackTrace.toString()),
         ],
       ),
     );

--- a/lib/src/gui/common.dart
+++ b/lib/src/gui/common.dart
@@ -221,7 +221,10 @@ class ErrorLogView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Center(
+    // Scroll vertically: a stack trace is easily taller than the viewport, and
+    // the message/trace text wraps rather than overflowing horizontally.
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
@@ -231,7 +234,7 @@ class ErrorLogView extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 8),
-          OutlinedButton.icon(
+          FilledButton.icon(
             onPressed: _copy,
             icon: const Icon(Symbols.content_copy_rounded, size: 18),
             label: Text("common.error_log.copy_tooltip".tr()),

--- a/lib/src/gui/theme_gallery.dart
+++ b/lib/src/gui/theme_gallery.dart
@@ -533,7 +533,7 @@ const Map<String, String> _roleUsages = {
   'surfaceContainerHighest': 'Raised backgrounds: table menu bar, input fields, module-update, statistics.',
   'outline': 'Borders and dividers: data-table grid lines, preset bar, script frame, settings-group header rules.',
   'outlineVariant':
-      'Faint outlines: the column-chip "settings group" frame and the inset per-row dividers in the column/table settings dialogs.',
+      'Faint outlines: the app-wide chip border (global chipTheme), the column-chip "settings group" frame, and the inset per-row dividers in the column/table settings dialogs.',
   'scrim': 'Dim backdrop behind modal dialogs (DialogLayer).',
   'onInverseSurface': 'Text on the inverse surface (column builder dialog).',
 };


### PR DESCRIPTION
## Summary

UI style adjustments and small refactors across the chara-detail column dialog, app-wide chips, and the loader error views.

- **Shared `ErrorLogView`**: Extract the duplicated error display in the capture and chara-detail page loaders into one widget. It scrolls long stack traces, wraps text instead of overflowing, and adds a filled copy button that puts the full message + stack trace on the clipboard for bug reports. The now-unused `ThemeData` argument is dropped from both `error()` callers.
- **Prune dead `ColumnCategory` entries**: Remove `supportCard`, `family`, and `race`. `supportCard`/`family` were never referenced by any builder; the two `race` builders are folded into the `campaign` category (ordered before fans so it reads winning counts → fans). Corresponding category labels are removed from `ja.json`.
- **Tag-driven builders marked as filters**: Set `type: ColumnBuilderType.filter` on the skill and factor tag-driven builders.
- **Scoped "add all" shortcut**: Only show the bulk "add all" chip for homogeneous categories (trainee, status, aptitude); other categories mix unrelated presets so the shortcut is omitted.
- **App-wide chip border**: Chips now carry a subtle `outlineVariant` 0.5px border instead of being borderless; theme-gallery role usage text updated to match.
- **Side panel toggle icon**: `dock_to_right_rounded` → `dock_to_left_rounded`.

## Verification

- Confirmed no remaining references to the removed `ColumnCategory` values.
- Verified the `type` parameter exists on both tag-driven skill and factor builders.
- `ja.json` parses; no import cycle introduced (`common` → `toast` is one-way).
- Note: a full `dart analyze` was not run to completion (whole-package load timed out locally); please run it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
