### PR TITLE
ci: retry OpenCppCoverage install and fail loudly on persistent outage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,26 @@ jobs:
           & native\cmake-build-tests\umacapture_tests.exe 2>&1 |
             Select-String -Pattern 'test cases:|assertions:|Status:'
 
-      # ---- P2: coverage visibility (non-gating) ----
+      # ---- P2: coverage visibility ----
+      # The chocolatey community feed intermittently 504s, and `choco install`
+      # exits 0 even when it fetched 0 packages, so a transient outage would
+      # otherwise sail past this step and only surface as a confusing "exe not
+      # found" in "Measure coverage". Retry until the binary actually exists, and
+      # fail loudly if it never appears -- coverage is never silently skipped: a
+      # persistent feed outage gates the job (red) rather than passing green.
       - name: Install OpenCppCoverage
-        run: choco install opencppcoverage -y
+        shell: pwsh
+        run: |
+          $exe = "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe"
+          foreach ($attempt in 1..5) {
+            Write-Host "Installing OpenCppCoverage (attempt $attempt/5)..."
+            choco install opencppcoverage -y --no-progress
+            if (Test-Path $exe) { exit 0 }
+            Write-Warning "OpenCppCoverage not present after attempt $attempt (chocolatey feed may be flaky); retrying in 30s..."
+            Start-Sleep -Seconds 30
+          }
+          Write-Error "OpenCppCoverage could not be installed after 5 attempts; failing so coverage is not silently skipped."
+          exit 1
 
       # Re-runs the Debug test binary under instrumentation and exports HTML + Cobertura.
       # --sources native\src keeps the report to backend code (substring match excludes


### PR DESCRIPTION
## Problem

An unrelated PR's `Native C++ tests` job went red at the **Measure coverage**
step with `OpenCppCoverage.exe ... is not recognized`. Root cause: the
chocolatey community feed returned **504 Gateway Timeout** while fetching
`opencppcoverage`, so `choco install` installed 0/0 packages — but exited 0.
The failure only surfaced one step later as a missing exe. The native
tests (ctest/doctest) themselves passed; only the coverage step failed, yet it
gated the PR on pure infrastructure flakiness.

## Change

Wrap the install in a PowerShell retry loop that checks the binary actually
exists (rather than trusting choco's exit code):

- A transient 504 is absorbed by up to 5 attempts (30s apart).
- A **persistent** outage fails the step (red) with an explicit message, so
  coverage measurement is **never silently skipped** — a missing coverage run
  is always visible, and the real native-test gate is unaffected (it runs
  earlier).

Only `.github/workflows/ci.yml` changes; no production or test code touched.

## Test plan

Exercised by this PR's own `Native C++ tests` job. On the happy path the first
attempt installs and coverage runs as before; the retry path only engages when
the feed is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
