### PR TITLE
Enable Windows PDB emission and Sentry symbol upload

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -89,6 +89,20 @@ resolves to the FVM default (3.44.0), but verify rather than assume.
    flutter_distributor, e.g. 0.6.6). Do not reactivate on every run — only when
    the probe fails. The published executable is `flutter_distributor:main`.
 
+5. **`sentry-cli` and a Sentry auth token are available** (needed by the symbol
+   upload in Phase 2, step 8.5). The upload lets Sentry symbolicate native
+   Windows crashes; skipping it only means that release's native crashes stay as
+   raw addresses, so it is not release-blocking, but do it whenever possible.
+   ```bash
+   sentry-cli --version || npm install -g @sentry/cli
+   [ -n "$(tr -d ' \t\r\n' < ~/.sentry_token)" ] && echo "sentry token present" || echo "MISSING"
+   ```
+   The read token at `~/.sentry_token` already carries `project:write`, so the
+   same file the `sentry-issues` skill reads is sufficient — no separate token is
+   needed. Org/project defaults come from the committed `.sentryclirc`
+   (`umasagashi` / `umacapture-release`); the token is passed via the
+   `SENTRY_AUTH_TOKEN` env var, never on the command line.
+
 ## Phase 1 — version bump + codegen + commit/push
 
 1. Pick the new version with the user (semver, e.g. `0.0.11`; no leading `v`).
@@ -152,6 +166,29 @@ release the publisher creates attaches to the pushed `v<version>` tag.
    ```
    This builds `dist/umacapture-v<version>-windows.exe` and `.zip`, then creates
    (or reuses) the `v<version>` GitHub **pre-release** and uploads both as assets.
+
+   flutter_distributor runs `flutter build windows --release` internally, so the
+   fresh, matching PDBs are now sitting in `build/windows/x64/runner/Release/`.
+   Do step 8.5 **before** anything cleans `build/` — the debug-ids must match the
+   exe that was just packaged, and they cannot be regenerated later.
+
+8.5. Upload debug symbols so Sentry can symbolicate this build's native crashes.
+   Two files matter: `umacapture.pdb` (covers the runner **and** the native C++
+   backend, which is linked straight into the exe) and the engine's
+   `flutter_windows.dll.pdb` (already in the FVM SDK cache — no download). Third-
+   party DLLs (`opencv_world455.dll`, `onnxruntime.dll`) ship without PDBs and
+   stay unsymbolicated; that is expected.
+   ```bash
+   export SENTRY_AUTH_TOKEN="$(tr -d ' \t\r\n' < ~/.sentry_token)"
+   ENGINE_PDB=".fvm/flutter_sdk/bin/cache/artifacts/engine/windows-x64-release/flutter_windows.dll.pdb"
+   sentry-cli debug-files upload --include-sources \
+     build/windows/x64/runner/Release/umacapture.pdb "$ENGINE_PDB"
+   ```
+   Expect `UPLOADED` lines for both debug-ids (source warnings about oversized
+   Windows SDK headers are harmless). Verify the exe carries a matching debug-id
+   with `sentry-cli debug-files check build/windows/x64/runner/Release/umacapture.exe`
+   — if the Debug ID is absent, the `/DEBUG` link flags in
+   `windows/runner/CMakeLists.txt` regressed and symbols will never match.
 9. Attach `version_info.json` as a release asset. flutter_distributor only
    uploads the packaged exe/zip, so add this lightweight file separately (it lets
    a client read the published version without downloading a build). `--clobber`

--- a/.claude/skills/sentry-issues/SKILL.md
+++ b/.claude/skills/sentry-issues/SKILL.md
@@ -61,8 +61,9 @@ command line and shell history.
 - If the file is missing or empty, ask the user to create one: Sentry → Settings →
   Auth Tokens, scopes `event:read` + `project:read` (add `org:read` only if you
   need org-wide queries). Read-only is enough for everything in this skill.
-- Uploading debug symbols (see below) needs a *different*, write-capable token —
-  out of scope here.
+- Uploading debug symbols (the `release` skill's Phase 2) needs `project:write`.
+  The token in `~/.sentry_token` already carries it, so the same file works for
+  both reading issues here and uploading PDBs there — no separate token needed.
 
 ## Quick start — use the helper script
 
@@ -118,13 +119,18 @@ The `--query` value is standard Sentry issue search:
 - **Native crashes** (`platform: native`, `mechanism: minidump`, e.g. an
   `EXCEPTION_ACCESS_VIOLATION`) arrive as raw addresses. Only OS modules
   (`ntdll`, `USER32`, `dxgi`, …) resolve to names automatically via Microsoft's
-  public symbol server; `umacapture.exe` and `flutter_windows.dll` frames stay as
-  `?` because **their debug symbols (PDBs) were never uploaded to Sentry**. You
-  can still read the surrounding OS frames to infer *what* the app was doing
-  (e.g. window teardown, graphics release), but not the exact app function.
-  Symbolicating app frames would require uploading the matching build's PDBs via
-  `sentry-cli debug-files upload` — there is currently no such step in the release
-  pipeline, and it's only worth setting up if native crashes become frequent.
+  public symbol server. As of the PDB-upload change, **`umacapture.exe` and
+  `flutter_windows.dll` frames also symbolicate — but only for builds released
+  after that change**. The `release` skill's Phase 2 now uploads both PDBs
+  (`sentry-cli debug-files upload`), and `windows/runner/CMakeLists.txt` emits a
+  `/DEBUG` PDB with a matching CodeView debug-id for the runner + native C++
+  backend. Builds from **before** the change (e.g. 0.1.0 and earlier) carry no
+  debug-id in the exe at all, so their native app frames can never be
+  symbolicated retroactively — no PDB will ever match them. Third-party DLLs
+  (`opencv_world455.dll`, `onnxruntime.dll`) ship without PDBs and stay `?` on
+  every build. For those pre-change or third-party frames, read the surrounding
+  OS frames to infer *what* the app was doing (window teardown, graphics
+  release), not the exact function.
 
 **Version tagging is consistent.** Both the Dart side (`assets/version_info.json`)
 and the native side (`windows/runner/Runner.rc` `FLUTTER_VERSION`) derive from the

--- a/.sentryclirc
+++ b/.sentryclirc
@@ -1,0 +1,7 @@
+# sentry-cli defaults for uploading debug symbols (PDBs) after a release build.
+# Non-secret coordinates only; the auth token is supplied via the
+# SENTRY_AUTH_TOKEN environment variable, never stored here.
+[defaults]
+url=https://sentry.io/
+org=umasagashi
+project=umacapture-release

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -41,6 +41,21 @@ message(STATUS "You don't need to add OpenCV to your PATH, but you need to copy 
 
 apply_standard_settings(${BINARY_NAME})
 
+# Emit debug symbols (a .pdb) for optimized builds so native crashes reported to
+# Sentry can be symbolicated. The native C++ backend is compiled straight into
+# this executable (see SOURCE_FILES above), so umacapture.pdb covers both the
+# runner and the recognition code. Without /DEBUG the exe carries no CodeView
+# debug-id, and Sentry has nothing to match an uploaded pdb against. /OPT:REF and
+# /OPT:ICF restore the size optimizations that /DEBUG otherwise turns off.
+set(RELEASE_OR_PROFILE "$<OR:$<CONFIG:Release>,$<CONFIG:Profile>>")
+target_compile_options(${BINARY_NAME} PRIVATE "$<${RELEASE_OR_PROFILE}:/Zi>")
+target_link_options(
+        ${BINARY_NAME} PRIVATE
+        "$<${RELEASE_OR_PROFILE}:/DEBUG>"
+        "$<${RELEASE_OR_PROFILE}:/OPT:REF>"
+        "$<${RELEASE_OR_PROFILE}:/OPT:ICF>"
+)
+
 target_compile_definitions(
         ${BINARY_NAME} PRIVATE
         NOMINMAX


### PR DESCRIPTION
## Problem

Native Windows crashes reported to Sentry on 0.1.0 arrive as raw addresses
(`umacapture.exe ? 0x7ff6...`). Inspecting the minidump debug images shows
`umacapture.exe` has **no debug-id at all** — the Release build never passed
`/DEBUG` to the linker, so no usable PDB was generated and nothing could ever
be matched against the shipped exe.

## Changes

- **`windows/runner/CMakeLists.txt`** — emit a `/DEBUG` PDB (`/Zi` + `/DEBUG` +
  `/OPT:REF,ICF`) for Release/Profile on the runner target. The native C++
  backend (`native/src/...`) is compiled straight into the exe, so a single
  `umacapture.pdb` covers both the runner and the recognition code.
- **`.sentryclirc`** (new) — non-secret `org`/`project` defaults for `sentry-cli`
  (`umasagashi` / `umacapture-release`). The auth token is supplied via the
  `SENTRY_AUTH_TOKEN` env var, never stored in the file.
- **`release` skill** — new Phase 2 step (8.5) that uploads `umacapture.pdb` and
  the engine's `flutter_windows.dll.pdb` (already in the FVM SDK cache) right
  after the build, plus a preflight check for `sentry-cli` and the token.
- **`sentry-issues` skill** — correct the now-stale notes that claimed no PDB
  step existed and that a separate write-capable token was required (the
  existing `~/.sentry_token` already has `project:write`).

## Verification

- `flutter build windows --release` now produces `umacapture.pdb`, and the exe
  carries a matching Debug ID (`8218f5ea-...`); `sentry-cli debug-files check`
  reports `Usable: yes`.
- Both `umacapture.pdb` and `flutter_windows.dll.pdb` upload cleanly with the
  existing token (`UPLOADED` for both debug-ids).

## Scope / caveats

- Builds from before this change (0.1.0 and earlier) have no debug-id in the
  exe and **cannot be symbolicated retroactively** — the benefit starts with the
  next release.
- Third-party DLLs (`opencv_world455.dll`, `onnxruntime.dll`) ship without PDBs
  and remain unsymbolicated; that is expected.
- The symbol upload is a manual step in the local release flow (CI does not run
  `flutter build windows`), consistent with how releases are cut today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
