### PR TITLE
feat(chara-detail): detect duplicate charas from the factor tab before scrolling

### DIFF
--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -52,7 +52,8 @@
                 "capture_completed_message": "キャプチャに成功しました。ここをクリックすると管理画面に移動します。",
                 "error": {
                     "closed_before_completed": "[エラー] キャプチャ完了前に詳細画面をロストしました。",
-                    "duplicated_character": "[エラー] このウマ娘はすでにキャプチャ済みです。"
+                    "duplicated_character": "[エラー] このウマ娘はすでにキャプチャ済みです。",
+                    "duplicated_character_probe": "[ヒント] このウマ娘は恐らくキャプチャ済みです。キャプチャを継続したい場合はそのまま続けてください。"
                 },
                 "requirement": {
                     "window_size": {

--- a/lib/src/chara_detail/chara_detail_record.dart
+++ b/lib/src/chara_detail/chara_detail_record.dart
@@ -440,12 +440,18 @@ class CharaDetailRecord extends JsonEquatable with CharaDetailRecordMappable {
   }
 
   /// Number of leading self-factors the probe and a stored record must agree on (id and star) for
-  /// the early duplicate check to fire. The factor tab shows ~16 self-factors before scrolling, all
-  /// read top-to-bottom / left-then-right exactly as the full pipeline reads [FactorSet.self], so a
-  /// recapture reproduces this many leading entries reliably. The threshold stays well below the
-  /// visible count so the bottom-most rows — which can be clipped or misrecognized on a single,
-  /// non-stitched frame — never affect the result, while remaining unique enough to avoid collisions.
-  static const int factorProbeMatchThreshold = 10;
+  /// the early duplicate check to fire, for a capture of the given record [type].
+  ///
+  /// The factors are read top-to-bottom / left-then-right exactly as the full pipeline reads
+  /// [FactorSet.self], so a recapture reproduces this many leading entries reliably. The threshold
+  /// stays below the count visible before scrolling so the bottom-most rows — which can be clipped or
+  /// misrecognized on a single, non-stitched frame — never affect the result, while remaining unique
+  /// enough to avoid collisions. [RecordType.friendStandard] uses a shifted factor-tab layout that
+  /// exposes fewer reliable rows, so it keeps a lower threshold; the other types show more rows and
+  /// use a higher, more collision-resistant one.
+  static int factorProbeMatchThreshold(RecordType? type) {
+    return type == RecordType.friendStandard ? 10 : 14;
+  }
 
   /// Length of the leading run of self-factors that exactly match [probeSelf] (id and star).
   ///

--- a/lib/src/chara_detail/chara_detail_record.dart
+++ b/lib/src/chara_detail/chara_detail_record.dart
@@ -461,11 +461,6 @@ class CharaDetailRecord extends JsonEquatable with CharaDetailRecordMappable {
     return common;
   }
 
-  /// Whether [probeSelf] matches this record under the early duplicate check.
-  bool matchesFactorProbe(List<Factor> probeSelf) {
-    return leadingFactorProbeMatch(probeSelf) >= factorProbeMatchThreshold;
-  }
-
   bool isObsoleted(ModuleVersion moduleVersion, bool includeCurrentVersion) {
     final recordVersion = metadata.recognizerVersion.toDateTime();
     final capturedDate = metadata.capturedDate.toDateTime();

--- a/lib/src/chara_detail/chara_detail_record.dart
+++ b/lib/src/chara_detail/chara_detail_record.dart
@@ -439,6 +439,33 @@ class CharaDetailRecord extends JsonEquatable with CharaDetailRecordMappable {
     ].everyIn();
   }
 
+  /// Number of leading self-factors the probe and a stored record must agree on (id and star) for
+  /// the early duplicate check to fire. The factor tab shows ~16 self-factors before scrolling, all
+  /// read top-to-bottom / left-then-right exactly as the full pipeline reads [FactorSet.self], so a
+  /// recapture reproduces this many leading entries reliably. The threshold stays well below the
+  /// visible count so the bottom-most rows — which can be clipped or misrecognized on a single,
+  /// non-stitched frame — never affect the result, while remaining unique enough to avoid collisions.
+  static const int factorProbeMatchThreshold = 10;
+
+  /// Length of the leading run of self-factors that exactly match [probeSelf] (id and star).
+  ///
+  /// The early duplicate check recognizes only the self-factors visible on the factor tab before
+  /// scrolling; this counts how many of them line up with this record's own factors from the top.
+  int leadingFactorProbeMatch(List<Factor> probeSelf) {
+    final self = factors.self;
+    final limit = probeSelf.length < self.length ? probeSelf.length : self.length;
+    var common = 0;
+    while (common < limit && self[common] == probeSelf[common]) {
+      common++;
+    }
+    return common;
+  }
+
+  /// Whether [probeSelf] matches this record under the early duplicate check.
+  bool matchesFactorProbe(List<Factor> probeSelf) {
+    return leadingFactorProbeMatch(probeSelf) >= factorProbeMatchThreshold;
+  }
+
   bool isObsoleted(ModuleVersion moduleVersion, bool includeCurrentVersion) {
     final recordVersion = metadata.recognizerVersion.toDateTime();
     final capturedDate = metadata.capturedDate.toDateTime();

--- a/lib/src/chara_detail/storage.dart
+++ b/lib/src/chara_detail/storage.dart
@@ -314,7 +314,10 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
     if (probeSelf.isEmpty) {
       return false;
     }
-    final activeRecords = state.asData?.value;
+    // Match add()'s view of the active set: fold in any pending batch updates so the probe and the
+    // authoritative dedup agree. `_pendingRecords` already includes the published state when non-null
+    // (see add()); fall back to the published state, staying null (fail-open) until storage loads.
+    final activeRecords = _pendingRecords ?? state.asData?.value;
     if (activeRecords == null) {
       return false;
     }

--- a/lib/src/chara_detail/storage.dart
+++ b/lib/src/chara_detail/storage.dart
@@ -346,7 +346,10 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
       return false;
     }
     _duplicatedCharaEvent.add(_duplicatedCharaEventSequence++);
-    ref.read(charaDetailCaptureStateProvider.notifier).fail("duplicated_character");
+    // Distinct from add()'s "duplicated_character": this fires before scrolling on the looser
+    // leading-factor prefix match, so the message tells the user it is a preliminary check and that
+    // scrolling anyway re-runs the authoritative dedup (which can clear a rare false positive).
+    ref.read(charaDetailCaptureStateProvider.notifier).fail("duplicated_character_probe");
     return true;
   }
 

--- a/lib/src/chara_detail/storage.dart
+++ b/lib/src/chara_detail/storage.dart
@@ -303,6 +303,48 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
     return charaCardMap.map((k, v) => MapEntry(k, (rootDirectory / v.id).filePath(traineeIconFileName)));
   }
 
+  /// Early duplicate check driven by the factor-tab probe (before scrolling).
+  ///
+  /// Returns true and fires the duplicate notification (error sound + capture error) when
+  /// [probeSelf] shares a long enough leading run of self-factors with any stored record (active or
+  /// archived) to clear [CharaDetailRecord.factorProbeMatchThreshold]. Fail-open: if storage is not
+  /// loaded yet or nothing matches it returns false, so the caller emits the normal scroll-ready
+  /// cue. This only notifies; the authoritative dedup still runs in [add] for the full record.
+  bool reportDuplicateFromFactorProbe(List<Factor> probeSelf) {
+    if (probeSelf.isEmpty) {
+      return false;
+    }
+    final activeRecords = state.asData?.value;
+    if (activeRecords == null) {
+      return false;
+    }
+    final archiveRecords =
+        ref.read(charaDetailArchiveStorageLoaderProvider).asData?.value ?? const <CharaDetailRecord>[];
+    final existing = [...activeRecords, ...archiveRecords];
+    var bestMatch = 0;
+    CharaDetailRecord? duplicated;
+    for (final record in existing) {
+      final common = record.leadingFactorProbeMatch(probeSelf);
+      if (common > bestMatch) {
+        bestMatch = common;
+      }
+      if (common >= CharaDetailRecord.factorProbeMatchThreshold) {
+        duplicated = record;
+        break;
+      }
+    }
+    logger.i(
+      "Factor probe: ${probeSelf.length} factors, best leading match "
+      "$bestMatch/${CharaDetailRecord.factorProbeMatchThreshold}, duplicate=${duplicated != null}",
+    );
+    if (duplicated == null) {
+      return false;
+    }
+    _duplicatedCharaEvent.add(_duplicatedCharaEventSequence++);
+    ref.read(charaDetailCaptureStateProvider.notifier).fail("duplicated_character");
+    return true;
+  }
+
   void add(CharaDetailRecord record) {
     final activeRecords = _records;
     // Consider archived records too, so a re-capture of an archived chara is

--- a/lib/src/chara_detail/storage.dart
+++ b/lib/src/chara_detail/storage.dart
@@ -307,10 +307,11 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
   ///
   /// Returns true and fires the duplicate notification (error sound + capture error) when
   /// [probeSelf] shares a long enough leading run of self-factors with any stored record (active or
-  /// archived) to clear [CharaDetailRecord.factorProbeMatchThreshold]. Fail-open: if storage is not
-  /// loaded yet or nothing matches it returns false, so the caller emits the normal scroll-ready
-  /// cue. This only notifies; the authoritative dedup still runs in [add] for the full record.
-  bool reportDuplicateFromFactorProbe(List<Factor> probeSelf) {
+  /// archived) to clear the match threshold for [recordType] (see
+  /// [CharaDetailRecord.factorProbeMatchThreshold]). Fail-open: if storage is not loaded yet or
+  /// nothing matches it returns false, so the caller emits the normal scroll-ready cue. This only
+  /// notifies; the authoritative dedup still runs in [add] for the full record.
+  bool reportDuplicateFromFactorProbe(List<Factor> probeSelf, RecordType? recordType) {
     if (probeSelf.isEmpty) {
       return false;
     }
@@ -321,6 +322,7 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
     if (activeRecords == null) {
       return false;
     }
+    final threshold = CharaDetailRecord.factorProbeMatchThreshold(recordType);
     final archiveRecords =
         ref.read(charaDetailArchiveStorageLoaderProvider).asData?.value ?? const <CharaDetailRecord>[];
     final existing = [...activeRecords, ...archiveRecords];
@@ -331,14 +333,14 @@ class CharaDetailRecordStorage extends AsyncNotifier<List<CharaDetailRecord>> im
       if (common > bestMatch) {
         bestMatch = common;
       }
-      if (common >= CharaDetailRecord.factorProbeMatchThreshold) {
+      if (common >= threshold) {
         duplicated = record;
         break;
       }
     }
     logger.i(
       "Factor probe: ${probeSelf.length} factors, best leading match "
-      "$bestMatch/${CharaDetailRecord.factorProbeMatchThreshold}, duplicate=${duplicated != null}",
+      "$bestMatch/$threshold, duplicate=${duplicated != null}",
     );
     if (duplicated == null) {
       return false;

--- a/lib/src/core/platform_controller.dart
+++ b/lib/src/core/platform_controller.dart
@@ -297,9 +297,15 @@ class PlatformController {
                 .whereType<Map>()
                 .map((e) => FactorMapper.fromMap(Map<String, dynamic>.from(e)))
                 .toList();
+            // The threshold depends on the capture's record type; -1 (or any out-of-range value)
+            // from native maps to null, which falls back to the default (non-friend-standard) threshold.
+            final recordTypeRaw = data['record_type'];
+            final recordType = (recordTypeRaw is int && recordTypeRaw >= 0 && recordTypeRaw < RecordType.values.length)
+                ? RecordType.values[recordTypeRaw]
+                : null;
             final isDuplicate = _ref
                 .read(charaDetailRecordStorageLoaderProvider.notifier)
-                .reportDuplicateFromFactorProbe(probeSelf);
+                .reportDuplicateFromFactorProbe(probeSelf, recordType);
             if (!isDuplicate) {
               _scrollReadyEvent.add(_soundEventSequence++);
             }

--- a/lib/src/core/platform_controller.dart
+++ b/lib/src/core/platform_controller.dart
@@ -284,6 +284,27 @@ class PlatformController {
         case 'onScrollReady':
           _scrollReadyEvent.add(_soundEventSequence++);
           break;
+        case 'onFactorProbe':
+          {
+            // Native deferred the factor-tab scroll-ready cue and instead sent the self-factors
+            // visible before scrolling. Run the early duplicate check: only emit the scroll-ready
+            // cue when it is not a duplicate; otherwise the storage layer raises the duplicate error.
+            final factorsRaw = data['factors'];
+            if (factorsRaw is! List) {
+              break;
+            }
+            final probeSelf = factorsRaw
+                .whereType<Map>()
+                .map((e) => FactorMapper.fromMap(Map<String, dynamic>.from(e)))
+                .toList();
+            final isDuplicate = _ref
+                .read(charaDetailRecordStorageLoaderProvider.notifier)
+                .reportDuplicateFromFactorProbe(probeSelf);
+            if (!isDuplicate) {
+              _scrollReadyEvent.add(_soundEventSequence++);
+            }
+          }
+          break;
         case 'onScrollUpdated':
           {
             final index = data['index'] as int?;

--- a/native/src/chara_detail/chara_detail_recognizer.h
+++ b/native/src/chara_detail/chara_detail_recognizer.h
@@ -338,6 +338,30 @@ public:
         record.trainee = recognizeTrainee(frame, record_info, scan_top, crop_info, history);
     }
 
+    // Recognizes only the trainee's own factors that are fully visible on a single, non-stitched
+    // factor-tab frame (no scrolling). Used by the early duplicate probe: the returned list is a
+    // prefix of the self-factors the full pipeline would read, which is enough to match a recapture.
+    [[nodiscard]] std::vector<record::Factor>
+    recognizeVisibleSelf(const Frame &frame, PredictionHistory &history) const {
+        const auto anchor = frame.anchor();
+
+        const auto top_banner_y = searchVertical(
+            frame,
+            config.bg_color,
+            {
+                anchor.absolute(config.left_rect).left(),
+                anchor.absolute(config.area).top(),
+            },
+            config.vertical_banner_upper_gap);
+        if (!top_banner_y) {
+            log_warning("Failed to find top banner of factor tab.");
+            return {};
+        }
+
+        double scan_top = top_banner_y.value() + config.vertical_banner_bottom_delta;
+        return recognizeOne(frame, scan_top, history, /*bounded=*/true);
+    }
+
 private:
     [[nodiscard]] record::Character recognizeTrainee(
         const Frame &frame,
@@ -370,11 +394,22 @@ private:
         return character;
     }
 
+    // When [bounded] is set the scan stops before any row whose cell rect would fall outside the
+    // frame. The full pipeline runs on a stitched image tall enough to hold every row, so it leaves
+    // [bounded] false and the guard never fires. The early probe runs on a single, non-stitched
+    // frame where the bottom-most visible row is clipped; predicting it would crop past the image
+    // and abort OpenCV, so the probe sets [bounded] to stop at the last fully-visible row.
     [[nodiscard]] std::vector<record::Factor>
-    recognizeOne(const Frame &frame, double &scan_top, PredictionHistory &history) const {
+    recognizeOne(const Frame &frame, double &scan_top, PredictionHistory &history, bool bounded = false) const {
         const auto anchor = frame.anchor();
         const auto left_rect = anchor.absolute(config.left_rect);
         const auto right_rect = anchor.absolute(config.right_rect);
+
+        const auto fits_frame = [&](const Rect<double> &cell, double top) {
+            const auto mapped = anchor.mapToFrame(cell + Point<double>{0, top});
+            return mapped.top() >= 0 && mapped.left() >= 0  //
+                && mapped.bottom() <= frame.height() && mapped.right() <= frame.width();
+        };
 
         std::vector<record::Factor> factors;
         for (;;) {
@@ -385,12 +420,18 @@ private:
             if (!left_column_y) {
                 break;
             }
+            if (bounded && !fits_frame(left_rect, left_column_y.value())) {
+                break;
+            }
             factors.push_back(predictFactor(frame, left_rect, left_column_y.value(), history));
             scan_top = left_column_y.value() + config.vertical_delta;
 
             // Find next row of RIGHT column.
             const auto right_column_y = findNext(frame, right_rect.topLeft().withY(current_scan_top));
             if (!right_column_y) {
+                break;
+            }
+            if (bounded && !fits_frame(right_rect, right_column_y.value())) {
                 break;
             }
             factors.push_back(predictFactor(frame, right_rect, right_column_y.value(), history));
@@ -896,6 +937,8 @@ public:
         const event_util::Sender<RecordInfo> &on_recognize_completed,
         const event_util::Listener<RecordInfo> &on_update_requested,
         const event_util::Sender<RecordInfo> &on_update_completed,
+        const event_util::Listener<Frame, RecordInfo> &on_factor_probe_ready,
+        const event_util::Sender<std::vector<record::Factor>> &on_factor_probe_completed,
         const recognizer_config::CharaDetailRecognizerConfig &config)
         : trainer_id(trainer_id)
         , record_root_dir(record_root_dir)
@@ -908,9 +951,31 @@ public:
         , on_recognize_ready(on_recognize_ready)
         , on_recognize_completed(on_recognize_completed)
         , on_update_requested(on_update_requested)
-        , on_update_completed(on_update_completed) {
+        , on_update_completed(on_update_completed)
+        , on_factor_probe_ready(on_factor_probe_ready)
+        , on_factor_probe_completed(on_factor_probe_completed) {
         this->on_recognize_ready->listen([this](const auto &info) { this->recognize(info, false); });
         this->on_update_requested->listen([this](const auto &info) { this->recognize(info, true); });
+        this->on_factor_probe_ready->listen([this](const auto &frame, const auto &info) { this->probe(frame, info); });
+    }
+
+    // Recognizes only the trainee's own factors visible on a single, non-stitched factor-tab frame
+    // (the stable frame captured at scroll-ready) so the duplicate check can run before scrolling.
+    // Reuses the same FactorTabRecognizer as the full pipeline, bounded to the visible rows; the
+    // result is a prefix of the self-factor list, matched against stored records on the Dart side.
+    void probe(const Frame &frame, const RecordInfo &raw_info) const {
+        vlog_debug(raw_info.record_id, raw_info.record_type.has_value());
+
+        recognizer_impl::PredictionHistory factor_tab_history;
+        auto self_factors = factor_tab_recognizer.recognizeVisibleSelf(frame, factor_tab_history);
+        // Drop the last recognized row: on a non-stitched live frame the bottom-most visible row can
+        // be clipped by the tab boundary, so its star rank is unreliable. The remaining prefix is still
+        // a strong signature and is matched against the leading self-factors of stored records.
+        if (!self_factors.empty()) {
+            self_factors.pop_back();
+        }
+
+        on_factor_probe_completed->send(self_factors);
     }
 
     void recognize(const RecordInfo &raw_info, bool isUpdateMode) const {
@@ -1023,6 +1088,9 @@ private:
 
     const event_util::Listener<RecordInfo> on_update_requested;
     const event_util::Sender<RecordInfo> on_update_completed;
+
+    const event_util::Listener<Frame, RecordInfo> on_factor_probe_ready;
+    const event_util::Sender<std::vector<record::Factor>> on_factor_probe_completed;
 };
 
 }  // namespace uma::chara_detail

--- a/native/src/chara_detail/chara_detail_recognizer.h
+++ b/native/src/chara_detail/chara_detail_recognizer.h
@@ -938,7 +938,7 @@ public:
         const event_util::Listener<RecordInfo> &on_update_requested,
         const event_util::Sender<RecordInfo> &on_update_completed,
         const event_util::Listener<Frame, RecordInfo> &on_factor_probe_ready,
-        const event_util::Sender<std::vector<record::Factor>> &on_factor_probe_completed,
+        const event_util::Sender<std::vector<record::Factor>, int> &on_factor_probe_completed,
         const recognizer_config::CharaDetailRecognizerConfig &config)
         : trainer_id(trainer_id)
         , record_root_dir(record_root_dir)
@@ -975,7 +975,12 @@ public:
             self_factors.pop_back();
         }
 
-        on_factor_probe_completed->send(self_factors);
+        // Forward the record type so the Dart side can pick a per-type match threshold (the factor
+        // tab's visible-row count differs by type). -1 means "unknown", mapped to null on Dart.
+        const int record_type = raw_info.record_type.has_value()  //
+                                  ? static_cast<int>(raw_info.record_type.value())
+                                  : -1;
+        on_factor_probe_completed->send(self_factors, record_type);
     }
 
     void recognize(const RecordInfo &raw_info, bool isUpdateMode) const {
@@ -1090,7 +1095,7 @@ private:
     const event_util::Sender<RecordInfo> on_update_completed;
 
     const event_util::Listener<Frame, RecordInfo> on_factor_probe_ready;
-    const event_util::Sender<std::vector<record::Factor>> on_factor_probe_completed;
+    const event_util::Sender<std::vector<record::Factor>, int> on_factor_probe_completed;
 };
 
 }  // namespace uma::chara_detail

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -787,6 +787,7 @@ public:
         const event_util::Sender<int, double> &on_scroll_updated,
         const event_util::Sender<int> &on_page_ready,
         const event_util::Sender<RecordInfo> &on_completed,
+        const event_util::Sender<Frame, RecordInfo> &on_factor_probe,
         const scraper_config::CharaDetailSceneScraperConfig &config,
         const std::filesystem::path &scraping_dir)
         : on_updated(on_updated)
@@ -797,6 +798,7 @@ public:
         , on_scroll_updated(on_scroll_updated)
         , on_page_ready(on_page_ready)
         , on_completed(on_completed)
+        , on_factor_probe(on_factor_probe)
         , config(config)
         , scraping_root_dir(scraping_dir) {
         this->on_opened->listen([this](const auto &info) { build(info); });
@@ -840,10 +842,19 @@ public:
             on_scroll_ready->bindLeft(TabPage::SkillPage),
             on_scroll_updated->bindLeft(TabPage::SkillPage));
 
+        // The factor tab's scroll-ready does not notify the UI directly. Instead it triggers a
+        // duplicate probe on the current stable full frame: only after that probe reports "not a
+        // duplicate" does the UI emit the scroll-ready cue (synthesized on the Dart side). This
+        // local connection bridges the per-page scraper's argument-less scroll-ready to the probe,
+        // attaching the full-screen frame (the per-page scraper only sees the cropped scroll area).
+        factor_scroll_ready = event_util::makeDirectConnection<>();
+        factor_scroll_ready->listen([this]() {
+            on_factor_probe->send(Frame(current_full_frame), RecordInfo(current_record_info));
+        });
         factor_scraper = std::make_unique<scraper_impl::SceneScraper>(
             common,
             scraping_box->factor_box(),
-            on_scroll_ready->bindLeft(TabPage::FactorPage),
+            factor_scroll_ready,
             on_scroll_updated->bindLeft(TabPage::FactorPage));
 
         campaign_scraper = std::make_unique<scraper_impl::SceneScraper>(
@@ -870,6 +881,11 @@ public:
     void update(const Frame &frame, const SceneState &scene_state) {
         vlog_trace(state.tab_page);
 
+        // Keep the latest full-screen frame so the factor scroll-ready callback (which fires from
+        // deep inside the per-page scraper, where only the cropped scroll area is in scope) can hand
+        // the whole frame to the duplicate probe.
+        current_full_frame = frame;
+
         if (ready()) {  // After ready, do nothing until scene is closed.
             return;
         }
@@ -893,6 +909,7 @@ public:
         factor_scraper = nullptr;
         campaign_scraper = nullptr;
         base_frame_catcher = nullptr;
+        factor_scroll_ready = nullptr;
         scraping_box = nullptr;
         scraping_state = scraper_impl::Null;
     }
@@ -927,6 +944,7 @@ private:
     const event_util::Sender<int, double> on_scroll_updated;  // When user scrolling.
     const event_util::Sender<int> on_page_ready;  // When each page is ready.
     const event_util::Sender<RecordInfo> on_completed;  // When all three pages are ready.
+    const event_util::Sender<Frame, RecordInfo> on_factor_probe;  // Factor tab scroll-ready, for dedup.
 
     const scraper_config::CharaDetailSceneScraperConfig config;
     const std::filesystem::path scraping_root_dir;
@@ -934,6 +952,8 @@ private:
     minimal_uuid4::Generator uuid_generator;
 
     RecordInfo current_record_info = {};
+    Frame current_full_frame = {};
+    event_util::Connection<> factor_scroll_ready;
     std::unique_ptr<scraper_impl::SceneScraper> skill_scraper;
     std::unique_ptr<scraper_impl::SceneScraper> factor_scraper;
     std::unique_ptr<scraper_impl::SceneScraper> campaign_scraper;

--- a/native/src/core/native_api.cpp
+++ b/native/src/core/native_api.cpp
@@ -136,8 +136,9 @@ void NativeApi::startEventLoop(const std::string &native_config) {
     const auto factor_probe_ready_connection = recognizer_runner->makeConnection<Frame, chara_detail::RecordInfo>();
 
     const auto factor_probe_completed_connection =
-        event_util::makeDirectConnection<std::vector<chara_detail::record::Factor>>();
-    factor_probe_completed_connection->listen([this](const auto &factors) { notifyFactorProbe(factors); });
+        event_util::makeDirectConnection<std::vector<chara_detail::record::Factor>, int>();
+    factor_probe_completed_connection->listen(
+        [this](const auto &factors, int record_type) { notifyFactorProbe(factors, record_type); });
 
     const auto scraping_dir = json_util::decodePath(config_json["directory"]["temp_dir"]) / "chara_detail";
 

--- a/native/src/core/native_api.cpp
+++ b/native/src/core/native_api.cpp
@@ -127,6 +127,18 @@ void NativeApi::startEventLoop(const std::string &native_config) {
         lap_time_buffer.clear();
     });
 
+    const auto recognizer_runner =
+        event_util::makeSingleThreadRunner(event_util::QueueLimitMode::NoLimit, detach_callback, "recognizer");
+    event_runners->add(recognizer_runner);
+
+    // Early duplicate probe: the scraper sends the stable factor-tab frame here (recognizer runner),
+    // the recognizer runs only the self-factor recognition on it, and the result is forwarded to the UI.
+    const auto factor_probe_ready_connection = recognizer_runner->makeConnection<Frame, chara_detail::RecordInfo>();
+
+    const auto factor_probe_completed_connection =
+        event_util::makeDirectConnection<std::vector<chara_detail::record::Factor>>();
+    factor_probe_completed_connection->listen([this](const auto &factors) { notifyFactorProbe(factors); });
+
     const auto scraping_dir = json_util::decodePath(config_json["directory"]["temp_dir"]) / "chara_detail";
 
     chara_detail_scene_scraper = std::make_unique<chara_detail::CharaDetailSceneScraper>(
@@ -138,12 +150,9 @@ void NativeApi::startEventLoop(const std::string &native_config) {
         scroll_updated_connection,
         page_ready_connection,
         stitch_ready_connection,
+        factor_probe_ready_connection,
         config_json["chara_detail"]["scene_scraper"].get<chara_detail::scraper_config::CharaDetailSceneScraperConfig>(),
         scraping_dir);
-
-    const auto recognizer_runner =
-        event_util::makeSingleThreadRunner(event_util::QueueLimitMode::NoLimit, detach_callback, "recognizer");
-    event_runners->add(recognizer_runner);
 
     const auto recognize_ready_connection = recognizer_runner->makeConnection<chara_detail::RecordInfo>();
     on_recognize_ready = recognize_ready_connection;
@@ -177,6 +186,8 @@ void NativeApi::startEventLoop(const std::string &native_config) {
         recognize_completed_connection,
         update_ready_connection,
         update_completed_connection,
+        factor_probe_ready_connection,
+        factor_probe_completed_connection,
         config_json["chara_detail"]["recognizer"].get<chara_detail::recognizer_config::CharaDetailRecognizerConfig>());
 
     event_runners->start();

--- a/native/src/core/native_api.h
+++ b/native/src/core/native_api.h
@@ -71,8 +71,8 @@ public:
 
     void notifyPageReady(int index) { notify(json_util::Json{{"type", "onPageReady"}, {"index", index}}.dump()); }
 
-    void notifyFactorProbe(const std::vector<chara_detail::record::Factor> &factors) {
-        notify(json_util::Json{{"type", "onFactorProbe"}, {"factors", factors}}.dump());
+    void notifyFactorProbe(const std::vector<chara_detail::record::Factor> &factors, int record_type) {
+        notify(json_util::Json{{"type", "onFactorProbe"}, {"factors", factors}, {"record_type", record_type}}.dump());
     }
 
     void notifyCharaDetailStarted(chara_detail::record::RecordType record_type) {

--- a/native/src/core/native_api.h
+++ b/native/src/core/native_api.h
@@ -71,6 +71,10 @@ public:
 
     void notifyPageReady(int index) { notify(json_util::Json{{"type", "onPageReady"}, {"index", index}}.dump()); }
 
+    void notifyFactorProbe(const std::vector<chara_detail::record::Factor> &factors) {
+        notify(json_util::Json{{"type", "onFactorProbe"}, {"factors", factors}}.dump());
+    }
+
     void notifyCharaDetailStarted(chara_detail::record::RecordType record_type) {
         notify(json_util::Json{{"type", "onCharaDetailStarted"}, {"record_type", static_cast<int>(record_type)}}.dump());
     }

--- a/test/factor_probe_match_test.dart
+++ b/test/factor_probe_match_test.dart
@@ -1,0 +1,125 @@
+// Verifies the early duplicate probe's prefix-matching primitive on
+// CharaDetailRecord: leadingFactorProbeMatch counts the leading run of
+// self-factors (id and star) shared with a probe, and the factorProbeMatchThreshold
+// constant gates the duplicate decision the storage layer makes with that count.
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/factor_probe_match_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/chara_detail/chara_detail_record.dart';
+
+Character _chara(int card) => Character(0, 0, card, 0);
+
+Parent _parent(int card) => Parent(_chara(card), _chara(0), _chara(0), null);
+
+// Builds a record carrying only the self-factors the probe reads; everything
+// else is dummy. Mirrors the minimal builder in family_registration_test.dart.
+CharaDetailRecord makeRecord({required List<Factor> self}) {
+  final metadata = Metadata(
+    '1.0.0',
+    'JPN',
+    const RecordId('id', null, null),
+    'trainer',
+    '2026-01-01T00:00:00+0900',
+    '2026-01-01T00:00:00+0900',
+    RecordStage.active,
+    0,
+    null,
+    RecordType.standard,
+  );
+  return CharaDetailRecord(
+    metadata,
+    _chara(1),
+    0,
+    const CharacterStatus(0, 0, 0, 0, 0),
+    const AptitudeSet(GroundAptitude(0, 0), DistanceAptitude(0, 0, 0, 0), StyleAptitude(0, 0, 0, 0)),
+    const <Skill>[],
+    FactorSet(self, const [], const []),
+    const <SupportCard>[],
+    Family(_parent(0), _parent(0)),
+    0,
+    const Scenario(0),
+    null,
+    null,
+    '2026/01/01',
+    const <Race>[],
+  );
+}
+
+void main() {
+  group('leadingFactorProbeMatch', () {
+    test('identical probe matches the full self length', () {
+      final self = [const Factor(1, 1), const Factor(2, 2), const Factor(3, 3)];
+      final record = makeRecord(self: self);
+
+      expect(record.leadingFactorProbeMatch([...self]), self.length);
+    });
+
+    test('stops at the first diverging star', () {
+      final record = makeRecord(self: [const Factor(1, 1), const Factor(2, 2), const Factor(3, 3)]);
+
+      // Same ids, but the second star differs.
+      expect(record.leadingFactorProbeMatch([const Factor(1, 1), const Factor(2, 9)]), 1);
+    });
+
+    test('stops at the first diverging id', () {
+      final record = makeRecord(self: [const Factor(1, 1), const Factor(2, 2), const Factor(3, 3)]);
+
+      // Same stars, but the second id differs.
+      expect(record.leadingFactorProbeMatch([const Factor(1, 1), const Factor(9, 2)]), 1);
+    });
+
+    test('returns zero when the first factor already differs', () {
+      final record = makeRecord(self: [const Factor(1, 1), const Factor(2, 2)]);
+
+      expect(record.leadingFactorProbeMatch([const Factor(9, 9), const Factor(1, 1)]), 0);
+    });
+
+    test('empty probe returns zero', () {
+      final record = makeRecord(self: [const Factor(1, 1), const Factor(2, 2)]);
+
+      expect(record.leadingFactorProbeMatch(const []), 0);
+    });
+
+    test('empty self returns zero for any probe', () {
+      final record = makeRecord(self: const []);
+
+      expect(record.leadingFactorProbeMatch([const Factor(1, 1)]), 0);
+    });
+
+    test('caps the count at min(self, probe) length', () {
+      final self = [const Factor(1, 1), const Factor(2, 2), const Factor(3, 3)];
+
+      // Probe longer than self: capped at self length.
+      expect(makeRecord(self: self).leadingFactorProbeMatch([...self, const Factor(4, 4)]), self.length);
+
+      // Probe shorter than self: capped at probe length.
+      expect(makeRecord(self: self).leadingFactorProbeMatch([const Factor(1, 1), const Factor(2, 2)]), 2);
+    });
+  });
+
+  group('factorProbeMatchThreshold gating', () {
+    // The storage layer treats a record as a duplicate when the leading match
+    // reaches the threshold; document that boundary with the same expression.
+    List<Factor> factors(int count) => [for (var i = 0; i < count; i++) Factor(i, i % 3)];
+
+    test('a leading run at the threshold counts as a duplicate', () {
+      final shared = factors(CharaDetailRecord.factorProbeMatchThreshold);
+      final record = makeRecord(self: [...shared, const Factor(999, 1)]);
+
+      final match = record.leadingFactorProbeMatch(shared);
+      expect(match, CharaDetailRecord.factorProbeMatchThreshold);
+      expect(match >= CharaDetailRecord.factorProbeMatchThreshold, isTrue);
+    });
+
+    test('a leading run one short of the threshold is not a duplicate', () {
+      final shared = factors(CharaDetailRecord.factorProbeMatchThreshold - 1);
+      // Diverge right after the shared prefix so the run stops one short.
+      final record = makeRecord(self: [...shared, const Factor(999, 1)]);
+      final probe = [...shared, const Factor(998, 2)];
+
+      final match = record.leadingFactorProbeMatch(probe);
+      expect(match, CharaDetailRecord.factorProbeMatchThreshold - 1);
+      expect(match >= CharaDetailRecord.factorProbeMatchThreshold, isFalse);
+    });
+  });
+}

--- a/test/factor_probe_match_test.dart
+++ b/test/factor_probe_match_test.dart
@@ -1,7 +1,8 @@
 // Verifies the early duplicate probe's prefix-matching primitive on
 // CharaDetailRecord: leadingFactorProbeMatch counts the leading run of
-// self-factors (id and star) shared with a probe, and the factorProbeMatchThreshold
-// constant gates the duplicate decision the storage layer makes with that count.
+// self-factors (id and star) shared with a probe, and the per-record-type
+// factorProbeMatchThreshold gates the duplicate decision the storage layer
+// makes with that count.
 //
 // Run: .fvm/flutter_sdk/bin/flutter test test/factor_probe_match_test.dart
 import 'package:flutter_test/flutter_test.dart';
@@ -97,29 +98,43 @@ void main() {
     });
   });
 
+  group('factorProbeMatchThreshold', () {
+    test('friendStandard uses the lower threshold', () {
+      expect(CharaDetailRecord.factorProbeMatchThreshold(RecordType.friendStandard), 10);
+    });
+
+    test('the other record types use the higher threshold', () {
+      for (final type in [RecordType.standard, RecordType.inheritanceOnly, RecordType.friendInheritance, null]) {
+        expect(CharaDetailRecord.factorProbeMatchThreshold(type), 14);
+      }
+    });
+  });
+
   group('factorProbeMatchThreshold gating', () {
     // The storage layer treats a record as a duplicate when the leading match
-    // reaches the threshold; document that boundary with the same expression.
+    // reaches the per-type threshold; document that boundary with the same expression.
     List<Factor> factors(int count) => [for (var i = 0; i < count; i++) Factor(i, i % 3)];
 
-    test('a leading run at the threshold counts as a duplicate', () {
-      final shared = factors(CharaDetailRecord.factorProbeMatchThreshold);
-      final record = makeRecord(self: [...shared, const Factor(999, 1)]);
+    for (final (type, threshold) in [(RecordType.friendStandard, 10), (RecordType.standard, 14)]) {
+      test('$type: a leading run at the threshold counts as a duplicate', () {
+        final shared = factors(threshold);
+        final record = makeRecord(self: [...shared, const Factor(999, 1)]);
 
-      final match = record.leadingFactorProbeMatch(shared);
-      expect(match, CharaDetailRecord.factorProbeMatchThreshold);
-      expect(match >= CharaDetailRecord.factorProbeMatchThreshold, isTrue);
-    });
+        final match = record.leadingFactorProbeMatch(shared);
+        expect(match, threshold);
+        expect(match >= CharaDetailRecord.factorProbeMatchThreshold(type), isTrue);
+      });
 
-    test('a leading run one short of the threshold is not a duplicate', () {
-      final shared = factors(CharaDetailRecord.factorProbeMatchThreshold - 1);
-      // Diverge right after the shared prefix so the run stops one short.
-      final record = makeRecord(self: [...shared, const Factor(999, 1)]);
-      final probe = [...shared, const Factor(998, 2)];
+      test('$type: a leading run one short of the threshold is not a duplicate', () {
+        final shared = factors(threshold - 1);
+        // Diverge right after the shared prefix so the run stops one short.
+        final record = makeRecord(self: [...shared, const Factor(999, 1)]);
+        final probe = [...shared, const Factor(998, 2)];
 
-      final match = record.leadingFactorProbeMatch(probe);
-      expect(match, CharaDetailRecord.factorProbeMatchThreshold - 1);
-      expect(match >= CharaDetailRecord.factorProbeMatchThreshold, isFalse);
-    });
+        final match = record.leadingFactorProbeMatch(probe);
+        expect(match, threshold - 1);
+        expect(match >= CharaDetailRecord.factorProbeMatchThreshold(type), isFalse);
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary

Adds an early duplicate check that runs on the factor tab **before the user scrolls**, so a recapture of an already-stored chara is flagged immediately instead of only after the full scroll-and-stitch pipeline completes.

When the factor tab reaches scroll-ready, native recognizes only the trainee's own factors visible on the single, non-stitched frame and forwards that prefix (plus the record type) to Dart. The storage layer matches it against the leading self-factors of every stored record (active + archived); if a long enough leading run agrees on id and star, it raises a distinct, advisory duplicate notification. Otherwise the normal scroll-ready cue fires.

## How it works

- **Native recognition** (`chara_detail_recognizer.h`): `recognizeVisibleSelf` runs the existing `FactorTabRecognizer` in a new `bounded` mode that stops before any row whose cell rect would fall outside the frame (a non-stitched live frame clips the bottom row, and predicting it would crop past the image and abort OpenCV). The probe additionally drops the last recognized row, since its star rank near the tab boundary is unreliable.
- **Scraper wiring** (`chara_detail_scene_scraper.h`): the factor tab's scroll-ready is rerouted through a local connection that attaches the latest full-screen frame and hands it to the probe; only a "not a duplicate" result lets the UI emit the scroll-ready cue.
- **Threading** (`native_api.cpp`): the probe runs on the recognizer runner; the stable frame is copied across the thread boundary and the result is forwarded to the UI as `onFactorProbe`.
- **Dart matching** (`chara_detail_record.dart`, `storage.dart`, `platform_controller.dart`): `leadingFactorProbeMatch` counts the shared leading run; `factorProbeMatchThreshold` gates the decision per record type (`friendStandard` uses a lower threshold because its shifted factor-tab layout exposes fewer reliable rows). The check is **fail-open** and **advisory only** — the authoritative dedup still runs in `add()` for the full record, so scrolling anyway re-checks and can clear a rare false positive.

## Design notes

- **Fail-open**: storage not loaded, empty probe, or no match all return false and emit the normal cue.
- **Threshold below visible-row count**: the bottom-most rows (clipped or misrecognized on a single frame) never affect the result, while a leading run of 10/14 id+star matches stays collision-resistant.
- **Distinct message**: `duplicated_character_probe` tells the user this is a preliminary check and that continuing re-runs the authoritative dedup, instead of reusing `add()`'s hard `duplicated_character`.

## Tests

`test/factor_probe_match_test.dart` covers the Dart prefix-matching primitive and the per-type threshold gating, including boundary cases (divergence on id vs star, empty probe/self, min-length capping, at-threshold vs one-short).

The native recognition path (`recognizeVisibleSelf`, the `bounded` guard, the `friendStandard` layout) depends on real captures and is exercised manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
