### PR TITLE
ci: cut the Flutter job wall-clock (~6m38s -> ~4m15s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,5 +179,9 @@ jobs:
       # is intentionally excluded. Coverage is deliberately not collected here: --coverage
       # roughly doubles the wall-clock (VM-service instrumentation) for a report that has no
       # enforced threshold and only served as a visibility artifact.
+      # -j 4 raises the suite-level parallelism from the default (cores/2 = 2 on the
+      # 4-vCPU Windows runner); flutter's own issue tracker reports the speedup plateaus
+      # around 4. --reporter github emits GitHub Actions annotations for failures and a
+      # more compact log.
       - name: Run tests
-        run: flutter test test
+        run: flutter test -j 4 --reporter github test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,21 @@ jobs:
       - name: Resolve dependencies
         run: flutter pub get
 
+      # Persist build_runner's incremental state (.dart_tool/build holds the asset graph
+      # of input content digests) so codegen only regenerates changed outputs instead of
+      # rebuilding from scratch every run. Correctness is preserved regardless of what is
+      # restored: build_runner re-validates every tracked input by digest on each run, and
+      # discards the whole graph on a builder/dependency/SDK version change. The key busts
+      # on pubspec.lock/build.yaml changes as a belt-and-suspenders; restore-keys keeps the
+      # incremental benefit across unrelated commits.
+      - name: Cache build_runner
+        uses: actions/cache@v4
+        with:
+          path: .dart_tool/build
+          key: build-runner-${{ runner.os }}-${{ hashFiles('pubspec.lock', 'build.yaml') }}
+          restore-keys: |
+            build-runner-${{ runner.os }}-
+
       # --force-jit is required in this repo (a transitive native build hook is
       # incompatible with build_runner's default AOT). Generated outputs are committed;
       # regenerating here also catches a stale/forgotten regeneration.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,17 +127,16 @@ jobs:
       # .fvm/ is gitignored, so CI cannot use the FVM path. Install the same pinned SDK
       # directly. Keep this version in sync with .fvmrc (currently 3.44.4).
       #
-      # cache is disabled on purpose: on the Windows runner, restoring the cached SDK
-      # (~1.8 GB) and pub cache (~0.26 GB) is dominated by tar/zstd extraction of many
-      # small files (~100 s total), which was slower than letting flutter-action fetch
-      # the release archive and running a cold `pub get`. Re-evaluate if the cold path
-      # regresses.
+      # cache stays enabled: `cache: false` was measured (PR #125) and lost. Skipping the
+      # cache trimmed SDK setup by ~24 s but forced a cold `pub get` that cost ~73 s more
+      # than restoring the pub cache -- a ~50 s net regression. The Windows tar/zstd
+      # extraction is slow, but re-downloading every package is slower.
       - name: Set up Flutter 3.44.4
         uses: subosito/flutter-action@v2
         with:
           flutter-version: 3.44.4
           channel: stable
-          cache: false
+          cache: true
 
       - name: Resolve dependencies
         run: flutter pub get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,12 +126,18 @@ jobs:
 
       # .fvm/ is gitignored, so CI cannot use the FVM path. Install the same pinned SDK
       # directly. Keep this version in sync with .fvmrc (currently 3.44.4).
+      #
+      # cache is disabled on purpose: on the Windows runner, restoring the cached SDK
+      # (~1.8 GB) and pub cache (~0.26 GB) is dominated by tar/zstd extraction of many
+      # small files (~100 s total), which was slower than letting flutter-action fetch
+      # the release archive and running a cold `pub get`. Re-evaluate if the cold path
+      # regresses.
       - name: Set up Flutter 3.44.4
         uses: subosito/flutter-action@v2
         with:
           flutter-version: 3.44.4
           channel: stable
-          cache: true
+          cache: false
 
       - name: Resolve dependencies
         run: flutter pub get
@@ -156,15 +162,8 @@ jobs:
         run: dart format --output=none --set-exit-if-changed lib test
 
       # Unit/widget only. The Windows-desktop integration_test (needs a full app build + uv)
-      # is intentionally excluded. --coverage emits coverage/lcov.info for visibility
-      # (mirrors the native OpenCppCoverage artifact); no threshold is enforced yet.
+      # is intentionally excluded. Coverage is deliberately not collected here: --coverage
+      # roughly doubles the wall-clock (VM-service instrumentation) for a report that has no
+      # enforced threshold and only served as a visibility artifact.
       - name: Run tests
-        run: flutter test --coverage test
-
-      - name: Upload coverage report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: flutter-coverage
-          path: coverage
-          if-no-files-found: warn
+        run: flutter test test


### PR DESCRIPTION
## Summary

The two CI jobs run in parallel; the native job finishes in ~2m13s while the
Flutter job took ~6m38s, so total CI time is Flutter-bound. This PR attacks the
Flutter job's largest steps. Every change below was measured on this branch.

Flutter job wall-clock: **~6m38s -> ~4m15-30s** (~2-2.5 min faster).

## Changes (in commit order)

1. **Drop `flutter test --coverage`** (and the coverage upload step). VM-service
   instrumentation roughly doubled the test step; the report had no enforced
   threshold and only served as a visibility artifact. Test step **147s -> 89s**.

2. **Keep the flutter-action SDK/pub cache** (`cache: true`). `cache: false` was
   tried and measured: it trimmed SDK setup ~24s but forced a cold `pub get`
   (~8s -> ~81s), a **~50s net regression**. Reverted.

3. **Cache `.dart_tool/build`** (build_runner incremental state). build_runner
   re-validates every tracked input by content digest each run and discards the
   whole asset graph on a builder/dependency/SDK version change, so a restored
   cache cannot produce stale outputs; the `pubspec.lock` / `build.yaml` key plus
   restore-keys is belt-and-suspenders. Codegen **~76s -> ~11s** on a warm cache.

4. **`flutter test -j 4 --reporter github`.** Raises suite parallelism from the
   default (cores/2 = 2 on the 4-vCPU runner); flutter/flutter#168268 reports the
   speedup plateaus around 4. Modest here (**85s -> ~78s**) because the suite is
   small, but it is not a regression and the github reporter surfaces failures as
   annotations.

## Measured step breakdown (Flutter job)

| Step | Baseline | This PR (warm cache) |
|---|---|---|
| Set up Flutter | ~120s | ~100s |
| build_runner | ~73s | **~11s** |
| Analyze | ~39s | ~39s |
| Run tests | ~147s (coverage) | **~78s** (`-j 4`, no coverage) |

## Investigated and deliberately not done

- **Test sharding (matrix):** counterproductive here. Each shard re-pays the
  fixed ~100s Flutter setup + pub + codegen before running a slice of a ~78s
  suite, so it would increase wall-clock and billed minutes. Only worth it once
  test time dwarfs setup.
- **Disabling caches / `cache: false`:** measured as a net regression (change 2).
- **Set up Flutter (~100s):** dominated by Windows tar/zstd extraction; standard
  caching cannot reduce it further. The remaining lever is a larger/faster
  (paid) runner, which would also help build and `-j`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
