### PR TITLE
test: expand Dart unit coverage, share test helpers, and measure coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,15 @@ jobs:
         run: dart format --output=none --set-exit-if-changed lib test
 
       # Unit/widget only. The Windows-desktop integration_test (needs a full app build + uv)
-      # is intentionally excluded.
+      # is intentionally excluded. --coverage emits coverage/lcov.info for visibility
+      # (mirrors the native OpenCppCoverage artifact); no threshold is enforced yet.
       - name: Run tests
-        run: flutter test test
+        run: flutter test --coverage test
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flutter-coverage
+          path: coverage
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,26 @@ jobs:
           & native\cmake-build-tests\umacapture_tests.exe 2>&1 |
             Select-String -Pattern 'test cases:|assertions:|Status:'
 
-      # ---- P2: coverage visibility (non-gating) ----
+      # ---- P2: coverage visibility ----
+      # The chocolatey community feed intermittently 504s, and `choco install`
+      # exits 0 even when it fetched 0 packages, so a transient outage would
+      # otherwise sail past this step and only surface as a confusing "exe not
+      # found" in "Measure coverage". Retry until the binary actually exists, and
+      # fail loudly if it never appears -- coverage is never silently skipped: a
+      # persistent feed outage gates the job (red) rather than passing green.
       - name: Install OpenCppCoverage
-        run: choco install opencppcoverage -y
+        shell: pwsh
+        run: |
+          $exe = "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe"
+          foreach ($attempt in 1..5) {
+            Write-Host "Installing OpenCppCoverage (attempt $attempt/5)..."
+            choco install opencppcoverage -y --no-progress
+            if (Test-Path $exe) { exit 0 }
+            Write-Warning "OpenCppCoverage not present after attempt $attempt (chocolatey feed may be flaky); retrying in 30s..."
+            Start-Sleep -Seconds 30
+          }
+          Write-Error "OpenCppCoverage could not be installed after 5 attempts; failing so coverage is not silently skipped."
+          exit 1
 
       # Re-runs the Debug test binary under instrumentation and exports HTML + Cobertura.
       # --sources native\src keeps the report to backend code (substring match excludes

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ lib/*.g.dart
 
 # Local working notes (kept out of version control)
 .notes/
+
+# Flutter test coverage output
+coverage/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1101,7 +1101,7 @@ packages:
     source: hosted
     version: "2.2.2"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
@@ -1149,7 +1149,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,6 +81,10 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_oss_licenses: ^3.2.0
   msix: ^3.6.3
+  # Test-only: lets bootstrap_test fake getApplicationSupportDirectory by
+  # swapping PathProviderPlatform.instance (see test/bootstrap_test.dart).
+  path_provider_platform_interface: ^2.1.3
+  plugin_platform_interface: ^2.1.8
 
 
 flutter:

--- a/test/addon_execution_test.dart
+++ b/test/addon_execution_test.dart
@@ -23,9 +23,7 @@ import 'package:umacapture/src/core/path_entity.dart';
 import 'package:umacapture/src/core/providers.dart';
 import 'package:umacapture/src/core/utils.dart';
 
-/// Exposes a [RefBase] from a container so `enrichPayload`/`resolveRecordById`
-/// (which take a RefBase, not a ProviderContainer) can be called in tests.
-final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+import 'support/riverpod.dart';
 
 void main() {
   setUpAll(initializeMappers);
@@ -453,7 +451,7 @@ void main() {
       File('${dir.path}/record.json').writeAsStringSync(fixtureJson);
     }
 
-    RefBase refOf(ProviderContainer container) => container.read(_refBaseProvider);
+    RefBase refOf(ProviderContainer container) => container.read(refBaseProvider);
 
     test('adds the modules_dir placeholder for any trigger, even without a record_id', () {
       final container = ProviderContainer.test(overrides: [pathInfoProvider.overrideWithValue(pathInfo())]);

--- a/test/addon_runner_test.dart
+++ b/test/addon_runner_test.dart
@@ -18,9 +18,7 @@ import 'package:umacapture/src/core/utils.dart';
 import 'package:umacapture/src/gui/addon.dart' show formatHistoryTimestamp;
 import 'package:umacapture/src/gui/addon/task_dialog.dart';
 
-/// Exposes a [RefBase] so the runners (which take one) can be called in tests.
-/// Both runners ignore it for these cases, but the signature requires it.
-final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+import 'support/riverpod.dart';
 
 void main() {
   group('WebhookRunner.start', () {
@@ -35,7 +33,7 @@ void main() {
       port = server.port;
       server.listen((request) => handler(request));
       container = ProviderContainer.test();
-      ref = container.read(_refBaseProvider);
+      ref = container.read(refBaseProvider);
     });
 
     tearDown(() async {
@@ -196,7 +194,7 @@ void main() {
 
     setUp(() {
       container = ProviderContainer.test();
-      ref = container.read(_refBaseProvider);
+      ref = container.read(refBaseProvider);
     });
     tearDown(() => container.dispose());
 

--- a/test/addon_tasks_test.dart
+++ b/test/addon_tasks_test.dart
@@ -4,7 +4,6 @@
 //
 // Run: .fvm/flutter_sdk/bin/flutter test test/addon_tasks_test.dart
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -26,9 +25,8 @@ import 'package:umacapture/src/chara_detail/storage.dart';
 import 'package:umacapture/src/core/mapper_init.dart';
 import 'package:umacapture/src/core/utils.dart';
 
-/// Exposes a [RefBase] from a container so runners that take a RefBase can be
-/// called in tests (mirrors test/addon_execution_test.dart).
-final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+import 'support/records.dart';
+import 'support/riverpod.dart';
 
 /// A controllable [ActionRunner] for execution-controller tests: it never starts
 /// real work; the test drives its progress and completion explicitly.
@@ -87,18 +85,6 @@ class _FakeRecordStorage extends CharaDetailRecordStorage {
 
   @override
   Future<List<CharaDetailRecord>> build() async => preloaded;
-}
-
-/// A copy of the fixture record with its id and captured date replaced, so a
-/// test can hold multiple distinct records.
-CharaDetailRecord _recordVariant(String id, String capturedDate) {
-  final map = (jsonDecode(File('test/fixtures/chara_detail_record.json').readAsStringSync()) as Map)
-      .cast<String, dynamic>();
-  final metadata = (map['metadata'] as Map).cast<String, dynamic>();
-  (metadata['record_id'] as Map)['self'] = id;
-  metadata['captured_date'] = capturedDate;
-  map['metadata'] = metadata;
-  return CharaDetailRecordMapper.fromMap(map);
 }
 
 void main() {
@@ -230,7 +216,7 @@ void main() {
 
     setUp(() {
       container = ProviderContainer.test();
-      ref = container.read(_refBaseProvider);
+      ref = container.read(refBaseProvider);
     });
     tearDown(() => container.dispose());
 
@@ -275,7 +261,7 @@ void main() {
 
       final handle = const BuiltinRunner(
         BuiltinAction(actionKey: 'stuck_timeout'),
-      ).start(timedContainer.read(_refBaseProvider), const {});
+      ).start(timedContainer.read(refBaseProvider), const {});
       final result = await handle.result;
       expect(result.status, ExecutionStatus.timeout);
     });
@@ -543,8 +529,8 @@ void main() {
     });
 
     test('runManual supplies the latest record by captured date', () async {
-      final older = _recordVariant('rec-old', '2026-01-01T10:00:00+0900');
-      final newest = _recordVariant('rec-new', '2026-06-01T10:00:00+0900');
+      final older = recordFromFixture('rec-old', '2026-01-01T10:00:00+0900');
+      final newest = recordFromFixture('rec-new', '2026-06-01T10:00:00+0900');
       // Insertion order is deliberately not capture order: startup load order is
       // filesystem-dependent, so the pick must go by captured date.
       final h = harness(records: [newest, older]);

--- a/test/bootstrap_test.dart
+++ b/test/bootstrap_test.dart
@@ -1,0 +1,189 @@
+// Covers the data-root bootstrap: reading and writing the fixed
+// `data_root.json` override that decides where the app stores its data before
+// Hive opens. A wrong result here loses track of where the user's data lives,
+// so every fallback branch (missing file, malformed JSON, unreachable drive) is
+// pinned here.
+//
+// The fixed file lives under getApplicationSupportDirectory(), which is not
+// implemented on the test host, so a fake PathProviderPlatform points it at a
+// per-test temp directory. `_bootstrapFile()` is private, so this override is
+// the only seam for controlling the file's location.
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/bootstrap_test.dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:umacapture/src/core/bootstrap.dart';
+
+class _FakePathProvider extends PathProviderPlatform with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.supportPath);
+
+  final String supportPath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => supportPath;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory supportDir;
+  final tempDirs = <Directory>[];
+
+  Directory makeTempDir(String prefix) {
+    final dir = Directory.systemTemp.createTempSync(prefix);
+    tempDirs.add(dir);
+    return dir;
+  }
+
+  File bootstrapFile() => File(p.join(supportDir.path, bootstrapFileName));
+
+  void writeBootstrap(String content) => bootstrapFile().writeAsStringSync(content);
+
+  setUp(() {
+    supportDir = makeTempDir('umacapture_bootstrap_support');
+    PathProviderPlatform.instance = _FakePathProvider(supportDir.path);
+    // Every entry point resets these globals; start each test from the same
+    // baseline so cross-test leakage can't mask a bug.
+    resolvedDataRoot = null;
+    dataRootDegraded = false;
+    configuredDataRoot = null;
+  });
+
+  tearDown(() {
+    for (final dir in tempDirs) {
+      if (dir.existsSync()) {
+        dir.deleteSync(recursive: true);
+      }
+    }
+    tempDirs.clear();
+  });
+
+  group('sampleBootstrapContent', () {
+    test('produces valid JSON with the current schema version and key', () {
+      final decoded = jsonDecode(sampleBootstrapContent(r'C:\Users\me\uma')) as Map<String, dynamic>;
+      expect(decoded['version'], 1);
+      expect(decoded['data_root'], r'C:\Users\me\uma');
+    });
+
+    test('escapes Windows backslashes so the sample is copy-pasteable', () {
+      // The raw encoder output must contain escaped backslashes; decoding it back
+      // must recover the original path unchanged.
+      final raw = sampleBootstrapContent(r'C:\data\uma');
+      expect(raw.contains(r'\\'), isTrue);
+      expect(jsonDecode(raw)['data_root'], r'C:\data\uma');
+    });
+  });
+
+  group('readDataRootOverride', () {
+    test('returns null and leaves globals pristine when the file is missing', () async {
+      final result = await readDataRootOverride();
+
+      expect(result, isNull);
+      expect(resolvedDataRoot, isNull);
+      expect(dataRootDegraded, isFalse);
+      expect(configuredDataRoot, isNull);
+    });
+
+    test('resolves a recorded root that exists right now', () async {
+      final dataRoot = makeTempDir('umacapture_bootstrap_data');
+      writeBootstrap(sampleBootstrapContent(dataRoot.path));
+
+      final result = await readDataRootOverride();
+
+      expect(result, dataRoot.path);
+      expect(resolvedDataRoot, dataRoot.path);
+      expect(dataRootDegraded, isFalse);
+      expect(configuredDataRoot, dataRoot.path);
+    });
+
+    test('degrades when the recorded root is absolute but unreachable', () async {
+      final missing = p.join(supportDir.path, 'unplugged_drive_root');
+      writeBootstrap(sampleBootstrapContent(missing));
+
+      final result = await readDataRootOverride();
+
+      expect(result, isNull);
+      expect(resolvedDataRoot, isNull);
+      // Degraded, not silently ignored: the UI needs to name the missing root.
+      expect(dataRootDegraded, isTrue);
+      expect(configuredDataRoot, missing);
+    });
+
+    test('degrades on a relative path rather than resolving it against the cwd', () async {
+      writeBootstrap(sampleBootstrapContent('relative/data'));
+
+      final result = await readDataRootOverride();
+
+      expect(result, isNull);
+      expect(dataRootDegraded, isTrue);
+      expect(configuredDataRoot, 'relative/data');
+    });
+
+    test('falls back cleanly on malformed JSON', () async {
+      writeBootstrap('{ this is not json');
+
+      final result = await readDataRootOverride();
+
+      expect(result, isNull);
+      expect(resolvedDataRoot, isNull);
+      // A parse failure is not a degraded external drive; it must not warn.
+      expect(dataRootDegraded, isFalse);
+      expect(configuredDataRoot, isNull);
+    });
+
+    test('falls back when data_root is not a string', () async {
+      writeBootstrap(jsonEncode({'version': 1, 'data_root': 123}));
+
+      final result = await readDataRootOverride();
+
+      expect(result, isNull);
+      expect(dataRootDegraded, isFalse);
+      expect(configuredDataRoot, isNull);
+    });
+
+    test('falls back when data_root is blank', () async {
+      writeBootstrap(jsonEncode({'version': 1, 'data_root': '   '}));
+
+      final result = await readDataRootOverride();
+
+      expect(result, isNull);
+      expect(dataRootDegraded, isFalse);
+      expect(configuredDataRoot, isNull);
+    });
+  });
+
+  group('writeDataRootOverride', () {
+    test('persists the override and reads back the same root', () async {
+      final dataRoot = makeTempDir('umacapture_bootstrap_data');
+
+      await writeDataRootOverride(dataRoot.path);
+
+      final onDisk = jsonDecode(bootstrapFile().readAsStringSync()) as Map<String, dynamic>;
+      expect(onDisk['version'], 1);
+      expect(onDisk['data_root'], dataRoot.path);
+      expect(resolvedDataRoot, dataRoot.path);
+      expect(configuredDataRoot, dataRoot.path);
+
+      // A fresh read must agree with what was just written.
+      expect(await readDataRootOverride(), dataRoot.path);
+    });
+
+    test('clears the override and resets globals when passed null', () async {
+      final dataRoot = makeTempDir('umacapture_bootstrap_data');
+      await writeDataRootOverride(dataRoot.path);
+      expect(bootstrapFile().existsSync(), isTrue);
+
+      await writeDataRootOverride(null);
+
+      expect(bootstrapFile().existsSync(), isFalse);
+      expect(resolvedDataRoot, isNull);
+      expect(configuredDataRoot, isNull);
+      expect(dataRootDegraded, isFalse);
+    });
+  });
+}

--- a/test/callback_test.dart
+++ b/test/callback_test.dart
@@ -1,0 +1,74 @@
+// Unit tests for the small callback utilities: the value-binding extension and
+// the ChangeNotifier subclass that re-exposes notifyListeners().
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/callback_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/core/callback.dart';
+
+void main() {
+  group('CallbackExtension.bind', () {
+    test('captures the value and forwards it on each call', () {
+      final received = <int>[];
+      final Callback<int> callback = received.add;
+
+      final bound = callback.bind(7);
+      bound();
+      bound();
+
+      expect(received, [7, 7]);
+    });
+
+    test('separate bindings of the same callback stay independent', () {
+      final received = <String>[];
+      final Callback<String> callback = received.add;
+
+      callback.bind('a')();
+      callback.bind('b')();
+
+      expect(received, ['a', 'b']);
+    });
+
+    test('binds a null value for a nullable callback', () {
+      int? seen = -1;
+      void capture(int? value) => seen = value;
+
+      capture.bind(null)();
+
+      expect(seen, isNull);
+    });
+  });
+
+  group('PlainChangeNotifier', () {
+    test('notifies every registered listener on each call', () {
+      final notifier = PlainChangeNotifier();
+      var a = 0;
+      var b = 0;
+      notifier.addListener(() => a++);
+      notifier.addListener(() => b++);
+
+      notifier.notifyListeners();
+      notifier.notifyListeners();
+
+      expect(a, 2);
+      expect(b, 2);
+    });
+
+    test('a removed listener no longer fires', () {
+      final notifier = PlainChangeNotifier();
+      var count = 0;
+      void listener() => count++;
+      notifier.addListener(listener);
+
+      notifier.notifyListeners();
+      notifier.removeListener(listener);
+      notifier.notifyListeners();
+
+      expect(count, 1);
+    });
+
+    test('notifying after dispose throws (ChangeNotifier contract)', () {
+      final notifier = PlainChangeNotifier()..dispose();
+      expect(notifier.notifyListeners, throwsFlutterError);
+    });
+  });
+}

--- a/test/character_spec_test.dart
+++ b/test/character_spec_test.dart
@@ -1,0 +1,117 @@
+// Covers the character-card column: its reject-list predicate, evaluation,
+// immutable copy/filter-reset helpers, and serialization round-trip. A wrong
+// predicate silently hides or shows the wrong trainees, and a lossy round-trip
+// would flag a healthy saved column as broken.
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/character_spec_test.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/chara_detail/spec/base.dart';
+import 'package:umacapture/src/chara_detail/spec/character.dart';
+import 'package:umacapture/src/chara_detail/spec/parser.dart';
+import 'package:umacapture/src/core/mapper_init.dart';
+import 'package:umacapture/src/core/utils.dart';
+
+final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+
+CharacterCardColumnSpec makeSpec({
+  CharacterCardPredicate? predicate,
+  bool hidden = false,
+  String? description,
+  double? width,
+}) {
+  return CharacterCardColumnSpec(
+    id: 'character-id',
+    title: 'Character',
+    parser: CharaCardParser(),
+    predicate: predicate ?? CharacterCardPredicate.any(),
+    hidden: hidden,
+    description: description,
+    width: width,
+  );
+}
+
+void main() {
+  setUpAll(initializeMappers);
+
+  group('CharacterCardPredicate', () {
+    test('any() accepts every id and rejects nothing', () {
+      final predicate = CharacterCardPredicate.any();
+      expect(predicate.rejects, isEmpty);
+      expect(predicate.apply(1), isTrue);
+      expect(predicate.apply(9999), isTrue);
+    });
+
+    test('rejects only the listed ids', () {
+      final predicate = CharacterCardPredicate(rejects: {1, 2, 3});
+      expect(predicate.apply(1), isFalse);
+      expect(predicate.apply(3), isFalse);
+      expect(predicate.apply(4), isTrue);
+    });
+
+    test('an empty reject set behaves like any()', () {
+      expect(CharacterCardPredicate(rejects: const {}).apply(42), isTrue);
+    });
+  });
+
+  group('CharacterCardColumnSpec.evaluate', () {
+    test('applies the predicate to each value in order', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+      final ref = container.read(_refBaseProvider);
+
+      final spec = makeSpec(predicate: CharacterCardPredicate(rejects: {100}));
+      expect(spec.evaluate(ref, [100, 200, 100, 300]), [isFalse, isTrue, isFalse, isTrue]);
+    });
+  });
+
+  group('CharacterCardColumnSpec.copyWith', () {
+    test('updates only the named field and preserves the rest', () {
+      final original = makeSpec(
+        predicate: CharacterCardPredicate(rejects: {1}),
+        hidden: true,
+        description: 'a note',
+        width: 240.0,
+      );
+
+      final copied = original.copyWith(title: 'Renamed');
+
+      expect(copied.title, 'Renamed');
+      expect(copied.hidden, isTrue);
+      expect(copied.description, 'a note');
+      expect(copied.width, 240.0);
+      expect(copied.predicate.rejects, {1});
+    });
+  });
+
+  group('CharacterCardColumnSpec.withFilterReset', () {
+    test('clears the reject set while keeping display settings', () {
+      final spec = makeSpec(
+        predicate: CharacterCardPredicate(rejects: {1, 2, 3}),
+        hidden: true,
+        description: 'keep me',
+        width: 250.0,
+      );
+
+      final reset = spec.withFilterReset(null) as CharacterCardColumnSpec;
+
+      expect(reset.predicate.rejects, isEmpty);
+      expect(reset.hidden, isTrue);
+      expect(reset.description, 'keep me');
+      expect(reset.width, 250.0);
+    });
+  });
+
+  group('CharacterCardColumnSpec serialization', () {
+    test('round-trips the reject set losslessly', () {
+      final spec = makeSpec(predicate: CharacterCardPredicate(rejects: {7, 8}), width: 200.0);
+      final map = spec.toMap();
+
+      final decoded = ColumnSpecMapper.fromMap(map) as CharacterCardColumnSpec;
+
+      expect(decoded.predicate.rejects, {7, 8});
+      expect(decoded.width, 200.0);
+      expect(isSpecMapIncomplete(map, decoded.toMap()), isFalse);
+    });
+  });
+}

--- a/test/character_spec_test.dart
+++ b/test/character_spec_test.dart
@@ -10,9 +10,8 @@ import 'package:umacapture/src/chara_detail/spec/base.dart';
 import 'package:umacapture/src/chara_detail/spec/character.dart';
 import 'package:umacapture/src/chara_detail/spec/parser.dart';
 import 'package:umacapture/src/core/mapper_init.dart';
-import 'package:umacapture/src/core/utils.dart';
 
-final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+import 'support/riverpod.dart';
 
 CharacterCardColumnSpec makeSpec({
   CharacterCardPredicate? predicate,
@@ -58,7 +57,7 @@ void main() {
     test('applies the predicate to each value in order', () {
       final container = ProviderContainer.test();
       addTearDown(container.dispose);
-      final ref = container.read(_refBaseProvider);
+      final ref = container.read(refBaseProvider);
 
       final spec = makeSpec(predicate: CharacterCardPredicate(rejects: {100}));
       expect(spec.evaluate(ref, [100, 200, 100, 300]), [isFalse, isTrue, isFalse, isTrue]);

--- a/test/column_spec_filter_clear_test.dart
+++ b/test/column_spec_filter_clear_test.dart
@@ -15,10 +15,8 @@ import 'package:umacapture/src/chara_detail/spec/ranged_integer.dart';
 import 'package:umacapture/src/chara_detail/spec/script.dart';
 import 'package:umacapture/src/chara_detail/spec/simple_label.dart';
 import 'package:umacapture/src/core/mapper_init.dart';
-import 'package:umacapture/src/core/utils.dart';
 
-/// Exposes a [RefBase] so `builderSpecOf` (which takes one) can run in tests.
-final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+import 'support/riverpod.dart';
 
 void main() {
   setUpAll(initializeMappers);
@@ -42,7 +40,7 @@ void main() {
         ],
       );
       addTearDown(container.dispose);
-      final ref = container.read(_refBaseProvider);
+      final ref = container.read(refBaseProvider);
 
       // A column created from that preset, but with the filter edited away.
       final spec = RangedLabelColumnSpec(
@@ -84,7 +82,7 @@ void main() {
         ],
       );
       addTearDown(container.dispose);
-      final ref = container.read(_refBaseProvider);
+      final ref = container.read(refBaseProvider);
 
       final spec = FactorColumnSpec(
         id: 'id-2',
@@ -101,7 +99,7 @@ void main() {
     test('an unknown builderId falls back to accept-all', () {
       final container = ProviderContainer.test(overrides: [columnBuilderProvider.overrideWithValue([])]);
       addTearDown(container.dispose);
-      final ref = container.read(_refBaseProvider);
+      final ref = container.read(refBaseProvider);
 
       final spec = RangedLabelColumnSpec(
         id: 'id-3',
@@ -122,7 +120,7 @@ void main() {
     test('a column with builderId=null resets to accept-all', () {
       final container = ProviderContainer.test();
       addTearDown(container.dispose);
-      final ref = container.read(_refBaseProvider);
+      final ref = container.read(refBaseProvider);
 
       final spec = SimpleLabelColumnSpec(
         id: 'id-4',

--- a/test/inheritance_resolver_test.dart
+++ b/test/inheritance_resolver_test.dart
@@ -12,57 +12,7 @@ import 'package:umacapture/src/chara_detail/inheritance.dart';
 import 'package:umacapture/src/core/mapper_init.dart';
 import 'package:umacapture/src/core/path_entity.dart';
 
-Character _chara(int card) => Character(0, 0, card, 0);
-
-Parent _parent(int card) => Parent(_chara(card), _chara(0), _chara(0), null);
-
-// A win (position 1) of race title [title]; other race fields are irrelevant to
-// the relation-bonus computation. Pass won: false for a non-winning entry.
-Race _race(int title, {bool won = true}) => Race(title, 0, 0, 0, 0, 0, 0, 0, won ? 1 : 2);
-
-// Builds a record carrying only the fields the resolver reads (card, factors,
-// family parent cards, record-id links, races); everything else is dummy.
-CharaDetailRecord makeRecord({
-  required String id,
-  required int card,
-  List<Factor> self = const [],
-  int parent1Card = 0,
-  List<Factor> parent1 = const [],
-  int parent2Card = 0,
-  List<Factor> parent2 = const [],
-  String? parent1Id,
-  String? parent2Id,
-  int? relationBonus,
-  List<Race> races = const [],
-}) {
-  final metadata = Metadata(
-    '1.0.0',
-    'JPN',
-    RecordId(id, parent1Id, parent2Id),
-    'trainer',
-    '2026-01-01T00:00:00+0900',
-    '2026-01-01T00:00:00+0900',
-    RecordStage.active,
-    0,
-    relationBonus,
-    RecordType.standard,
-  );
-  return CharaDetailRecord(
-    metadata,
-    _chara(card),
-    0,
-    const CharacterStatus(0, 0, 0, 0, 0),
-    const AptitudeSet(GroundAptitude(0, 0), DistanceAptitude(0, 0, 0, 0), StyleAptitude(0, 0, 0, 0)),
-    const <Skill>[],
-    FactorSet(self, parent1, parent2),
-    const <SupportCard>[],
-    Family(_parent(parent1Card), _parent(parent2Card)),
-    0,
-    const Scenario(0),
-    '2026/01/01',
-    races,
-  );
-}
+import 'support/records.dart';
 
 // Assembles a record-by-id lookup, as the resolver builds internally.
 Map<String, CharaDetailRecord> _byId(List<CharaDetailRecord> records) {
@@ -246,22 +196,22 @@ void main() {
     CharaDetailRecord parent2({required List<Race> races}) =>
         makeRecord(id: 'p2', card: 3, parent1Id: 'gp21', parent2Id: 'gp22', races: races);
     CharaDetailRecord grandparent(String id, int card, List<int> wins) =>
-        makeRecord(id: id, card: card, races: [for (final title in wins) _race(title)]);
+        makeRecord(id: id, card: card, races: [for (final title in wins) race(title)]);
 
     test('scores the five pairs independently and multiplies the total by three', () {
       // Designed so each pair contributes a distinct count: A=1, B=2, C=3, D=4,
       // E=5 -> (1+2+3+4+5)*3 = 45. Trainee races overlap the ancestors yet must
       // not change the result (the trainee is not a member of any pair).
       final records = [
-        trainee(traineeRaces: [_race(1), _race(2), _race(11)]),
+        trainee(traineeRaces: [race(1), race(2), race(11)]),
         parent1(
           races: [
-            for (final t in [1, 2, 3, 4, 5, 6]) _race(t),
+            for (final t in [1, 2, 3, 4, 5, 6]) race(t),
           ],
         ),
         parent2(
           races: [
-            for (final t in [1, 11, 12, 13, 14, 15, 16, 17]) _race(t),
+            for (final t in [1, 11, 12, 13, 14, 15, 16, 17]) race(t),
           ],
         ),
         grandparent('gp11', 4, [2, 3]),
@@ -279,8 +229,8 @@ void main() {
     test('counts only G1 titles, ignoring shared non-graded wins', () {
       final records = [
         makeRecord(id: 't', card: 1, parent1Id: 'p1', parent2Id: 'p2'),
-        makeRecord(id: 'p1', card: 2, races: [_race(5), _race(99)]),
-        makeRecord(id: 'p2', card: 3, races: [_race(5), _race(99)]),
+        makeRecord(id: 'p1', card: 2, races: [race(5), race(99)]),
+        makeRecord(id: 'p2', card: 3, races: [race(5), race(99)]),
       ];
 
       // Only title 5 is G1, so the parent1xparent2 pair scores 1 -> bonus 3; the
@@ -293,8 +243,8 @@ void main() {
     test('counts a shared race once even if won more than once', () {
       final records = [
         makeRecord(id: 't', card: 1, parent1Id: 'p1', parent2Id: 'p2'),
-        makeRecord(id: 'p1', card: 2, races: [_race(5), _race(5)]),
-        makeRecord(id: 'p2', card: 3, races: [_race(5)]),
+        makeRecord(id: 'p1', card: 2, races: [race(5), race(5)]),
+        makeRecord(id: 'p2', card: 3, races: [race(5)]),
       ];
 
       final bonus = InheritanceResolver.relationBonus(records.first, _byId(records), {5});
@@ -305,8 +255,8 @@ void main() {
     test('a non-winning entry of a shared title does not count', () {
       final records = [
         makeRecord(id: 't', card: 1, parent1Id: 'p1', parent2Id: 'p2'),
-        makeRecord(id: 'p1', card: 2, races: [_race(5)]),
-        makeRecord(id: 'p2', card: 3, races: [_race(5, won: false)]),
+        makeRecord(id: 'p1', card: 2, races: [race(5)]),
+        makeRecord(id: 'p2', card: 3, races: [race(5, won: false)]),
       ];
 
       final bonus = InheritanceResolver.relationBonus(records.first, _byId(records), {5});
@@ -319,8 +269,8 @@ void main() {
       // leaving just A = parent1xparent2 = {5} -> bonus 3.
       final records = [
         makeRecord(id: 't', card: 1, parent1Id: 'p1', parent2Id: 'p2'),
-        makeRecord(id: 'p1', card: 2, parent1Id: 'gp11', races: [_race(5)]),
-        makeRecord(id: 'p2', card: 3, races: [_race(5)]),
+        makeRecord(id: 'p1', card: 2, parent1Id: 'gp11', races: [race(5)]),
+        makeRecord(id: 'p2', card: 3, races: [race(5)]),
       ];
 
       final bonus = InheritanceResolver.relationBonus(records.first, _byId(records), {5});
@@ -329,7 +279,7 @@ void main() {
     });
 
     test('returns null when the record has no linked parent', () {
-      final record = makeRecord(id: 't', card: 1, races: [_race(5)]);
+      final record = makeRecord(id: 't', card: 1, races: [race(5)]);
 
       expect(InheritanceResolver.relationBonus(record, _byId([record]), {5}), isNull);
     });
@@ -345,8 +295,8 @@ void main() {
         parent2Card: 20,
         parent2: [const Factor(2, 2)],
       );
-      final p1 = makeRecord(id: 'p1', card: 10, self: [const Factor(1, 1)], races: [_race(5)]);
-      final p2 = makeRecord(id: 'p2', card: 20, self: [const Factor(2, 2)], races: [_race(5)]);
+      final p1 = makeRecord(id: 'p1', card: 10, self: [const Factor(1, 1)], races: [race(5)]);
+      final p2 = makeRecord(id: 'p2', card: 20, self: [const Factor(2, 2)], races: [race(5)]);
 
       final result = InheritanceResolver.resolveAll([child, p1, p2], g1RaceSids: {5});
 
@@ -358,7 +308,7 @@ void main() {
 
     test('resolveAll leaves the bonus untouched without a G1 set', () {
       final child = makeRecord(id: 'c', card: 30, parent1Card: 10, parent1: [const Factor(1, 1)]);
-      final p1 = makeRecord(id: 'p1', card: 10, self: [const Factor(1, 1)], races: [_race(5)]);
+      final p1 = makeRecord(id: 'p1', card: 10, self: [const Factor(1, 1)], races: [race(5)]);
 
       final result = InheritanceResolver.resolveAll([child, p1]);
 
@@ -376,8 +326,8 @@ void main() {
         parent2Card: 20,
         parent2: [const Factor(2, 2)],
       );
-      final p1 = makeRecord(id: 'p1', card: 10, self: [const Factor(1, 1)], races: [_race(5)]);
-      final p2 = makeRecord(id: 'p2', card: 20, self: [const Factor(2, 2)], races: [_race(5)]);
+      final p1 = makeRecord(id: 'p1', card: 10, self: [const Factor(1, 1)], races: [race(5)]);
+      final p2 = makeRecord(id: 'p2', card: 20, self: [const Factor(2, 2)], races: [race(5)]);
 
       // First pass links the lineage and writes the bonus; apply the changes
       // back, then a second pass over the resolved set must be a no-op.
@@ -399,14 +349,14 @@ void main() {
       // captured. After that, GC's parent1xgrandparent pair (C x N, sharing G1
       // title 5) scores 1, so GC's bonus changes from 0 to 3 even though GC's own
       // links never change.
-      final newGrandparent = makeRecord(id: 'n', card: 10, self: [const Factor(1, 1)], races: [_race(5)]);
+      final newGrandparent = makeRecord(id: 'n', card: 10, self: [const Factor(1, 1)], races: [race(5)]);
       final child = makeRecord(
         id: 'c',
         card: 20,
         self: [const Factor(2, 2)],
         parent1Card: 10,
         parent1: [const Factor(1, 1)],
-        races: [_race(5)],
+        races: [race(5)],
       );
       final grandchild = makeRecord(
         id: 'gc',
@@ -427,8 +377,8 @@ void main() {
     });
 
     test('resolveForNewRecord does not write a bonus without a G1 set', () {
-      final child = makeRecord(id: 'c', card: 20, parent1Card: 10, parent1: [const Factor(1, 1)], races: [_race(5)]);
-      final parent = makeRecord(id: 'p', card: 10, self: [const Factor(1, 1)], races: [_race(5)]);
+      final child = makeRecord(id: 'c', card: 20, parent1Card: 10, parent1: [const Factor(1, 1)], races: [race(5)]);
+      final parent = makeRecord(id: 'p', card: 10, self: [const Factor(1, 1)], races: [race(5)]);
 
       final updated = InheritanceResolver.resolveForNewRecord(child, [parent]).changed.single;
 

--- a/test/json_adapter_test.dart
+++ b/test/json_adapter_test.dart
@@ -1,0 +1,67 @@
+// Unit tests for the custom dart_mappable mappers that serialize dart:ui /
+// material types (Size / Offset / RegExp / ThemeMode). These guard the
+// encode<->decode round-trip; a regression here silently corrupts persisted
+// window geometry, theme mode, or saved regex filters.
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/json_adapter_test.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/core/json_adapter.dart';
+
+void main() {
+  group('SizeMapper', () {
+    const mapper = SizeMapper();
+
+    test('round-trips width and height', () {
+      const size = Size(12.5, 34.0);
+      final encoded = mapper.encode(size);
+      expect(encoded, {'width': 12.5, 'height': 34.0});
+      expect(mapper.decode(encoded), size);
+    });
+
+    test('decodes integer JSON numbers via toDouble', () {
+      expect(mapper.decode({'width': 3, 'height': 4}), const Size(3, 4));
+    });
+  });
+
+  group('OffsetMapper', () {
+    const mapper = OffsetMapper();
+
+    test('round-trips dx and dy', () {
+      const offset = Offset(-5.5, 7.0);
+      final encoded = mapper.encode(offset);
+      expect(encoded, {'dx': -5.5, 'dy': 7.0});
+      expect(mapper.decode(encoded), offset);
+    });
+  });
+
+  group('RegExpMapper', () {
+    const mapper = RegExpMapper();
+
+    test('round-trips the pattern string', () {
+      final source = RegExp(r'^foo\d+$');
+      expect(mapper.encode(source), r'^foo\d+$');
+      expect(mapper.decode(mapper.encode(source)).pattern, source.pattern);
+    });
+
+    test('preserves only the pattern, not flags (documented limitation)', () {
+      final decoded = mapper.decode(mapper.encode(RegExp('a', caseSensitive: false)));
+      expect(decoded.isCaseSensitive, isTrue, reason: 'the case-insensitive flag is not serialized');
+    });
+  });
+
+  group('ThemeModeMapper', () {
+    const mapper = ThemeModeMapper();
+
+    test('round-trips every ThemeMode by name', () {
+      for (final mode in ThemeMode.values) {
+        expect(mapper.encode(mode), mode.name);
+        expect(mapper.decode(mode.name), mode);
+      }
+    });
+
+    test('throws on an unknown name', () {
+      expect(() => mapper.decode('not_a_mode'), throwsStateError);
+    });
+  });
+}

--- a/test/privacy_setting_test.dart
+++ b/test/privacy_setting_test.dart
@@ -1,0 +1,68 @@
+// Provider/storage tests for the privacy (post-user-data) setting: the tri-state
+// read that drives the consent prompt, and the notifier's default + persistence.
+// isFeedbackAvailable additionally gates on Sentry, which is not initialized in
+// tests, so only its Sentry-unavailable branch is asserted here.
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/privacy_setting_test.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:umacapture/src/preference/privacy_setting.dart';
+import 'package:umacapture/src/preference/settings_state.dart';
+import 'package:umacapture/src/preference/storage_box.dart';
+
+import 'support/hive.dart';
+
+void main() {
+  late Future<void> Function() closeHive;
+
+  setUpAll(() async {
+    // allowPostUserData() and the notifier both resolve StorageBox(settings).
+    closeHive = await initHiveForTest(['settings']);
+  });
+
+  tearDownAll(() async {
+    await closeHive();
+  });
+
+  setUp(() async {
+    await Hive.box('settings').clear();
+  });
+
+  StorageEntry<bool> entry() => StorageBox(StorageBoxKey.settings).entry<bool>(SettingsEntryKey.allowPostUserData.name);
+
+  group('allowPostUserData', () {
+    test('is notConfirmed when nothing has been stored', () {
+      expect(allowPostUserData(), PostUserData.notConfirmed);
+    });
+
+    test('is allow when the stored value is true', () {
+      entry().push(true);
+      expect(allowPostUserData(), PostUserData.allow);
+    });
+
+    test('is deny when the stored value is false', () {
+      entry().push(false);
+      expect(allowPostUserData(), PostUserData.deny);
+    });
+  });
+
+  group('allowPostUserDataStateProvider', () {
+    test('defaults to true, then persists a change back to storage', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      expect(container.read(allowPostUserDataStateProvider), isTrue);
+
+      container.read(allowPostUserDataStateProvider.notifier).set(false);
+
+      expect(container.read(allowPostUserDataStateProvider), isFalse);
+      // The change is written through: the raw entry (and a fresh container) see it.
+      expect(allowPostUserData(), PostUserData.deny);
+
+      final reopened = ProviderContainer.test();
+      addTearDown(reopened.dispose);
+      expect(reopened.read(allowPostUserDataStateProvider), isFalse);
+    });
+  });
+}

--- a/test/race_grade_spec_test.dart
+++ b/test/race_grade_spec_test.dart
@@ -13,11 +13,10 @@ import 'package:umacapture/src/chara_detail/spec/loader.dart';
 import 'package:umacapture/src/chara_detail/spec/race_grade.dart';
 import 'package:umacapture/src/chara_detail/spec/ranged_integer.dart';
 import 'package:umacapture/src/core/mapper_init.dart';
-import 'package:umacapture/src/core/utils.dart';
+
+import 'support/riverpod.dart';
 
 const _grade = 'grade_g1';
-
-final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
 
 Character _chara(int card) => Character(0, 0, card, 0);
 
@@ -80,7 +79,7 @@ RaceGradeWinningCountColumnSpec makeSpec({
 List<int> parseWith(RaceGradeWinningCountColumnSpec spec, Set<int> gradeSids, List<CharaDetailRecord> records) {
   final container = ProviderContainer.test(overrides: [raceGradeSidProvider(_grade).overrideWithValue(gradeSids)]);
   addTearDown(container.dispose);
-  return spec.parse(container.read(_refBaseProvider), records);
+  return spec.parse(container.read(refBaseProvider), records);
 }
 
 void main() {
@@ -136,14 +135,14 @@ void main() {
     test('an open range accepts every count', () {
       final container = ProviderContainer.test();
       addTearDown(container.dispose);
-      final ref = container.read(_refBaseProvider);
+      final ref = container.read(refBaseProvider);
       expect(makeSpec().evaluate(ref, [0, 1, 10]), [isTrue, isTrue, isTrue]);
     });
 
     test('a bounded range filters counts, inclusive of both ends', () {
       final container = ProviderContainer.test();
       addTearDown(container.dispose);
-      final ref = container.read(_refBaseProvider);
+      final ref = container.read(refBaseProvider);
       final spec = makeSpec(predicate: IsInRangeIntegerPredicate(min: 2, max: 5));
       expect(spec.evaluate(ref, [1, 2, 5, 6]), [isFalse, isTrue, isTrue, isFalse]);
     });

--- a/test/race_grade_spec_test.dart
+++ b/test/race_grade_spec_test.dart
@@ -1,0 +1,173 @@
+// Covers the graded-race winning-count column: which race titles it counts
+// (the selection intersected with the grade), how it counts wins, and the range
+// filter. A stale selection left over after a game-data update must not count
+// races that are no longer of the graded set.
+//
+// _targets is private, so its behavior is verified through parse().
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/race_grade_spec_test.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/chara_detail/chara_detail_record.dart';
+import 'package:umacapture/src/chara_detail/spec/loader.dart';
+import 'package:umacapture/src/chara_detail/spec/race_grade.dart';
+import 'package:umacapture/src/chara_detail/spec/ranged_integer.dart';
+import 'package:umacapture/src/core/mapper_init.dart';
+import 'package:umacapture/src/core/utils.dart';
+
+const _grade = 'grade_g1';
+
+final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+
+Character _chara(int card) => Character(0, 0, card, 0);
+
+Parent _parent(int card) => Parent(_chara(card), _chara(0), _chara(0), null);
+
+// A race in `title` that the trainee either won (finished 1st) or lost. Only the
+// finishing position drives Race.won, so the other columns are dummy.
+Race _race(int title, {required bool won}) => Race(title, won ? 1 : 2, 0, 0, 0, 0, 0, 0, won ? 1 : 2);
+
+CharaDetailRecord makeRecord({required String id, required List<Race> races}) {
+  final metadata = Metadata(
+    '1.0.0',
+    'JPN',
+    RecordId(id, null, null),
+    'trainer',
+    '2026-01-01T00:00:00+0900',
+    '2026-01-01T00:00:00+0900',
+    RecordStage.active,
+    0,
+    null,
+    RecordType.standard,
+  );
+  return CharaDetailRecord(
+    metadata,
+    _chara(1),
+    0,
+    const CharacterStatus(0, 0, 0, 0, 0),
+    const AptitudeSet(GroundAptitude(0, 0), DistanceAptitude(0, 0, 0, 0), StyleAptitude(0, 0, 0, 0)),
+    const <Skill>[],
+    const FactorSet([], [], []),
+    const <SupportCard>[],
+    Family(_parent(0), _parent(0)),
+    0,
+    const Scenario(0),
+    '2026/01/01',
+    races,
+  );
+}
+
+RaceGradeWinningCountColumnSpec makeSpec({
+  IsInRangeIntegerPredicate? predicate,
+  Set<int> selection = const {},
+  bool hidden = false,
+  String? description,
+  double? width,
+}) {
+  return RaceGradeWinningCountColumnSpec(
+    id: 'race-grade-id',
+    title: 'G1 Wins',
+    predicate: predicate ?? IsInRangeIntegerPredicate(),
+    grade: _grade,
+    selection: selection,
+    hidden: hidden,
+    description: description,
+    width: width,
+  );
+}
+
+// Runs `parse` with the grade's sid set overridden to [gradeSids].
+List<int> parseWith(RaceGradeWinningCountColumnSpec spec, Set<int> gradeSids, List<CharaDetailRecord> records) {
+  final container = ProviderContainer.test(overrides: [raceGradeSidProvider(_grade).overrideWithValue(gradeSids)]);
+  addTearDown(container.dispose);
+  return spec.parse(container.read(_refBaseProvider), records);
+}
+
+void main() {
+  setUpAll(initializeMappers);
+
+  group('RaceGradeWinningCountColumnSpec.parse targeting', () {
+    final record = makeRecord(id: 'c', races: [_race(101, won: true), _race(102, won: true), _race(103, won: true)]);
+
+    test('an empty selection counts every win of the grade', () {
+      expect(parseWith(makeSpec(), {101, 102, 103}, [record]), [3]);
+    });
+
+    test('a selection narrows the count to the chosen races', () {
+      expect(parseWith(makeSpec(selection: {101, 102}), {101, 102, 103}, [record]), [2]);
+    });
+
+    test('a stale selected sid no longer in the grade is not counted', () {
+      // 103 was selected but the grade set now lacks it (data update).
+      expect(parseWith(makeSpec(selection: {101, 103}), {101, 102}, [record]), [1]);
+    });
+  });
+
+  group('RaceGradeWinningCountColumnSpec.parse counting', () {
+    test('counts only wins whose title is in the target set', () {
+      final record = makeRecord(
+        id: 'c',
+        races: [
+          _race(101, won: true), // counted
+          _race(101, won: false), // lost, not counted
+          _race(102, won: true), // counted
+          _race(999, won: true), // won but off-grade, not counted
+        ],
+      );
+      expect(parseWith(makeSpec(), {101, 102}, [record]), [2]);
+    });
+
+    test('counts repeated wins of the same title separately', () {
+      final record = makeRecord(id: 'c', races: [_race(101, won: true), _race(101, won: true)]);
+      expect(parseWith(makeSpec(), {101}, [record]), [2]);
+    });
+
+    test('a record with no races counts zero', () {
+      final record = makeRecord(id: 'c', races: const []);
+      expect(parseWith(makeSpec(), {101}, [record]), [0]);
+    });
+
+    test('an empty record list yields an empty result', () {
+      expect(parseWith(makeSpec(), {101}, const []), isEmpty);
+    });
+  });
+
+  group('RaceGradeWinningCountColumnSpec.evaluate', () {
+    test('an open range accepts every count', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+      final ref = container.read(_refBaseProvider);
+      expect(makeSpec().evaluate(ref, [0, 1, 10]), [isTrue, isTrue, isTrue]);
+    });
+
+    test('a bounded range filters counts, inclusive of both ends', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+      final ref = container.read(_refBaseProvider);
+      final spec = makeSpec(predicate: IsInRangeIntegerPredicate(min: 2, max: 5));
+      expect(spec.evaluate(ref, [1, 2, 5, 6]), [isFalse, isTrue, isTrue, isFalse]);
+    });
+  });
+
+  group('RaceGradeWinningCountColumnSpec.withFilterReset', () {
+    test('clears the range and selection while keeping grade and display settings', () {
+      final spec = makeSpec(
+        predicate: IsInRangeIntegerPredicate(min: 2, max: 10),
+        selection: {101, 102},
+        hidden: true,
+        description: 'keep me',
+        width: 180.0,
+      );
+
+      final reset = spec.withFilterReset(null) as RaceGradeWinningCountColumnSpec;
+
+      expect(reset.predicate.min, isNull);
+      expect(reset.predicate.max, isNull);
+      expect(reset.selection, isEmpty);
+      expect(reset.grade, _grade);
+      expect(reset.hidden, isTrue);
+      expect(reset.description, 'keep me');
+      expect(reset.width, 180.0);
+    });
+  });
+}

--- a/test/relation_bonus_spec_test.dart
+++ b/test/relation_bonus_spec_test.dart
@@ -14,9 +14,8 @@ import 'package:umacapture/src/chara_detail/spec/ranged_integer.dart';
 import 'package:umacapture/src/chara_detail/spec/relation_bonus.dart';
 import 'package:umacapture/src/chara_detail/storage.dart';
 import 'package:umacapture/src/core/mapper_init.dart';
-import 'package:umacapture/src/core/utils.dart';
 
-final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+import 'support/riverpod.dart';
 
 Character _chara(int card) => Character(0, 0, card, 0);
 
@@ -113,7 +112,7 @@ void main() {
     test('an open range accepts every value', () {
       final container = ProviderContainer.test();
       addTearDown(container.dispose);
-      final ref = container.read(_refBaseProvider);
+      final ref = container.read(refBaseProvider);
 
       final result = makeSpec().evaluate(ref, const [
         RelationBonusStatus(null, 0),
@@ -126,7 +125,7 @@ void main() {
     test('a bounded range filters on filterValue, inclusive of both ends', () {
       final container = ProviderContainer.test();
       addTearDown(container.dispose);
-      final ref = container.read(_refBaseProvider);
+      final ref = container.read(refBaseProvider);
 
       final spec = makeSpec(predicate: IsInRangeIntegerPredicate(min: 50, max: 100));
       final result = spec.evaluate(ref, const [
@@ -149,7 +148,7 @@ void main() {
         ],
       );
       addTearDown(container.dispose);
-      final ref = container.read(_refBaseProvider);
+      final ref = container.read(refBaseProvider);
 
       final statuses = makeSpec().parse(ref, [record]);
 

--- a/test/relation_bonus_spec_test.dart
+++ b/test/relation_bonus_spec_test.dart
@@ -1,0 +1,196 @@
+// Covers the relation-bonus column: the RelationBonusStatus value type (which
+// distinguishes a confirmed number from a "-" placeholder or a "≧ n" lower
+// bound) and the column's range filter. The confirmed-vs-lower-bound
+// distinction is the whole point of the column, so a confirmed 0 must never
+// read the same as a not-yet-known 0.
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/relation_bonus_spec_test.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+import 'package:umacapture/src/chara_detail/chara_detail_record.dart';
+import 'package:umacapture/src/chara_detail/spec/base.dart';
+import 'package:umacapture/src/chara_detail/spec/ranged_integer.dart';
+import 'package:umacapture/src/chara_detail/spec/relation_bonus.dart';
+import 'package:umacapture/src/chara_detail/storage.dart';
+import 'package:umacapture/src/core/mapper_init.dart';
+import 'package:umacapture/src/core/utils.dart';
+
+final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+
+Character _chara(int card) => Character(0, 0, card, 0);
+
+Parent _parent(int card) => Parent(_chara(card), _chara(0), _chara(0), null);
+
+// A record carrying only the stored relation bonus and no parent links, so its
+// lineage resolves to zero linked ancestors (an incomplete status).
+CharaDetailRecord makeRecord({required String id, required int? relationBonus}) {
+  final metadata = Metadata(
+    '1.0.0',
+    'JPN',
+    RecordId(id, null, null),
+    'trainer',
+    '2026-01-01T00:00:00+0900',
+    '2026-01-01T00:00:00+0900',
+    RecordStage.active,
+    0,
+    relationBonus,
+    RecordType.standard,
+  );
+  return CharaDetailRecord(
+    metadata,
+    _chara(1),
+    0,
+    const CharacterStatus(0, 0, 0, 0, 0),
+    const AptitudeSet(GroundAptitude(0, 0), DistanceAptitude(0, 0, 0, 0), StyleAptitude(0, 0, 0, 0)),
+    const <Skill>[],
+    const FactorSet([], [], []),
+    const <SupportCard>[],
+    Family(_parent(0), _parent(0)),
+    0,
+    const Scenario(0),
+    '2026/01/01',
+    const <Race>[],
+  );
+}
+
+RelationBonusColumnSpec makeSpec({
+  IsInRangeIntegerPredicate? predicate,
+  bool hidden = false,
+  String? description,
+  double? width,
+}) {
+  return RelationBonusColumnSpec(
+    id: 'relation-bonus-id',
+    title: 'Relation Bonus',
+    predicate: predicate ?? IsInRangeIntegerPredicate(),
+    hidden: hidden,
+    description: description,
+    width: width,
+  );
+}
+
+void main() {
+  setUpAll(initializeMappers);
+
+  group('RelationBonusStatus', () {
+    test('unlinked (no stored value) shows the placeholder and is unconfirmed', () {
+      const status = RelationBonusStatus(null, 0);
+      expect(status.isComplete, isFalse);
+      expect(status.isConfirmed, isFalse);
+      expect(status.filterValue, 0);
+      expect(status.label, '-');
+    });
+
+    test('a full lineage confirms the stored value', () {
+      const status = RelationBonusStatus(50, 6);
+      expect(status.isComplete, isTrue);
+      expect(status.isConfirmed, isTrue);
+      expect(status.filterValue, 50);
+      expect(status.label, '50');
+    });
+
+    test('an incomplete lineage marks the value as a lower bound', () {
+      const status = RelationBonusStatus(50, 3);
+      expect(status.isComplete, isFalse);
+      expect(status.isConfirmed, isFalse);
+      expect(status.filterValue, 50);
+      expect(status.label, '≧ 50');
+    });
+
+    test('a confirmed 0 is distinct from a not-yet-known 0', () {
+      const confirmed = RelationBonusStatus(0, 6);
+      expect(confirmed.isConfirmed, isTrue);
+      expect(confirmed.label, '0');
+
+      const unknown = RelationBonusStatus(null, 6);
+      expect(unknown.isConfirmed, isFalse);
+      expect(unknown.label, '-');
+    });
+  });
+
+  group('RelationBonusColumnSpec.evaluate', () {
+    test('an open range accepts every value', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+      final ref = container.read(_refBaseProvider);
+
+      final result = makeSpec().evaluate(ref, const [
+        RelationBonusStatus(null, 0),
+        RelationBonusStatus(100, 6),
+        RelationBonusStatus(50, 3),
+      ]);
+      expect(result, [isTrue, isTrue, isTrue]);
+    });
+
+    test('a bounded range filters on filterValue, inclusive of both ends', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+      final ref = container.read(_refBaseProvider);
+
+      final spec = makeSpec(predicate: IsInRangeIntegerPredicate(min: 50, max: 100));
+      final result = spec.evaluate(ref, const [
+        RelationBonusStatus(40, 6), // below min
+        RelationBonusStatus(50, 6), // at min
+        RelationBonusStatus(75, 3), // incomplete but in range (uses filterValue)
+        RelationBonusStatus(100, 6), // at max
+        RelationBonusStatus(110, 6), // above max
+      ]);
+      expect(result, [isFalse, isTrue, isTrue, isTrue, isFalse]);
+    });
+  });
+
+  group('RelationBonusColumnSpec.parse', () {
+    test('pairs the stored bonus with the live linked-ancestor count', () {
+      final record = makeRecord(id: 'c', relationBonus: 30);
+      final container = ProviderContainer.test(
+        overrides: [
+          allRecordsByIdProvider.overrideWithValue({record.id: record}),
+        ],
+      );
+      addTearDown(container.dispose);
+      final ref = container.read(_refBaseProvider);
+
+      final statuses = makeSpec().parse(ref, [record]);
+
+      expect(statuses.single.value, 30);
+      // No parent links, so the lineage is incomplete and the value is a bound.
+      expect(statuses.single.linkedAncestors, 0);
+      expect(statuses.single.isConfirmed, isFalse);
+    });
+  });
+
+  group('RelationBonusColumnSpec.withFilterReset', () {
+    test('clears the range while keeping display settings', () {
+      final spec = makeSpec(
+        predicate: IsInRangeIntegerPredicate(min: 50, max: 100),
+        hidden: true,
+        description: 'keep me',
+        width: 200.0,
+      );
+
+      final reset = spec.withFilterReset(null) as RelationBonusColumnSpec;
+
+      expect(reset.predicate.min, isNull);
+      expect(reset.predicate.max, isNull);
+      expect(reset.hidden, isTrue);
+      expect(reset.description, 'keep me');
+      expect(reset.width, 200.0);
+    });
+  });
+
+  group('RelationBonusColumnSpec.measuredText', () {
+    test('reports the status label from the cell for row-height measurement', () {
+      final spec = makeSpec();
+
+      TrinaCell cellFor(RelationBonusStatus status) =>
+          TrinaCell(value: status.filterValue)..setUserData(RelationBonusCellData(status));
+
+      expect(spec.measuredText(cellFor(const RelationBonusStatus(75, 6)), '75'), '75');
+      expect(spec.measuredText(cellFor(const RelationBonusStatus(75, 3)), '75'), '≧ 75');
+      expect(spec.measuredText(cellFor(const RelationBonusStatus(null, 0)), '0'), '-');
+      // With no attached cell data, it falls back to the formatted value.
+      expect(spec.measuredText(null, 'fallback'), 'fallback');
+    });
+  });
+}

--- a/test/sentry_custom_hint_test.dart
+++ b/test/sentry_custom_hint_test.dart
@@ -1,0 +1,36 @@
+// Covers CustomHint, the only pure, SDK-independent piece of sentry_util: it
+// serializes our extra fields through a sentry Hint (the sole channel that
+// reaches beforeSend) and reads them back. A lossy round-trip would drop the
+// unique-fingerprint flag or the title prefix used to group reports.
+//
+// The remaining sentry_util surface (capture wrappers, beforeSend, report
+// counting) needs the Sentry SDK / Hive mocked and is deferred to a later phase.
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/sentry_custom_hint_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/core/sentry_util.dart';
+
+void main() {
+  group('CustomHint round-trip', () {
+    test('preserves both fields when set', () {
+      final restored = CustomHint.from(CustomHint(useUniqueFingerprint: true, titlePrefix: 'Record').toHint());
+
+      expect(restored.useUniqueFingerprint, isTrue);
+      expect(restored.titlePrefix, 'Record');
+    });
+
+    test('defaults to no fingerprint override and a null prefix', () {
+      final restored = CustomHint.from(CustomHint().toHint());
+
+      expect(restored.useUniqueFingerprint, isFalse);
+      expect(restored.titlePrefix, isNull);
+    });
+
+    test('keeps the fingerprint flag independent of the prefix', () {
+      final restored = CustomHint.from(CustomHint(useUniqueFingerprint: true).toHint());
+
+      expect(restored.useUniqueFingerprint, isTrue);
+      expect(restored.titlePrefix, isNull);
+    });
+  });
+}

--- a/test/settings_notifier_test.dart
+++ b/test/settings_notifier_test.dart
@@ -2,22 +2,27 @@
 // its StorageEntry from storageBoxProvider inside build() and persists via set().
 // Verifies the read -> mutate -> persist round-trip through the Hive settings box.
 // Run: .fvm/flutter_sdk/bin/flutter test test/settings_notifier_test.dart
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:umacapture/src/preference/notifier.dart';
+
+import 'support/hive.dart';
 
 // Mirrors the real settings providers (e.g. fontBoldSettingProvider) without
 // depending on their concrete keys/defaults.
 final _flagProvider = BooleanNotifierProvider(() => BooleanNotifier(entryKey: 'test_flag', defaultValue: false));
 
 void main() {
+  late Future<void> Function() closeHive;
+
   setUpAll(() async {
-    Hive.init(Directory.systemTemp.createTempSync('umacapture_settings_test').path);
     // storageBoxProvider opens StorageBox(StorageBoxKey.settings) -> Hive.box('settings').
-    await Hive.openBox('settings');
+    closeHive = await initHiveForTest(['settings']);
+  });
+
+  tearDownAll(() async {
+    await closeHive();
   });
 
   setUp(() async {

--- a/test/spec_tree_test.dart
+++ b/test/spec_tree_test.dart
@@ -1,0 +1,170 @@
+// Unit tests for the pure forest algebra that backs column-selection tree edits
+// (insert/detach/lift/replace/flatten). These helpers are Flutter- and Hive-free;
+// only the mappers are needed to build leaf specs via ColumnSpecMapper.fromMap.
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/spec_tree_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/chara_detail/spec/base.dart';
+import 'package:umacapture/src/chara_detail/spec/logic.dart';
+import 'package:umacapture/src/chara_detail/spec/spec_tree.dart';
+import 'package:umacapture/src/core/mapper_init.dart';
+
+void main() {
+  setUpAll(initializeMappers);
+
+  ColumnSpec leaf(String id) => ColumnSpecMapper.fromMap(<String, dynamic>{
+    'type': 'RangedIntegerColumnSpec',
+    'id': id,
+    'title': id.toUpperCase(),
+    'parser': <String, dynamic>{'type': 'FansParser'},
+    'predicate': <String, dynamic>{'min': null, 'max': null},
+    'cellAction': 'openCampaignPreview',
+  });
+
+  LogicColumnSpec container(String id, List<ColumnSpec> children) =>
+      LogicColumnSpec(id: id, title: id.toUpperCase(), logic: LogicMode.and, children: children);
+
+  List<String> ids(List<ColumnSpec> specs) => [for (final s in specs) s.id];
+
+  group('findInForest', () {
+    test('finds a top-level spec', () {
+      expect(findInForest([leaf('a'), leaf('b')], 'b')?.id, 'b');
+    });
+
+    test('finds a deeply nested spec', () {
+      final forest = [
+        leaf('a'),
+        container('g', [
+          leaf('b'),
+          container('h', [leaf('c')]),
+        ]),
+      ];
+      expect(findInForest(forest, 'c')?.id, 'c');
+    });
+
+    test('returns null for an absent id and an empty forest', () {
+      expect(findInForest([leaf('a')], 'x'), isNull);
+      expect(findInForest(const [], 'a'), isNull);
+    });
+  });
+
+  group('detachFromForest', () {
+    test('removes a top-level spec and reports it', () {
+      final (forest, removed) = detachFromForest([leaf('a'), leaf('b')], 'a');
+      expect(ids(forest), ['b']);
+      expect(removed?.id, 'a');
+    });
+
+    test('removes a nested spec, rebuilding only its parent branch', () {
+      final (forest, removed) = detachFromForest([
+        container('g', [leaf('b'), leaf('c')]),
+      ], 'b');
+      expect(removed?.id, 'b');
+      final group = forest.single as LogicColumnSpec;
+      expect(ids(group.children), ['c']);
+    });
+
+    test('leaves the forest unchanged and reports null when absent', () {
+      final input = [leaf('a'), leaf('b')];
+      final (forest, removed) = detachFromForest(input, 'x');
+      expect(removed, isNull);
+      expect(ids(forest), ['a', 'b']);
+    });
+  });
+
+  group('insertIntoForest', () {
+    test('inserts into the top level at the given index', () {
+      final result = insertIntoForest([leaf('a'), leaf('c')], null, 1, leaf('b'));
+      expect(ids(result), ['a', 'b', 'c']);
+    });
+
+    test('clamps an out-of-range index to the ends', () {
+      expect(ids(insertIntoForest([leaf('a')], null, 99, leaf('z'))), ['a', 'z']);
+      expect(ids(insertIntoForest([leaf('a')], null, -5, leaf('z'))), ['z', 'a']);
+    });
+
+    test('inserts into a target container by id', () {
+      final result = insertIntoForest(
+        [
+          container('g', [leaf('b')]),
+        ],
+        'g',
+        1,
+        leaf('d'),
+      );
+      final group = result.single as LogicColumnSpec;
+      expect(ids(group.children), ['b', 'd']);
+    });
+
+    test('does not mutate the input list', () {
+      final input = [leaf('a'), leaf('c')];
+      insertIntoForest(input, null, 1, leaf('b'));
+      expect(ids(input), ['a', 'c']);
+    });
+  });
+
+  group('removeLifting', () {
+    test('dissolves a container, lifting its children into its slot', () {
+      final result = removeLifting([
+        leaf('a'),
+        container('g', [leaf('b'), leaf('c')]),
+        leaf('d'),
+      ], 'g');
+      expect(ids(result!), ['a', 'b', 'c', 'd']);
+    });
+
+    test('lifts a nested container in place', () {
+      final result = removeLifting([
+        container('outer', [
+          leaf('a'),
+          container('inner', [leaf('b')]),
+        ]),
+      ], 'inner');
+      final outer = result!.single as LogicColumnSpec;
+      expect(ids(outer.children), ['a', 'b']);
+    });
+
+    test('returns null when the id is absent', () {
+      expect(removeLifting([leaf('a')], 'x'), isNull);
+    });
+  });
+
+  group('replaceInForest', () {
+    test('replaces a top-level spec with the given instance', () {
+      final replacement = leaf('a');
+      final result = replaceInForest([leaf('a'), leaf('b')], replacement);
+      expect(identical(result![0], replacement), isTrue);
+    });
+
+    test('replaces a nested spec sharing the replacement id', () {
+      final replacement = leaf('b');
+      final result = replaceInForest([
+        container('g', [leaf('b')]),
+      ], replacement);
+      final group = result!.single as LogicColumnSpec;
+      expect(identical(group.children.single, replacement), isTrue);
+    });
+
+    test('returns null when no spec has the replacement id', () {
+      expect(replaceInForest([leaf('a')], leaf('x')), isNull);
+    });
+  });
+
+  group('flattenForest', () {
+    test('emits each parent immediately before its children, depth-first', () {
+      final forest = [
+        leaf('a'),
+        container('g', [
+          leaf('b'),
+          container('h', [leaf('c')]),
+        ]),
+        leaf('d'),
+      ];
+      expect(ids(flattenForest(forest)), ['a', 'g', 'b', 'h', 'c', 'd']);
+    });
+
+    test('an empty forest flattens to empty', () {
+      expect(flattenForest(const []), isEmpty);
+    });
+  });
+}

--- a/test/storage_archive_inheritance_test.dart
+++ b/test/storage_archive_inheritance_test.dart
@@ -20,48 +20,7 @@ import 'package:umacapture/src/core/platform_controller.dart';
 import 'package:umacapture/src/core/providers.dart';
 import 'package:umacapture/src/core/version_check.dart';
 
-Character _chara(int card) => Character(0, 0, card, 0);
-
-Parent _parent(int card) => Parent(_chara(card), _chara(0), _chara(0), null);
-
-// Builds a record carrying only the fields dedup and the resolver read; the rest
-// is dummy. Mirrors the helper in inheritance_resolver_test.dart.
-CharaDetailRecord makeRecord({
-  required String id,
-  required int card,
-  List<Factor> self = const [],
-  int parent1Card = 0,
-  List<Factor> parent1 = const [],
-  String? parent1Id,
-}) {
-  final metadata = Metadata(
-    '1.0.0',
-    'JPN',
-    RecordId(id, parent1Id, null),
-    'trainer',
-    '2026-01-01T00:00:00+0900',
-    '2026-01-01T00:00:00+0900',
-    RecordStage.active,
-    0,
-    null,
-    RecordType.standard,
-  );
-  return CharaDetailRecord(
-    metadata,
-    _chara(card),
-    0,
-    const CharacterStatus(0, 0, 0, 0, 0),
-    const AptitudeSet(GroundAptitude(0, 0), DistanceAptitude(0, 0, 0, 0), StyleAptitude(0, 0, 0, 0)),
-    const <Skill>[],
-    FactorSet(self, parent1, const []),
-    const <SupportCard>[],
-    Family(_parent(parent1Card), _parent(0)),
-    0,
-    const Scenario(0),
-    '2026/01/01',
-    const <Race>[],
-  );
-}
+import 'support/records.dart';
 
 void main() {
   setUpAll(initializeMappers);

--- a/test/support/hive.dart
+++ b/test/support/hive.dart
@@ -1,0 +1,23 @@
+// Shared Hive setup for tests that exercise Hive-backed storage.
+import 'dart:io';
+
+import 'package:hive_ce/hive.dart';
+
+/// Initializes Hive against a throwaway temp directory and opens [boxes].
+///
+/// Returns a teardown callback that closes Hive and removes the temp directory;
+/// register it with `addTearDown` or invoke it in `tearDownAll`. Callers that
+/// need a clean box per test can `Hive.box(name).clear()` in `setUp`.
+Future<Future<void> Function()> initHiveForTest(List<String> boxes) async {
+  final dir = Directory.systemTemp.createTempSync('umacapture_hive_test');
+  Hive.init(dir.path);
+  for (final box in boxes) {
+    await Hive.openBox(box);
+  }
+  return () async {
+    await Hive.close();
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+  };
+}

--- a/test/support/records.dart
+++ b/test/support/records.dart
@@ -1,0 +1,77 @@
+// Shared CharaDetailRecord fixtures for the domain-logic tests.
+//
+// Records built here carry only the fields the domain logic reads (card,
+// factors, family parent cards, record-id links, races); every other field is a
+// dummy zero value. Direct construction needs no mappers; [recordFromFixture]
+// does (call initializeMappers() in setUpAll).
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:umacapture/src/chara_detail/chara_detail_record.dart';
+
+/// A [Character] carrying only its [card] id; the other slots are irrelevant to
+/// the domain logic these fixtures exercise.
+Character chara(int card) => Character(0, 0, card, 0);
+
+/// A [Parent] whose own card is [card]; its grandparents are zeroed.
+Parent parentOf(int card) => Parent(chara(card), chara(0), chara(0), null);
+
+/// A win (finish position 1) of race title [title]; pass `won: false` for a
+/// non-winning entry. Other race fields are irrelevant to relation-bonus scoring.
+Race race(int title, {bool won = true}) => Race(title, 0, 0, 0, 0, 0, 0, 0, won ? 1 : 2);
+
+/// Builds a record carrying only the fields dedup and the inheritance resolver
+/// read; everything else is dummy.
+CharaDetailRecord makeRecord({
+  required String id,
+  required int card,
+  List<Factor> self = const [],
+  int parent1Card = 0,
+  List<Factor> parent1 = const [],
+  int parent2Card = 0,
+  List<Factor> parent2 = const [],
+  String? parent1Id,
+  String? parent2Id,
+  int? relationBonus,
+  List<Race> races = const [],
+}) {
+  final metadata = Metadata(
+    '1.0.0',
+    'JPN',
+    RecordId(id, parent1Id, parent2Id),
+    'trainer',
+    '2026-01-01T00:00:00+0900',
+    '2026-01-01T00:00:00+0900',
+    RecordStage.active,
+    0,
+    relationBonus,
+    RecordType.standard,
+  );
+  return CharaDetailRecord(
+    metadata,
+    chara(card),
+    0,
+    const CharacterStatus(0, 0, 0, 0, 0),
+    const AptitudeSet(GroundAptitude(0, 0), DistanceAptitude(0, 0, 0, 0), StyleAptitude(0, 0, 0, 0)),
+    const <Skill>[],
+    FactorSet(self, parent1, parent2),
+    const <SupportCard>[],
+    Family(parentOf(parent1Card), parentOf(parent2Card)),
+    0,
+    const Scenario(0),
+    '2026/01/01',
+    races,
+  );
+}
+
+/// A copy of the shared fixture record with its id and captured date replaced,
+/// so a test can hold multiple distinct real records. Requires initializeMappers().
+CharaDetailRecord recordFromFixture(String id, String capturedDate) {
+  final map = (jsonDecode(File('test/fixtures/chara_detail_record.json').readAsStringSync()) as Map)
+      .cast<String, dynamic>();
+  final metadata = (map['metadata'] as Map).cast<String, dynamic>();
+  (metadata['record_id'] as Map)['self'] = id;
+  metadata['captured_date'] = capturedDate;
+  map['metadata'] = metadata;
+  return CharaDetailRecordMapper.fromMap(map);
+}

--- a/test/support/riverpod.dart
+++ b/test/support/riverpod.dart
@@ -1,0 +1,8 @@
+// Shared Riverpod test helpers.
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:umacapture/src/core/utils.dart';
+
+/// Exposes a [RefBase] from a container so functions and runners that take a
+/// [RefBase] (rather than a [ProviderContainer]) can be exercised in tests:
+/// `container.read(refBaseProvider)`.
+final refBaseProvider = Provider<RefBase>((ref) => ref.base);

--- a/test/tag_driven_column_test.dart
+++ b/test/tag_driven_column_test.dart
@@ -11,10 +11,8 @@ import 'package:umacapture/src/chara_detail/spec/factor.dart';
 import 'package:umacapture/src/chara_detail/spec/loader.dart';
 import 'package:umacapture/src/chara_detail/spec/parser.dart';
 import 'package:umacapture/src/chara_detail/spec/skill.dart';
-import 'package:umacapture/src/core/utils.dart';
 
-// Exposes a [RefBase] so the spec's evaluate (which takes one) can run in tests.
-final _refBaseProvider = Provider<RefBase>((ref) => ref.base);
+import 'support/riverpod.dart';
 
 SkillInfo _skillInfo(int sid, Set<String> tags) => SkillInfo(sid, sid, ['skill$sid'], ['desc$sid'], tags);
 
@@ -62,7 +60,7 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
-    final ref = container.read(_refBaseProvider);
+    final ref = container.read(refBaseProvider);
 
     final spec = _tagSkillSpec({'green'});
     final results = spec.evaluate(ref, [
@@ -90,7 +88,7 @@ void main() {
       ],
     );
     addTearDown(before.dispose);
-    expect(spec.evaluate(before.read(_refBaseProvider), values), [false]);
+    expect(spec.evaluate(before.read(refBaseProvider), values), [false]);
 
     // Same spec, updated master where skill 3 has gained the green tag.
     final after = ProviderContainer.test(
@@ -102,7 +100,7 @@ void main() {
       ],
     );
     addTearDown(after.dispose);
-    expect(spec.evaluate(after.read(_refBaseProvider), values), [true]);
+    expect(spec.evaluate(after.read(refBaseProvider), values), [true]);
   });
 
   test('factor column resolves both tag axes (factor tag AND linked skill tag) from the master', () {
@@ -116,7 +114,7 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
-    final ref = container.read(_refBaseProvider);
+    final ref = container.read(refBaseProvider);
 
     // Factor-tag axis only.
     final statusSpec = _tagFactorSpec(factorTags: {'factor_status'});
@@ -153,7 +151,7 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
-    final ref = container.read(_refBaseProvider);
+    final ref = container.read(refBaseProvider);
 
     final goldSpec = _tagFactorSpec(skillTags: {'gold'}); // no factor's linked skill is gold
     expect(
@@ -174,7 +172,7 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
-    final ref = container.read(_refBaseProvider);
+    final ref = container.read(refBaseProvider);
 
     final spec = _tagSkillSpec({'nonexistent'});
     expect(
@@ -198,7 +196,7 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
-    final ref = container.read(_refBaseProvider);
+    final ref = container.read(refBaseProvider);
 
     final spec = _tagFactorSpec(); // no tags selected
     expect(
@@ -220,7 +218,7 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
-    final ref = container.read(_refBaseProvider);
+    final ref = container.read(refBaseProvider);
 
     final spec = _tagSkillSpec(const {}); // no tags selected
     expect(
@@ -235,7 +233,7 @@ void main() {
   test('the green-skill preset builder produces a tag-driven, display-only column', () {
     final container = ProviderContainer.test();
     addTearDown(container.dispose);
-    final ref = container.read(_refBaseProvider);
+    final ref = container.read(refBaseProvider);
 
     final builder = TagDrivenSkillColumnBuilder(
       title: '緑スキル',
@@ -259,7 +257,7 @@ void main() {
   test('resetting a legacy frozen green-skill column migrates it to tag-driven', () {
     final container = ProviderContainer.test();
     addTearDown(container.dispose);
-    final ref = container.read(_refBaseProvider);
+    final ref = container.read(refBaseProvider);
 
     // A column as persisted by the old preset: frozen ids, selectByTag = false.
     final legacy = SkillColumnSpec(

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,8 +1,0 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-void main() {}


### PR DESCRIPTION
## Summary

Adds unit tests for high-risk Dart logic that previously had no coverage,
consolidates the duplicated per-test scaffolding into `test/support/`, makes the
Dart test coverage visible in CI, and hardens the native coverage CI step that
was flaking on this PR.

### Tests (no production code changes)

Following existing conventions (`initializeMappers`, `ProviderContainer.test`,
shared record helpers):

- **`core/bootstrap.dart`** — data-root override read/write plus every fallback
  branch: missing file, malformed JSON, non-string / blank `data_root`, an
  absolute-but-unreachable root, and a relative path. Pins the
  `dataRootDegraded` flag and the process-global reset. A fake
  `PathProviderPlatform` points the fixed `data_root.json` at a temp directory,
  since `_bootstrapFile()` is private.
- **`chara_detail/spec/{character,relation_bonus,race_grade}.dart`** — the three
  spec columns that had no tests: predicates, `evaluate` / `parse`, `copyWith`,
  `withFilterReset`, and serialization round-trips. Covers the
  confirmed-vs-lower-bound relation-bonus distinction (confirmed `0` ≠
  not-yet-known `0`) and stale-selection handling in the graded-race win count.
- **`core/sentry_util.dart`** — `CustomHint` Hint serialization round-trip.
- **`chara_detail/spec/spec_tree.dart`** — the forest algebra behind
  column-selection tree edits (insert / detach / lift / replace / flatten),
  including index clamping, absent-id handling, and input immutability (100%).
- **`core/json_adapter.dart`** — the Size / Offset / RegExp / ThemeMode mapper
  encode↔decode round-trip, including the documented flags-not-serialized
  limitation and unknown-name rejection (88%).
- **`core/callback.dart`** — `CallbackExtension.bind` value capture and
  `PlainChangeNotifier` listener/dispose behavior (100%).
- **`preference/privacy_setting.dart`** — `allowPostUserData()` tri-state and the
  notifier default/persistence (75%; the Sentry-available branch of
  `isFeedbackAvailable` is intentionally out of scope).

Adds `path_provider_platform_interface` and `plugin_platform_interface` as dev
dependencies so `bootstrap_test` can swap `PathProviderPlatform.instance`
(makes the transitive deps explicit; avoids `depend_on_referenced_packages`).

### Shared test helpers (`test/support/`)

Consolidates scaffolding that was copy-pasted across the suite, with no change in
behavior (net −107 lines in the touched files):

- **`records.dart`** — `makeRecord` / `race` / `chara` / `parentOf` and
  `recordFromFixture`, replacing the identical `makeRecord` duplicated across the
  inheritance and archive tests and the `_recordVariant` helper in the addon
  tests.
- **`riverpod.dart`** — `refBaseProvider`, replacing the local definition
  duplicated across eight test files.
- **`hive.dart`** — `initHiveForTest`, adopted by the new privacy test and the
  settings notifier test (which also gains temp-dir teardown).

Deletes the empty `test/widget_test.dart` flutter template stub. Single-use
fakes (`FakeRunner`, `FakeRecordStorage`, `_settle`) were left local rather than
over-extracted.

### CI: measure Dart coverage; harden the native OpenCppCoverage install

- The Flutter test job now runs `flutter test --coverage test` and uploads
  `coverage/lcov.info` as the `flutter-coverage` artifact (mirrors the
  native-coverage upload: `if: always`, `if-no-files-found: warn`). No threshold
  is enforced yet — this is baseline visibility, since the Dart side previously
  had none.
- The `Native C++ tests` job flaked here: the chocolatey feed returned **504**
  while fetching `opencppcoverage`, and `choco install` exits 0 even when it
  fetched 0 packages, so it only surfaced later as `OpenCppCoverage.exe ... is
  not recognized`. The install is now a retry loop that checks the binary
  actually exists: a transient 504 is absorbed (up to 5 attempts), while a
  persistent outage fails the step loudly so coverage is never silently skipped.

## Test plan

- `flutter test --coverage test` → 436 passed (+35 new); `coverage/lcov.info`
  generated.
- `flutter analyze --no-fatal-infos` → no issues.
- `dart format --output=none --set-exit-if-changed lib test` clean (pre-commit
  hook passes).
- Native coverage step exercised by this PR's own job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
