### PR TITLE
refactor(chara-detail): drive scrollbar geometry from config and gate the factor reset on the green header

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -21,6 +21,23 @@ the user explicitly asks**.
 - Keep all repository artifacts in English per the language policy, including
   commit messages and PR titles/descriptions.
 
+## PR title and body style
+
+Match the repo convention (see recent merged PRs):
+
+- **Title — Conventional Commits** `type(scope): summary`. Types in use: `feat`,
+  `fix`, `refactor`, `chore`, `ci`, `test`, `style`. Scope is optional, kebab-case,
+  and names the area (`chara-detail`, `native`, `sentry`, …). The summary is
+  lowercase, imperative, and has no trailing period.
+- **Body — Markdown with `##` sections.** Lead with `## Summary` (1–2 sentences on
+  what changed and why), then the detail (`## What changed` with **bold**-led
+  bullets, or numbered `### 1. …` subsections for a multi-part PR), and close with
+  `## Testing` stating what was run and the result. Add `## Risk / scope`,
+  `## Design notes`, or `## Follow-up` only when they carry real information.
+- Use `code` for identifiers and paths and **bold** for each point's key term;
+  keep it skimmable. End the body with the
+  `🤖 Generated with [Claude Code](https://claude.com/claude-code)` footer.
+
 ## Generated files and line endings
 
 - This repo uses `core.autocrlf=true`, so generated files written with LF would

--- a/assets/config/chara_detail/scene_scraper.json
+++ b/assets/config/chara_detail/scene_scraper.json
@@ -498,6 +498,6 @@
     "band_start": 0.65,
     "band_end": 0.88,
     "green_fraction_threshold": 0.5,
-    "flush_tolerance": 0.006
+    "flush_tolerance": 0.002
   }
 }

--- a/assets/config/chara_detail/scene_scraper.json
+++ b/assets/config/chara_detail/scene_scraper.json
@@ -481,5 +481,23 @@
       "b": 57
     }
   },
-  "header_visible_time_threshold": 100
+  "header_visible_time_threshold": 100,
+  "factor_header": {
+    "color_range": {
+      "min": {
+        "r": 83,
+        "g": 177,
+        "b": 0
+      },
+      "max": {
+        "r": 173,
+        "g": 255,
+        "b": 65
+      }
+    },
+    "band_start": 0.65,
+    "band_end": 0.88,
+    "green_fraction_threshold": 0.5,
+    "flush_tolerance": 0.006
+  }
 }

--- a/assets/config/chara_detail/scene_scraper.json
+++ b/assets/config/chara_detail/scene_scraper.json
@@ -156,6 +156,16 @@
         "g": 255,
         "b": 255
       }
+    },
+    "scroll_bar_thumb_probe": {
+      "centroid_half_width": 0.010869565217391304,
+      "white_reference_gap": 0.012228260869565218,
+      "white_reference_band": 0.002717391304347826,
+      "core_half_width": 0.002717391304347826,
+      "cap_skip": 0.004076086956521739,
+      "max_sampled_rows": 32,
+      "minimum_contrast": 20.0,
+      "minimum_coverage": 3.0
     }
   },
   "friend_common": {
@@ -315,6 +325,16 @@
         "g": 255,
         "b": 255
       }
+    },
+    "scroll_bar_thumb_probe": {
+      "centroid_half_width": 0.010869565217391304,
+      "white_reference_gap": 0.012228260869565218,
+      "white_reference_band": 0.002717391304347826,
+      "core_half_width": 0.002717391304347826,
+      "cap_skip": 0.004076086956521739,
+      "max_sampled_rows": 32,
+      "minimum_contrast": 20.0,
+      "minimum_coverage": 3.0
     }
   },
   "skill_scans": [

--- a/assets/config/chara_detail/scene_scraper.json
+++ b/assets/config/chara_detail/scene_scraper.json
@@ -498,6 +498,6 @@
     "band_start": 0.65,
     "band_end": 0.88,
     "green_fraction_threshold": 0.5,
-    "flush_tolerance": 0.002
+    "flush_tolerance_px": 1.5
   }
 }

--- a/assets/config/chara_detail/scene_scraper.json
+++ b/assets/config/chara_detail/scene_scraper.json
@@ -72,6 +72,24 @@
         }
       }
     },
+    "scroll_bar_rect": {
+      "top_left": {
+        "x": 0.0,
+        "y": 0.8093,
+        "anchor": {
+          "h": "IntersectStart",
+          "v": "IntersectStart"
+        }
+      },
+      "bottom_right": {
+        "x": 0.0,
+        "y": -0.2426,
+        "anchor": {
+          "h": "IntersectPixelEnd",
+          "v": "IntersectLogicalEnd"
+        }
+      }
+    },
     "scroll_area_stationary_rect": {
       "top_left": {
         "x": 0.0222,
@@ -196,6 +214,24 @@
       }
     },
     "scroll_area_rect": {
+      "top_left": {
+        "x": 0.0,
+        "y": 0.9896304347826087,
+        "anchor": {
+          "h": "IntersectStart",
+          "v": "IntersectStart"
+        }
+      },
+      "bottom_right": {
+        "x": 0.0,
+        "y": -0.2426,
+        "anchor": {
+          "h": "IntersectPixelEnd",
+          "v": "IntersectLogicalEnd"
+        }
+      }
+    },
+    "scroll_bar_rect": {
       "top_left": {
         "x": 0.0,
         "y": 0.9896304347826087,

--- a/assets/config/chara_detail/scene_scraper.json
+++ b/assets/config/chara_detail/scene_scraper.json
@@ -122,7 +122,7 @@
     },
     "scroll_bar_scan_line": {
       "p1": {
-        "x": 0.9676,
+        "x": 0.9693,
         "y": 0.0092,
         "anchor": {
           "h": "IntersectStart",
@@ -130,7 +130,7 @@
         }
       },
       "p2": {
-        "x": 0.9676,
+        "x": 0.9693,
         "y": -0.0092,
         "anchor": {
           "h": "IntersectStart",
@@ -281,7 +281,7 @@
     },
     "scroll_bar_scan_line": {
       "p1": {
-        "x": 0.9676,
+        "x": 0.9693,
         "y": 0.0092,
         "anchor": {
           "h": "IntersectStart",
@@ -289,7 +289,7 @@
         }
       },
       "p2": {
-        "x": 0.9676,
+        "x": 0.9693,
         "y": -0.0092,
         "anchor": {
           "h": "IntersectStart",

--- a/assets/config/chara_detail/scene_scraper.json
+++ b/assets/config/chara_detail/scene_scraper.json
@@ -124,7 +124,21 @@
     "minimum_scroll_threshold": 0.05,
     "stationary_time_threshold": 200,
     "minimum_color_threshold": 18,
-    "stationary_color_threshold": 100
+    "stationary_color_threshold": 100,
+    "viewport": 0.738,
+    "cap_offset": 0.00126,
+    "scroll_bar_margin_color": {
+      "min": {
+        "r": 228,
+        "g": 228,
+        "b": 228
+      },
+      "max": {
+        "r": 255,
+        "g": 255,
+        "b": 255
+      }
+    }
   },
   "friend_common": {
     "base_image_stationary_rect": {
@@ -251,7 +265,21 @@
     "minimum_scroll_threshold": 0.05,
     "stationary_time_threshold": 200,
     "minimum_color_threshold": 18,
-    "stationary_color_threshold": 100
+    "stationary_color_threshold": 100,
+    "viewport": 0.553,
+    "cap_offset": 0.00126,
+    "scroll_bar_margin_color": {
+      "min": {
+        "r": 228,
+        "g": 228,
+        "b": 228
+      },
+      "max": {
+        "r": 255,
+        "g": 255,
+        "b": 255
+      }
+    }
   },
   "skill_scans": [
     {

--- a/native/src/chara_detail/chara_detail_config.h
+++ b/native/src/chara_detail/chara_detail_config.h
@@ -99,6 +99,31 @@ struct ScanParameter {
     EXTENDED_JSON_TYPE_NDC(ScanParameter, x, length, color_range);
 };
 
+// Locates the green "因子" section header, whose top edge moves 1:1 with the factor list (unlike the scroll
+// thumb, whose travel is compressed by viewport/content). maybeResetOnFactorChange uses it as a precise "flush
+// at the very top" sensor: it runs the same-character content diff only when the header sits at its reference
+// (flush) y, so a tiny scroll of the same character no longer reads as a switch.
+struct FactorHeaderConfig {
+    // Vivid header green (same UI green as factor_end_green / header_color_range).
+    Range<Color> color_range;
+    // Horizontal probe band, expressed as fractions of the scroll-area crop width. Right of centre, clear of the
+    // left icon column and the diagonal stripes, where only the solid header spans the whole band.
+    double band_start;
+    double band_end;
+    // Minimum green fraction across the band for a row to count as the header (rejects a narrow stray green pill).
+    double green_fraction_threshold;
+    // Max |current - reference| header y (width-normalized, matching the anchor's units) still treated as flush.
+    double flush_tolerance;
+
+    EXTENDED_JSON_TYPE_NDC(
+        FactorHeaderConfig,
+        color_range,
+        band_start,
+        band_end,
+        green_fraction_threshold,
+        flush_tolerance);
+};
+
 struct CharaDetailSceneScraperConfig {
     SceneScraperConfig common;
     SceneScraperConfig friend_common;
@@ -109,6 +134,7 @@ struct CharaDetailSceneScraperConfig {
     Line<double> header_scan_line;
     Range<Color> header_color_range;
     uint64 header_visible_time_threshold;
+    FactorHeaderConfig factor_header;
 
     EXTENDED_JSON_TYPE_NDC(
         CharaDetailSceneScraperConfig,
@@ -120,7 +146,8 @@ struct CharaDetailSceneScraperConfig {
         factor_end_green,
         header_scan_line,
         header_color_range,
-        header_visible_time_threshold);
+        header_visible_time_threshold,
+        factor_header);
 };
 
 }  // namespace scraper_config

--- a/native/src/chara_detail/chara_detail_config.h
+++ b/native/src/chara_detail/chara_detail_config.h
@@ -55,6 +55,16 @@ struct SceneScraperConfig {
     uint64 stationary_time_threshold;
     int minimum_color_threshold;
     uint64 stationary_color_threshold;
+    // Scrollbar physics, all width-normalized so they scale with the screen and never depend on the crop
+    // height (each layout carries its own values). `viewport` is the visible content height V used to turn
+    // thumb geometry into a content-pixel offset (abs = V * upper_gap / thumb_length); it is NOT the crop
+    // height. `cap_offset` is the thumb's rounded-cap depth c: the tip-to-tip length over-reads the logical
+    // thumb length by 2c, so the logical length is `tip - 2 * cap_offset`. `scroll_bar_margin_color` is the
+    // near-white band flanking the placeholder track; isolating it locates the fixed track ends so the
+    // position is measured against the true track, not the (slightly longer) config scan line.
+    double viewport;
+    double cap_offset;
+    Range<Color> scroll_bar_margin_color;
 
     EXTENDED_JSON_TYPE_NDC(
         SceneScraperConfig,
@@ -69,7 +79,10 @@ struct SceneScraperConfig {
         minimum_scroll_threshold,
         stationary_time_threshold,
         minimum_color_threshold,
-        stationary_color_threshold);
+        stationary_color_threshold,
+        viewport,
+        cap_offset,
+        scroll_bar_margin_color);
 };
 
 struct ScanParameter {

--- a/native/src/chara_detail/chara_detail_config.h
+++ b/native/src/chara_detail/chara_detail_config.h
@@ -42,6 +42,41 @@ inline const auto path_config = PathUtil();  // NOLINT(cert-err58-cpp)
 
 namespace scraper_config {
 
+// Sub-pixel thumb-centre probe geometry for ScrollBarOffsetEstimator::trackCenterX. The thumb is a
+// fixed-DPI pill; the spatial fields are fractions of the scroll-area crop width (reference: 736 px capture,
+// ~7 px pill) and converted to pixels through the frame anchor, so they scale with the capture resolution
+// instead of assuming one. `max_sampled_rows`, `minimum_contrast` and `minimum_coverage` are not spatial: a
+// plain row count and two intensity/coverage thresholds.
+struct ScrollBarThumbProbeConfig {
+    // Half-width (columns) of the AA intensity-weighted centroid window centred on the config column.
+    double centroid_half_width;
+    // Outward offset to the near-white reference band flanking the pill, just past its edge.
+    double white_reference_gap;
+    // Width of the white reference band, sampled inward from `white_reference_gap`.
+    double white_reference_band;
+    // Half-width (columns) of the darkest-core sample taken at the column.
+    double core_half_width;
+    // Rows skipped at each rounded cap, so the centroid reads only the thumb's straight central run.
+    double cap_skip;
+    // Sampled-row cap (a count, resolution-independent); keeps a tall thumb cheap.
+    int max_sampled_rows;
+    // Minimum white-to-core intensity gap (0-255) for a row to contribute a centroid.
+    double minimum_contrast;
+    // Minimum summed AA coverage across the window for a row's centroid to be kept.
+    double minimum_coverage;
+
+    EXTENDED_JSON_TYPE_NDC(
+        ScrollBarThumbProbeConfig,
+        centroid_half_width,
+        white_reference_gap,
+        white_reference_band,
+        core_half_width,
+        cap_skip,
+        max_sampled_rows,
+        minimum_contrast,
+        minimum_coverage);
+};
+
 struct SceneScraperConfig {
     Rect<double> base_image_stationary_rect;
     Rect<double> base_image_rect;
@@ -70,6 +105,8 @@ struct SceneScraperConfig {
     double viewport;
     double cap_offset;
     Range<Color> scroll_bar_margin_color;
+    // Sub-pixel thumb-centre probe geometry (self-centres the vertical scan on the thumb; see trackCenterX).
+    ScrollBarThumbProbeConfig scroll_bar_thumb_probe;
 
     EXTENDED_JSON_TYPE_NDC(
         SceneScraperConfig,
@@ -88,7 +125,8 @@ struct SceneScraperConfig {
         stationary_color_threshold,
         viewport,
         cap_offset,
-        scroll_bar_margin_color);
+        scroll_bar_margin_color,
+        scroll_bar_thumb_probe);
 };
 
 struct ScanParameter {

--- a/native/src/chara_detail/chara_detail_config.h
+++ b/native/src/chara_detail/chara_detail_config.h
@@ -112,8 +112,12 @@ struct FactorHeaderConfig {
     double band_end;
     // Minimum green fraction across the band for a row to count as the header (rejects a narrow stray green pill).
     double green_fraction_threshold;
-    // Max |current - reference| header y (width-normalized, matching the anchor's units) still treated as flush.
-    double flush_tolerance;
+    // Max |current - reference| header top-edge offset, in capture pixels, still treated as flush. In pixels (not
+    // a width fraction) on purpose: the two quantities this discriminates -- the ~1 px header-row detection jitter
+    // and the ~2 px scroll at which the content diff already spikes -- are pixel-scale, not screen-geometry-scale.
+    // A width fraction would drift with capture resolution and, at a smaller capture, shrink below the 1 px jitter
+    // floor and start dropping real switches.
+    double flush_tolerance_px;
 
     EXTENDED_JSON_TYPE_NDC(
         FactorHeaderConfig,
@@ -121,7 +125,7 @@ struct FactorHeaderConfig {
         band_start,
         band_end,
         green_fraction_threshold,
-        flush_tolerance);
+        flush_tolerance_px);
 };
 
 struct CharaDetailSceneScraperConfig {

--- a/native/src/chara_detail/chara_detail_config.h
+++ b/native/src/chara_detail/chara_detail_config.h
@@ -47,6 +47,11 @@ struct SceneScraperConfig {
     Rect<double> base_image_rect;
     Rect<double> tab_button_rect;
     Rect<double> scroll_area_rect;
+    // Full-width band the scrollbar is detected in, decoupled from scroll_area_rect (the content/stitch crop)
+    // so the latter can move without shifting the scan geometry. It MUST stay full width (x IntersectStart ->
+    // IntersectPixelEnd): the scan line x, viewport and cap_offset are all normalized by the crop width, so a
+    // narrower band would silently mis-scale them. Only its y-range is meant to diverge from scroll_area_rect.
+    Rect<double> scroll_bar_rect;
     Rect<double> scroll_area_stationary_rect;
     Range<Color> scroll_bar_bg_color;
     Line<double> scroll_bar_scan_line;
@@ -72,6 +77,7 @@ struct SceneScraperConfig {
         base_image_rect,
         tab_button_rect,
         scroll_area_rect,
+        scroll_bar_rect,
         scroll_area_stationary_rect,
         scroll_bar_bg_color,
         scroll_bar_scan_line,

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -39,28 +39,154 @@ constexpr double kFactorEndGreenSearchSpan = 0.08;
 }  // namespace
 
 ScrollBarOffsetEstimator::ScrollBarOffsetEstimator(
-    const Range<Color> &scroll_bar_bg_color_range, const Line<double> &scroll_bar_scan_line)
+    const Range<Color> &scroll_bar_bg_color_range,
+    const Line<double> &scroll_bar_scan_line,
+    const Range<Color> &scroll_bar_margin_color_range,
+    double viewport,
+    double cap_offset)
     : scroll_bar_bg_color_range(scroll_bar_bg_color_range)
-    , scroll_bar_scan_line(scroll_bar_scan_line) {}
+    , scroll_bar_scan_line(scroll_bar_scan_line)
+    , scroll_bar_margin_color_range(scroll_bar_margin_color_range)
+    , viewport(viewport)
+    , cap_offset(cap_offset) {}
 
 bool ScrollBarOffsetEstimator::hasScrollbar(const Frame &frame) const {
     return findScrollbar(frame).has_value();
 }
 
-std::optional<double> ScrollBarOffsetEstimator::position(const Frame &frame) const {
-    const auto margin = scanMargin(frame);
-    if (!margin) {
+std::optional<ScrollBarOffsetEstimator::TrackGeometry>
+ScrollBarOffsetEstimator::geometryAt(const Frame &frame, const Line<double> &scan_line) const {
+    // Background run from each end reaches the thumb (dark, out of the light bg range). == 1. means the whole
+    // line is background: no thumb, so no scrollbar. Same guard as scanMargin().
+    const auto upper = frame.lengthIn(scroll_bar_bg_color_range, scan_line);
+    const auto lower = frame.lengthIn(scroll_bar_bg_color_range, scan_line.reversed());
+    if (!upper || upper.value() == 1. || !lower || lower.value() == 1.) {
+        return std::nullopt;  // Bar not found.
+    }
+
+    // Margin run from each end reaches the (non-white) placeholder track, locating its fixed top/bottom.
+    // Fail open: if the near-white margin is absent (== 1. is the whole line, so ignore it too), fall back to
+    // the scan endpoints, i.e. the old scan-line-relative behaviour, rather than dropping the whole frame.
+    const auto margin_upper = frame.lengthIn(scroll_bar_margin_color_range, scan_line);
+    const auto margin_lower = frame.lengthIn(scroll_bar_margin_color_range, scan_line.reversed());
+    const double m_up = (margin_upper && margin_upper.value() < 1.) ? margin_upper.value() : 0.0;
+    const double m_lo = (margin_lower && margin_lower.value() < 1.) ? margin_lower.value() : 0.0;
+
+    const auto scan = frame.anchor().absolute(scan_line).vertical();
+    const double thumb_top = scan.pointAt(upper.value());
+    const double thumb_bottom = scan.pointAt(1. - lower.value());
+    const double track_top = scan.pointAt(m_up);
+    const double track_bottom = scan.pointAt(1. - m_lo);
+
+    const double thumb_logical = (thumb_bottom - thumb_top) - 2. * cap_offset;
+    const double track_span = track_bottom - track_top;
+    if (thumb_logical <= 0. || track_span <= 0.) {
         return std::nullopt;
     }
-    return 1.0 - margin->second;
+    // Clamp on overscroll: the thumb shortens and its top pins to the track top, so a tiny negative gap from
+    // sub-pixel noise should read as "at the top" (0), not a small backward offset.
+    const double upper_gap = std::max(0., thumb_top - track_top);
+    return TrackGeometry{upper_gap, track_span, thumb_logical};
+}
+
+std::optional<double> ScrollBarOffsetEstimator::trackCenterX(const Frame &frame) const {
+    // Locate the thumb vertically at the configured column (its dark run out of the light bg), then read the
+    // AA coverage centroid across the columns spanning the thumb over its central rows (caps skipped).
+    const auto upper = frame.lengthIn(scroll_bar_bg_color_range, scroll_bar_scan_line);
+    const auto lower = frame.lengthIn(scroll_bar_bg_color_range, scroll_bar_scan_line.reversed());
+    if (!upper || upper.value() == 1. || !lower || lower.value() == 1.) {
+        return std::nullopt;
+    }
+    const auto &anchor = frame.anchor();
+    const auto scan = anchor.absolute(scroll_bar_scan_line).vertical();
+    const int unit = anchor.scaleToPixels(1.0);
+    const int cfg = anchor.scaleToPixels(scroll_bar_scan_line.p1().x());
+    const int thumb_top = anchor.scaleToPixels(scan.pointAt(upper.value()));
+    const int thumb_bottom = anchor.scaleToPixels(scan.pointAt(1. - lower.value()));
+
+    constexpr int kHalf = 8;      // centroid window half-width (columns)
+    constexpr int kWhiteGap = 9;  // white reference sampled at +-[7,9] from cfg, clear of the ~7 px pill
+    constexpr int kCapSkip = 3;   // rows skipped at each rounded cap (sub-thumb intensity)
+    constexpr int kMaxRows = 32;  // cap the sampled rows so a tall thumb stays cheap
+    constexpr double kMinContrast = 20.;
+
+    const cv::Mat &image = frame.data();
+    const int row_lo = thumb_top + kCapSkip;
+    const int row_hi = thumb_bottom - kCapSkip;
+    if (cfg - kWhiteGap < 0 || cfg + kWhiteGap >= image.cols || row_lo < 0 || row_hi >= image.rows
+        || row_hi - row_lo < 1) {
+        return std::nullopt;
+    }
+    const auto red = [&image](int x, int y) { return static_cast<double>(image.at<cv::Vec3b>(y, x)[2]); };
+
+    const int stride = std::max(1, (row_hi - row_lo) / kMaxRows);
+    std::vector<double> centers;
+    for (int y = row_lo; y <= row_hi; y += stride) {
+        std::array<double, 6> whites = {
+            red(cfg - kWhiteGap, y),
+            red(cfg - kWhiteGap + 1, y),
+            red(cfg - kWhiteGap + 2, y),
+            red(cfg + kWhiteGap - 2, y),
+            red(cfg + kWhiteGap - 1, y),
+            red(cfg + kWhiteGap, y),
+        };
+        std::sort(whites.begin(), whites.end());
+        const double white = (whites[2] + whites[3]) / 2.;
+        double core = 255.;
+        for (int x = cfg - 2; x <= cfg + 2; x++) {
+            core = std::min(core, red(x, y));
+        }
+        if (white - core < kMinContrast) {
+            continue;
+        }
+        double weight_sum = 0.;
+        double weighted_x = 0.;
+        for (int x = cfg - kHalf; x <= cfg + kHalf; x++) {
+            const double coverage = std::clamp((white - red(x, y)) / (white - core), 0., 1.);
+            weight_sum += coverage;
+            weighted_x += coverage * x;
+        }
+        if (weight_sum >= 3.) {
+            centers.push_back(weighted_x / weight_sum);
+        }
+    }
+    if (centers.empty()) {
+        return std::nullopt;
+    }
+    std::nth_element(centers.begin(), centers.begin() + static_cast<long>(centers.size() / 2), centers.end());
+    return centers[centers.size() / 2] / unit;
+}
+
+std::optional<ScrollBarOffsetEstimator::TrackGeometry>
+ScrollBarOffsetEstimator::trackGeometry(const Frame &frame) const {
+    const auto center_x = trackCenterX(frame);
+    if (!center_x) {
+        return geometryAt(frame, scroll_bar_scan_line);  // Fall back to the fixed config column.
+    }
+    const auto &p1 = scroll_bar_scan_line.p1();
+    const auto &p2 = scroll_bar_scan_line.p2();
+    const Line<double> centered_line{{center_x.value(), p1.y(), p1.anchor()}, {center_x.value(), p2.y(), p2.anchor()}};
+    return geometryAt(frame, centered_line);
+}
+
+std::optional<double> ScrollBarOffsetEstimator::position(const Frame &frame) const {
+    const auto geometry = trackGeometry(frame);
+    if (!geometry) {
+        return std::nullopt;
+    }
+    const double scrollable = geometry->track_span - geometry->thumb_logical;
+    if (scrollable <= 0.) {
+        return std::nullopt;  // Thumb fills the track: nothing to scroll.
+    }
+    return std::clamp(geometry->upper_gap / scrollable, 0., 1.);
 }
 
 std::optional<double> ScrollBarOffsetEstimator::topMargin(const Frame &frame) const {
-    const auto margin = scanMargin(frame);
-    if (!margin) {
+    const auto geometry = trackGeometry(frame);
+    if (!geometry) {
         return std::nullopt;
     }
-    return margin->first;
+    return geometry->upper_gap / geometry->track_span;
 }
 
 std::optional<double> ScrollBarOffsetEstimator::estimate(FrameDescriptor &from, FrameDescriptor &to) const {
@@ -113,29 +239,21 @@ std::optional<std::pair<double, double>> ScrollBarOffsetEstimator::scanMargin(co
 }
 
 std::optional<double> ScrollBarOffsetEstimator::scrollOffsetGuess(const Frame &from, const Frame &to) const {
-    const auto from_margin = scanMargin(from);
-    const auto to_margin = scanMargin(to);
-    if (!from_margin || !to_margin) {
+    const auto from_geometry = trackGeometry(from);
+    const auto to_geometry = trackGeometry(to);
+    if (!from_geometry || !to_geometry) {
         return std::nullopt;
     }
-    // Absolute scroll offset (content px from the top) implied by one frame's scrollbar geometry, using
-    // THAT frame's own thumb length -- unlike estimate()'s shared-length delta, this stays correct
-    // across a thumb-length change. Derivation: total content = V/f, scrollable range = V(1/f - 1),
-    // scrolled fraction = upper/(upper+lower); their product simplifies to V*upper/f.
-    const auto absolute_offset = [](const Frame &frame,
-                                    const std::pair<double, double> &margin) -> std::optional<double> {
-        const double thumb_length = 1.0 - margin.first - margin.second;
-        if (thumb_length <= 0.0) {
-            return std::nullopt;
-        }
-        return static_cast<double>(frame.height()) * margin.first / thumb_length;
+    // Absolute scroll offset (content px from the top) implied by one frame's scrollbar geometry, using THAT
+    // frame's own thumb length -- unlike estimate()'s shared-length delta, this stays correct across a
+    // thumb-length change. abs = V * upper_gap / thumb_logical, with V the true viewport (config, width-
+    // normalized -> px via scaleToPixels) rather than the crop height, and thumb_logical the cap-corrected
+    // thumb length. The fixed track top cancels in the delta below, but V and the -2c correction do not.
+    const auto absolute_offset = [this](const Frame &frame, const TrackGeometry &geometry) -> double {
+        const double viewport_px = frame.anchor().scaleToPixels(viewport);
+        return viewport_px * geometry.upper_gap / geometry.thumb_logical;
     };
-    const auto from_offset = absolute_offset(from, from_margin.value());
-    const auto to_offset = absolute_offset(to, to_margin.value());
-    if (!from_offset || !to_offset) {
-        return std::nullopt;
-    }
-    return to_offset.value() - from_offset.value();
+    return absolute_offset(to, to_geometry.value()) - absolute_offset(from, from_geometry.value());
 }
 
 ImageOffsetEstimator::ImageOffsetEstimator(const ImageOffsetEstimatorConfig &config)
@@ -839,8 +957,12 @@ void SceneScraper::build(const Frame &frame) {
     const auto initial_frame = frame.view(config.scroll_area_rect);
     log_debug("{}, {}", initial_frame.size().width(), initial_frame.size().height());
 
-    scroll_bar_estimator =
-        std::make_unique<ScrollBarOffsetEstimator>(config.scroll_bar_bg_color, config.scroll_bar_scan_line);
+    scroll_bar_estimator = std::make_unique<ScrollBarOffsetEstimator>(
+        config.scroll_bar_bg_color,
+        config.scroll_bar_scan_line,
+        config.scroll_bar_margin_color,
+        config.viewport,
+        config.cap_offset);
     const auto &scroll_bar_offset_estimator = *scroll_bar_estimator;
 
     const auto stationary_catcher = StationaryFrameCatcher(

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -387,11 +387,11 @@ ScrollAreaOffsetEstimator::ScrollAreaOffsetEstimator(
     , image_offset_estimator(image_offset_estimator) {}
 
 std::optional<double> ScrollAreaOffsetEstimator::position(const FrameDescriptor &descriptor) const {
-    return scroll_bar_offset_estimator.position(descriptor.frame);
+    return scroll_bar_offset_estimator.position(descriptor.scroll_bar_frame);
 }
 
 std::optional<double> ScrollAreaOffsetEstimator::estimate(FrameDescriptor &from, FrameDescriptor &to) const {
-    const auto guess = scroll_bar_offset_estimator.estimate(from.frame, to.frame);
+    const auto guess = scroll_bar_offset_estimator.estimate(from.scroll_bar_frame, to.scroll_bar_frame);
     if (!guess) {
         return std::nullopt;
     }
@@ -407,7 +407,7 @@ ScrollAreaOffsetEstimator::estimateAcrossRescale(FrameDescriptor &from, FrameDes
     if (!(from.frame.size() == to.frame.size())) {
         return std::nullopt;  // resolution change; estimate() already rejected it -- do not recover here.
     }
-    const auto guess = scroll_bar_offset_estimator.scrollOffsetGuess(from.frame, to.frame);
+    const auto guess = scroll_bar_offset_estimator.scrollOffsetGuess(from.scroll_bar_frame, to.scroll_bar_frame);
     if (!guess) {
         return std::nullopt;
     }
@@ -745,14 +745,18 @@ Frame StationaryFrameCatcher::croppedFrame() const {
 }
 
 NonScrollableScrapingInterpreter::NonScrollableScrapingInterpreter(
-    const std::shared_ptr<PageScrapingBox> &scraping_box, const StationaryFrameCatcher &stationary_catcher)
+    const std::shared_ptr<PageScrapingBox> &scraping_box,
+    const StationaryFrameCatcher &stationary_catcher,
+    const Rect<double> &scroll_area_rect)
     : stationary_catcher(stationary_catcher)
+    , scroll_area_rect(scroll_area_rect)
     , scraping_box(scraping_box) {}
 
 void NonScrollableScrapingInterpreter::update(const Frame &frame) {
     assert_(state == Updatable);
     has_updated = true;
-    if (readyAfterUpdate(stationary_catcher, frame)) {
+    // Crop the content region from the full frame; the catcher and capture see the same pixels as before.
+    if (readyAfterUpdate(stationary_catcher, frame.copy(scroll_area_rect))) {
         scraping_box->setScrollArea(stationary_catcher.fullSizeFrame());
         state = Ready;
     }
@@ -770,6 +774,8 @@ ScrollableScrapingInterpreter::ScrollableScrapingInterpreter(
     const std::shared_ptr<PageScrapingBox> &scraping_box,
     const ScrollAreaOffsetEstimator &offset_estimator,
     const StationaryFrameCatcher &stationary_catcher,
+    const Rect<double> &scroll_area_rect,
+    const Rect<double> &scroll_bar_rect,
     double initial_scroll_threshold,
     double minimum_scroll_threshold,
     const event_util::Sender<> &on_scroll_ready,
@@ -777,6 +783,8 @@ ScrollableScrapingInterpreter::ScrollableScrapingInterpreter(
     : on_scroll_ready(on_scroll_ready)
     , on_scroll_updated(on_scroll_updated)
     , offset_estimator(offset_estimator)
+    , scroll_area_rect(scroll_area_rect)
+    , scroll_bar_rect(scroll_bar_rect)
     , initial_scroll(initial_scroll_threshold)
     , minimum_scroll(minimum_scroll_threshold)
     , scraping_box(scraping_box)
@@ -801,34 +809,36 @@ bool ScrollableScrapingInterpreter::started() const {
 }
 
 void ScrollableScrapingInterpreter::updateBefore(const Frame &frame) {
-    if (readyAfterUpdate(stationary_catcher, frame)) {
-        startScrolling(stationary_catcher.fullSizeFrame());
+    // `frame` is the full frame: the catcher/capture use the content crop, the estimator the scroll-bar band.
+    if (readyAfterUpdate(stationary_catcher, frame.copy(scroll_area_rect))) {
+        // The catcher latched a stationary content frame; pair it with the current (stationary) scroll-bar band.
+        startScrolling({stationary_catcher.fullSizeFrame(), frame.copy(scroll_bar_rect)});
         on_scroll_ready->send();
         return;
     }
 
     if (initial_descriptor.empty()) {
-        initial_descriptor = {frame};
+        initial_descriptor = {frame.copy(scroll_area_rect), frame.copy(scroll_bar_rect)};
         return;
     }
 
-    FrameDescriptor current_descriptor = {frame};
+    FrameDescriptor current_descriptor = {frame.copy(scroll_area_rect), frame.copy(scroll_bar_rect)};
     if (offset_estimator.estimate(initial_descriptor, current_descriptor).value_or(-1.0) > initial_scroll) {
-        startScrolling(initial_descriptor.frame);
+        startScrolling(initial_descriptor);
         // didn't get a stationary image, so won't send a ready.
         return;
     }
 }
 
-void ScrollableScrapingInterpreter::startScrolling(const Frame &valid_frame) {
-    scraping_box->addScrollArea(valid_frame);
-    previous_descriptor = {valid_frame};
+void ScrollableScrapingInterpreter::startScrolling(const FrameDescriptor &valid_descriptor) {
+    scraping_box->addScrollArea(valid_descriptor.frame);
+    previous_descriptor = valid_descriptor;
     is_scrolling = true;
     on_scroll_updated->send(offset_estimator.position(previous_descriptor).value_or(0.0));
 }
 
 void ScrollableScrapingInterpreter::updateScrolling(const Frame &frame) {
-    FrameDescriptor current_fragment = {frame};
+    FrameDescriptor current_fragment = {frame.copy(scroll_area_rect), frame.copy(scroll_bar_rect)};
     auto offset = offset_estimator.estimate(previous_descriptor, current_fragment);
     if (!offset.has_value()) {
         // The shared-length scroll-bar guess in estimate() breaks when the game lazily re-scales the
@@ -846,12 +856,13 @@ void ScrollableScrapingInterpreter::updateScrolling(const Frame &frame) {
     // stationary (a scrollbar re-scale, not a real scroll), so the offset stays under minimum_scroll and
     // no strip is latched -- exactly the case a latch-coupled scan misses. Skip frames with no usable
     // offset (rescale non-match); the bar stays visible ~1 s (30+ frames), so a valid frame always comes.
-    if (offset.has_value() && scraping_box->detectGreenTerminator(frame, std::lround(offset.value()))) {
+    if (offset.has_value()
+        && scraping_box->detectGreenTerminator(current_fragment.frame, std::lround(offset.value()))) {
         // Crop the saved fragments to the same bottom line the gray-completion path uses, so the trailing
         // background below the last factor is a fixed margin regardless of which terminator ended the tab.
         // The last fragment otherwise runs to the frame bottom (addScrollArea's fallback save), leaving a
         // variable gap above the footer.
-        scraping_box->trimScrollAreaToFactorEnd(frame, std::lround(offset.value()));
+        scraping_box->trimScrollAreaToFactorEnd(current_fragment.frame, std::lround(offset.value()));
         // Report the final position before going Ready so the UI progress reaches 100% for the tab,
         // matching the gray-completion path below (which emits via addScrollArea). Without this, a
         // short-history factor tab that ends via the green terminator would stall one update short.
@@ -866,7 +877,7 @@ void ScrollableScrapingInterpreter::updateScrolling(const Frame &frame) {
         return;
     }
 
-    scraping_box->addScrollArea(frame, std::lround(offset.value()));
+    scraping_box->addScrollArea(current_fragment.frame, std::lround(offset.value()));
 
     // Report the position of the fragment just latched (current), not the previous one. position() reads only
     // the current frame's scrollbar geometry, so it is valid on current_fragment.
@@ -906,7 +917,8 @@ void SceneScraper::update(const Frame &frame) {
         readyForStitch();
     }
 
-    if (updateUntilReady(scroll_area_scraper, frame.copy(config.scroll_area_rect))) {
+    // Pass the full frame; the interpreter crops the content and scroll-bar regions internally.
+    if (updateUntilReady(scroll_area_scraper, frame)) {
         readyForStitch();
     }
 }
@@ -923,13 +935,16 @@ std::optional<double> SceneScraper::topMargin(const Frame &frame) const {
     if (scroll_bar_estimator == nullptr) {
         return std::nullopt;
     }
-    return scroll_bar_estimator->topMargin(frame.copy(config.scroll_area_rect));
+    return scroll_bar_estimator->topMargin(frame.copy(config.scroll_bar_rect));
 }
 
 void SceneScraper::build(const Frame &frame) {
     assert_(state == Null);
 
+    // Content crop: sizes the scroll thresholds (a content-scroll concern). Scroll-bar band: gates scrollbar
+    // detection, decoupled from the content crop.
     const auto initial_frame = frame.view(config.scroll_area_rect);
+    const auto scroll_bar_frame = frame.view(config.scroll_bar_rect);
     log_debug("{}, {}", initial_frame.size().width(), initial_frame.size().height());
 
     scroll_bar_estimator = std::make_unique<ScrollBarOffsetEstimator>(
@@ -946,17 +961,20 @@ void SceneScraper::build(const Frame &frame) {
         config.stationary_color_threshold,
         config.scroll_area_stationary_rect);
 
-    if (scroll_bar_offset_estimator.hasScrollbar(initial_frame)) {
+    if (scroll_bar_offset_estimator.hasScrollbar(scroll_bar_frame)) {
         scroll_area_scraper = std::make_unique<ScrollableScrapingInterpreter>(
             scraping_box,
             ScrollAreaOffsetEstimator(scroll_bar_offset_estimator, ImageOffsetEstimator()),
             stationary_catcher,
+            config.scroll_area_rect,
+            config.scroll_bar_rect,
             config.initial_scroll_threshold * initial_frame.height(),
             config.minimum_scroll_threshold * initial_frame.height(),
             on_scroll_ready,
             on_scroll_updated);
     } else {
-        scroll_area_scraper = std::make_unique<NonScrollableScrapingInterpreter>(scraping_box, stationary_catcher);
+        scroll_area_scraper = std::make_unique<NonScrollableScrapingInterpreter>(
+            scraping_box, stationary_catcher, config.scroll_area_rect);
     }
 
     tab_button_catcher = std::make_unique<StationaryFrameCatcher>(

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -51,13 +51,13 @@ ScrollBarOffsetEstimator::ScrollBarOffsetEstimator(
     , cap_offset(cap_offset) {}
 
 bool ScrollBarOffsetEstimator::hasScrollbar(const Frame &frame) const {
-    return findScrollbar(frame).has_value();
+    return trackGeometry(frame).has_value();
 }
 
 std::optional<ScrollBarOffsetEstimator::TrackGeometry>
 ScrollBarOffsetEstimator::geometryAt(const Frame &frame, const Line<double> &scan_line) const {
     // Background run from each end reaches the thumb (dark, out of the light bg range). == 1. means the whole
-    // line is background: no thumb, so no scrollbar. Same guard as scanMargin().
+    // line is background: no thumb, so no scrollbar.
     const auto upper = frame.lengthIn(scroll_bar_bg_color_range, scan_line);
     const auto lower = frame.lengthIn(scroll_bar_bg_color_range, scan_line.reversed());
     if (!upper || upper.value() == 1. || !lower || lower.value() == 1.) {
@@ -189,53 +189,31 @@ std::optional<double> ScrollBarOffsetEstimator::topMargin(const Frame &frame) co
     return geometry->upper_gap / geometry->track_span;
 }
 
-std::optional<double> ScrollBarOffsetEstimator::estimate(FrameDescriptor &from, FrameDescriptor &to) const {
-    // A resolution change mid-scroll would mix from.frame.height() (new-frame pixels) with a scroll_bar_length
-    // latched at the old scale below, yielding a wrong pixel offset. Bail before touching the latch so it is not
-    // polluted with a cross-scale max. (!= is not auto-generated for value types here; use !(==).)
-    if (!(from.frame.size() == to.frame.size())) {
+std::optional<double> ScrollBarOffsetEstimator::estimate(const Frame &from, const Frame &to) const {
+    // A mid-scroll resolution change would mix from's pixel scale (viewport_px below) with a cross-scale
+    // averaged thumb length, so the delta is only valid at one scale. Bail. (!= is not auto-generated for
+    // value types here; use !(==).)
+    if (!(from.size() == to.size())) {
         return std::nullopt;
     }
 
-    const auto &from_line = findScrollbar(from.frame);
-    const auto &to_line = findScrollbar(to.frame);
-    if (!from_line || !to_line) {
+    const auto from_geometry = trackGeometry(from);
+    const auto to_geometry = trackGeometry(to);
+    if (!from_geometry || !to_geometry) {
         return std::nullopt;
     }
 
-    const auto scroll_bar_length = std::max({
-        from.scroll_bar_length,
-        to.scroll_bar_length,
-        from_line->length(),
-        to_line->length(),
-    });
-    from.scroll_bar_length = scroll_bar_length;
-    to.scroll_bar_length = scroll_bar_length;
-
-    const auto &line_delta = to_line.value() - from_line.value();
-    const auto offset = (std::abs(line_delta.p1()) > std::abs(line_delta.p2())) ? line_delta.p1() : line_delta.p2();
-    return static_cast<double>(from.frame.height()) * offset / scroll_bar_length;
-}
-
-std::optional<Line1D<double>> ScrollBarOffsetEstimator::findScrollbar(const Frame &frame) const {
-    const auto margin = scanMargin(frame);
-    if (!margin) {
+    // Delta form over the calibrated track geometry: the fixed track top cancels in the upper_gap
+    // difference, so only one shared thumb length divides -- unlike scrollOffsetGuess()'s per-frame absolute
+    // difference, this cancels each frame's constant measurement bias and stays low-noise. When the game
+    // re-scales the thumb mid-scroll the two lengths disagree and this guess drifts; the image match then
+    // rejects it and estimateAcrossRescale() (each frame's OWN length) recovers -- see updateScrolling().
+    const double thumb_logical = (from_geometry->thumb_logical + to_geometry->thumb_logical) / 2.0;
+    if (thumb_logical <= 0.0) {
         return std::nullopt;
     }
-    const auto &scan_line = frame.anchor().absolute(scroll_bar_scan_line).vertical();
-    return Line1D<double>{
-        scan_line.pointAt(margin->first),
-        scan_line.pointAt(1. - margin->second),
-    };
-}
-
-std::optional<std::pair<double, double>> ScrollBarOffsetEstimator::scanMargin(const Frame &frame) const {
-    const auto &upper_margin = frame.lengthIn(scroll_bar_bg_color_range, scroll_bar_scan_line);
-    const auto &lower_margin = frame.lengthIn(scroll_bar_bg_color_range, scroll_bar_scan_line.reversed());
-    if (!upper_margin || upper_margin.value() == 1. || !lower_margin || lower_margin.value() == 1.) {
-        return std::nullopt;  // Bar not found.
-    }
-    return std::make_pair(upper_margin.value(), lower_margin.value());
+    const double viewport_px = from.anchor().scaleToPixels(viewport);
+    return viewport_px * (to_geometry->upper_gap - from_geometry->upper_gap) / thumb_logical;
 }
 
 std::optional<double> ScrollBarOffsetEstimator::scrollOffsetGuess(const Frame &from, const Frame &to) const {
@@ -413,7 +391,7 @@ std::optional<double> ScrollAreaOffsetEstimator::position(const FrameDescriptor 
 }
 
 std::optional<double> ScrollAreaOffsetEstimator::estimate(FrameDescriptor &from, FrameDescriptor &to) const {
-    const auto guess = scroll_bar_offset_estimator.estimate(from, to);
+    const auto guess = scroll_bar_offset_estimator.estimate(from.frame, to.frame);
     if (!guess) {
         return std::nullopt;
     }
@@ -844,7 +822,7 @@ void ScrollableScrapingInterpreter::updateBefore(const Frame &frame) {
 
 void ScrollableScrapingInterpreter::startScrolling(const Frame &valid_frame) {
     scraping_box->addScrollArea(valid_frame);
-    previous_descriptor = {valid_frame, initial_descriptor.scroll_bar_length};
+    previous_descriptor = {valid_frame};
     is_scrolling = true;
     on_scroll_updated->send(offset_estimator.position(previous_descriptor).value_or(0.0));
 }
@@ -854,16 +832,13 @@ void ScrollableScrapingInterpreter::updateScrolling(const Frame &frame) {
     auto offset = offset_estimator.estimate(previous_descriptor, current_fragment);
     if (!offset.has_value()) {
         // The shared-length scroll-bar guess in estimate() breaks when the game lazily re-scales the
-        // thumb (factor inheritance history appended mid-scroll): the guess becomes inconsistent with
-        // the pixels, the image match rejects it, and the reference would freeze -- stalling the tab.
-        // Recover with a guess computed from each frame's OWN thumb length, which stays valid across the
-        // re-scale. If the frames still match we keep the true offset and capture the fragment normally
-        // (no skipped content), instead of stalling; if they do not match this stays nullopt exactly as
-        // before. Resetting scroll_bar_length lets the next estimate re-latch at the new thumb length.
+        // thumb (factor inheritance history appended mid-scroll): the two frames' thumb lengths disagree,
+        // the guess becomes inconsistent with the pixels, the image match rejects it, and the reference
+        // would freeze -- stalling the tab. Recover with a guess computed from each frame's OWN thumb
+        // length, which stays valid across the re-scale. If the frames still match we keep the true offset
+        // and capture the fragment normally (no skipped content); if they do not match this stays nullopt
+        // exactly as before.
         offset = offset_estimator.estimateAcrossRescale(previous_descriptor, current_fragment);
-        if (offset.has_value()) {
-            current_fragment.scroll_bar_length = 0.0;
-        }
     }
 
     // Check the green terminator every frame, anchored to the scroll frontier (height - offset), BEFORE
@@ -894,7 +869,7 @@ void ScrollableScrapingInterpreter::updateScrolling(const Frame &frame) {
     scraping_box->addScrollArea(frame, std::lround(offset.value()));
 
     // Report the position of the fragment just latched (current), not the previous one. position() reads only
-    // the frame's scrollbar margin (independent of scroll_bar_length), so it is valid on current_fragment.
+    // the current frame's scrollbar geometry, so it is valid on current_fragment.
     // Emitting here also covers the final/bottom position before scrollAreaReady() returns, so the UI progress
     // reaches 100% for the tab instead of stalling one fragment short.
     const auto position = offset_estimator.position(current_fragment);

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -1142,6 +1142,12 @@ void CharaDetailSceneScraper::buildSession(record::RecordType record_type) {
         // Capture the flush header position alongside the reference; both are taken on this settled, at-top frame,
         // so maybeResetOnFactorChange can later reject a tiny scroll by comparing the header against it.
         reference_header_y = factorHeaderTopY(current_full_frame);
+        // If the header green is not found here, the flush gate is unavailable and maybeResetOnFactorChange falls
+        // back to the top-margin gate. A capture source whose green differs from the configured range (e.g. live
+        // WinRT vs a recorded clip) would trip this, so surface it rather than silently losing the header gate.
+        if (!reference_header_y) {
+            log_warning("factor probe: header not found; factor reset falls back to the top-margin gate");
+        }
         factor_change_pending_since = std::nullopt;
         on_factor_probe->send(Frame(current_full_frame), RecordInfo(current_record_info));
     });
@@ -1387,14 +1393,23 @@ void CharaDetailSceneScraper::maybeResetOnFactorChange(const Frame &frame, recor
         factor_change_pending_since = std::nullopt;
         return;
     }
-    // Gate the diff on the green "因子" header being flush at the very top, measured from the header itself
-    // (which moves 1:1 with the content) rather than the scroll thumb (whose travel is compressed by
-    // viewport/content, so a tiny content scroll barely moves topMargin and a same-character micro-scroll used
-    // to read as a switch). Both header positions cancel per-device layout, so compare current vs reference.
+    // Gate the diff on being flush at the very top. Prefer the green "因子" header, which moves 1:1 with the
+    // content, over the scroll thumb (whose travel is compressed by viewport/content, so a tiny content scroll
+    // barely moves topMargin and a same-character micro-scroll used to read as a switch). The header gate needs
+    // the header detected in BOTH the reference and the current frame; when either is missing -- a capture
+    // source whose green falls outside the configured range leaves reference_header_y empty -- fall back to the
+    // top-margin gate so switch detection keeps working instead of going dead (worse than the original bug).
     const auto header_y = factorHeaderTopY(frame);
-    const double tolerance = config.factor_header.flush_tolerance;
-    const bool flush =
-        header_y.has_value() && reference_header_y.has_value() && std::abs(*header_y - *reference_header_y) <= tolerance;
+    bool flush;
+    bool used_header_gate;
+    if (header_y.has_value() && reference_header_y.has_value()) {
+        flush = std::abs(*header_y - *reference_header_y) <= config.factor_header.flush_tolerance;
+        used_header_gate = true;
+    } else {
+        const auto top_margin = factor_scraper->topMargin(frame);
+        flush = top_margin.has_value() && top_margin.value() <= kTopMarginThreshold;
+        used_header_gate = false;
+    }
     if (!flush || factor_probe_reference.size() != frame.size()) {
         factor_change_pending_since = std::nullopt;
         return;
@@ -1425,7 +1440,12 @@ void CharaDetailSceneScraper::maybeResetOnFactorChange(const Frame &frame, recor
     if (chrono_util::monotonicElapsed(timestamp, factor_change_pending_since.value()) < kMonitorDwellMs) {
         return;
     }
-    log_debug("factor content changed at top -> reset session (ratio={:.4f})", ratio);
+    log_info(
+        "factor reset (ratio={:.4f}, gate={}, header_y={:.4f}, ref_header_y={:.4f})",
+        ratio,
+        used_header_gate ? "header" : "topmargin",
+        header_y.value_or(-1.0),
+        reference_header_y.value_or(-1.0));
     resetSession(record_type);
 }
 

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -1367,22 +1367,24 @@ void CharaDetailSceneScraper::rebuildTab(TabPage tab_page) {
     on_scroll_updated->send(tab_page, 0.0);  // Zero the tab's progress in the UI.
 }
 
-std::optional<double> CharaDetailSceneScraper::factorHeaderTopY(const Frame &frame) const {
+std::optional<int> CharaDetailSceneScraper::factorHeaderTopY(const Frame &frame) const {
     if (active_common == nullptr) {
         return std::nullopt;
     }
     const auto &header = config.factor_header;
-    // Crop to the scroll area so the scan (and the returned y) are relative to its top -- the coordinate that
+    // Crop to the scroll area so the scan (and the returned row) are relative to its top -- the coordinate that
     // moves with the content. view() shares the buffer (read-only here) and, like the diff below, degrades via
-    // the scraper try/catch if the rect ever falls outside the frame.
+    // the scraper try/catch if the rect ever falls outside the frame. Return the pixel row (not a fraction): the
+    // caller compares it against the reference in pixels, and both are taken on same-size frames.
     const Frame area = frame.view(active_common->scroll_area_rect);
     const int height = area.height();
     for (int y = 0; y < height; y++) {
-        // Row y in the crop's width-normalized coordinates (the anchor scales both axes by the crop width).
+        // The probe band x-range is a fraction of the crop width; y maps back to this same row (the anchor
+        // scales both axes by the crop width, so scaleFromPixels(y) * width == y).
         const double normalized_y = area.anchor().scaleFromPixels(y);
         const Line<double> row = {{header.band_start, normalized_y}, {header.band_end, normalized_y}};
         if (area.fractionIn(header.color_range, row) > header.green_fraction_threshold) {
-            return normalized_y;
+            return y;
         }
     }
     return std::nullopt;
@@ -1403,7 +1405,9 @@ void CharaDetailSceneScraper::maybeResetOnFactorChange(const Frame &frame, recor
     bool flush;
     bool used_header_gate;
     if (header_y.has_value() && reference_header_y.has_value()) {
-        flush = std::abs(*header_y - *reference_header_y) <= config.factor_header.flush_tolerance;
+        // Both rows are measured on same-size frames (guaranteed by the size check below), so their pixel
+        // difference is meaningful directly.
+        flush = std::abs(*header_y - *reference_header_y) <= config.factor_header.flush_tolerance_px;
         used_header_gate = true;
     } else {
         const auto top_margin = factor_scraper->topMargin(frame);
@@ -1441,11 +1445,11 @@ void CharaDetailSceneScraper::maybeResetOnFactorChange(const Frame &frame, recor
         return;
     }
     log_info(
-        "factor reset (ratio={:.4f}, gate={}, header_y={:.4f}, ref_header_y={:.4f})",
+        "factor reset (ratio={:.4f}, gate={}, header_y={}, ref_header_y={})",
         ratio,
         used_header_gate ? "header" : "topmargin",
-        header_y.value_or(-1.0),
-        reference_header_y.value_or(-1.0));
+        header_y.value_or(-1),
+        reference_header_y.value_or(-1));
     resetSession(record_type);
 }
 

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -104,16 +104,21 @@ std::optional<double> ScrollBarOffsetEstimator::trackCenterX(const Frame &frame)
     const int thumb_top = anchor.scaleToPixels(scan.pointAt(upper.value()));
     const int thumb_bottom = anchor.scaleToPixels(scan.pointAt(1. - lower.value()));
 
-    constexpr int kHalf = 8;      // centroid window half-width (columns)
-    constexpr int kWhiteGap = 9;  // white reference sampled at +-[7,9] from cfg, clear of the ~7 px pill
-    constexpr int kCapSkip = 3;   // rows skipped at each rounded cap (sub-thumb intensity)
-    constexpr int kMaxRows = 32;  // cap the sampled rows so a tall thumb stays cheap
-    constexpr double kMinContrast = 20.;
+    // The thumb is a fixed-DPI pill; its probe geometry is expressed as fractions of the frame width
+    // (reference: 736 px capture, ~7 px pill) and converted to pixels through the anchor, so it scales with
+    // the capture resolution instead of assuming one. Only the sub-pixel neighbour steps below stay at 1 px.
+    const int half = std::max(1, anchor.scaleToPixels(8. / 736.));       // centroid window half-width (columns)
+    const int white_gap = std::max(1, anchor.scaleToPixels(9. / 736.));  // white reference offset, just past the pill
+    const int white_band = anchor.scaleToPixels(2. / 736.);              // white reference band width (inward)
+    const int core_half = std::max(1, anchor.scaleToPixels(2. / 736.));  // darkest-core half-width at the column
+    const int cap_skip = std::max(1, anchor.scaleToPixels(3. / 736.));   // rows skipped at each rounded cap
+    constexpr int kMaxRows = 32;          // sampled-row cap (a count, resolution-independent); keeps a tall thumb cheap
+    constexpr double kMinContrast = 20.;  // minimum white-to-core intensity gap (0-255), not a spatial constant
 
     const cv::Mat &image = frame.data();
-    const int row_lo = thumb_top + kCapSkip;
-    const int row_hi = thumb_bottom - kCapSkip;
-    if (cfg - kWhiteGap < 0 || cfg + kWhiteGap >= image.cols || row_lo < 0 || row_hi >= image.rows
+    const int row_lo = thumb_top + cap_skip;
+    const int row_hi = thumb_bottom - cap_skip;
+    if (cfg - white_gap < 0 || cfg + white_gap >= image.cols || row_lo < 0 || row_hi >= image.rows
         || row_hi - row_lo < 1) {
         return std::nullopt;
     }
@@ -121,19 +126,22 @@ std::optional<double> ScrollBarOffsetEstimator::trackCenterX(const Frame &frame)
 
     const int stride = std::max(1, (row_hi - row_lo) / kMaxRows);
     std::vector<double> centers;
+    std::vector<double> whites;
     for (int y = row_lo; y <= row_hi; y += stride) {
-        std::array<double, 6> whites = {
-            red(cfg - kWhiteGap, y),
-            red(cfg - kWhiteGap + 1, y),
-            red(cfg - kWhiteGap + 2, y),
-            red(cfg + kWhiteGap - 2, y),
-            red(cfg + kWhiteGap - 1, y),
-            red(cfg + kWhiteGap, y),
-        };
+        // White reference: the near-white band flanking the pill, sampled inward from each outer offset and
+        // taken as its median to shrug off a stray dark pixel.
+        whites.clear();
+        for (int x = cfg - white_gap; x <= cfg - white_gap + white_band; x++) {
+            whites.push_back(red(x, y));
+        }
+        for (int x = cfg + white_gap - white_band; x <= cfg + white_gap; x++) {
+            whites.push_back(red(x, y));
+        }
         std::sort(whites.begin(), whites.end());
-        const double white = (whites[2] + whites[3]) / 2.;
+        const std::size_t n = whites.size();
+        const double white = (n % 2 == 0) ? (whites[n / 2 - 1] + whites[n / 2]) / 2. : whites[n / 2];
         double core = 255.;
-        for (int x = cfg - 2; x <= cfg + 2; x++) {
+        for (int x = cfg - core_half; x <= cfg + core_half; x++) {
             core = std::min(core, red(x, y));
         }
         if (white - core < kMinContrast) {
@@ -141,7 +149,7 @@ std::optional<double> ScrollBarOffsetEstimator::trackCenterX(const Frame &frame)
         }
         double weight_sum = 0.;
         double weighted_x = 0.;
-        for (int x = cfg - kHalf; x <= cfg + kHalf; x++) {
+        for (int x = cfg - half; x <= cfg + half; x++) {
             const double coverage = std::clamp((white - red(x, y)) / (white - core), 0., 1.);
             weight_sum += coverage;
             weighted_x += coverage * x;

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -102,6 +102,11 @@ std::optional<double> ScrollBarOffsetEstimator::trackCenterX(const Frame &frame)
     const auto &anchor = frame.anchor();
     const auto scan = anchor.absolute(scroll_bar_scan_line).vertical();
     const int unit = anchor.scaleToPixels(1.0);
+    // cfg indexes raw Mat columns directly, so unlike the vertical scan above it deliberately skips absolute():
+    // the scroll-bar frame always comes from Frame::view()/copy(), which returns a fixed-anchored crop with
+    // intersection.left() == 0, so the IntersectStart x-offset absolute() would add is 0 (a no-op). Routing cfg
+    // through absolute() as well would only add a false impression of generality -- the trackCenterX -> geometryAt
+    // center_x hand-off relies on the same fixed-anchor invariant, so this is safe by construction, not by luck.
     const int cfg = anchor.scaleToPixels(scroll_bar_scan_line.p1().x());
     const int thumb_top = anchor.scaleToPixels(scan.pointAt(upper.value()));
     const int thumb_bottom = anchor.scaleToPixels(scan.pointAt(1. - lower.value()));
@@ -111,7 +116,7 @@ std::optional<double> ScrollBarOffsetEstimator::trackCenterX(const Frame &frame)
     // resolution instead of assuming one. Only the sub-pixel neighbour steps below stay at 1 px.
     const int half = std::max(1, anchor.scaleToPixels(thumb_probe.centroid_half_width));
     const int white_gap = std::max(1, anchor.scaleToPixels(thumb_probe.white_reference_gap));
-    const int white_band = anchor.scaleToPixels(thumb_probe.white_reference_band);
+    const int white_band = std::max(1, anchor.scaleToPixels(thumb_probe.white_reference_band));
     const int core_half = std::max(1, anchor.scaleToPixels(thumb_probe.core_half_width));
     const int cap_skip = std::max(1, anchor.scaleToPixels(thumb_probe.cap_skip));
     const int kMaxRows = thumb_probe.max_sampled_rows;

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -43,12 +43,14 @@ ScrollBarOffsetEstimator::ScrollBarOffsetEstimator(
     const Line<double> &scroll_bar_scan_line,
     const Range<Color> &scroll_bar_margin_color_range,
     double viewport,
-    double cap_offset)
+    double cap_offset,
+    const scraper_config::ScrollBarThumbProbeConfig &thumb_probe)
     : scroll_bar_bg_color_range(scroll_bar_bg_color_range)
     , scroll_bar_scan_line(scroll_bar_scan_line)
     , scroll_bar_margin_color_range(scroll_bar_margin_color_range)
     , viewport(viewport)
-    , cap_offset(cap_offset) {}
+    , cap_offset(cap_offset)
+    , thumb_probe(thumb_probe) {}
 
 bool ScrollBarOffsetEstimator::hasScrollbar(const Frame &frame) const {
     return trackGeometry(frame).has_value();
@@ -104,16 +106,16 @@ std::optional<double> ScrollBarOffsetEstimator::trackCenterX(const Frame &frame)
     const int thumb_top = anchor.scaleToPixels(scan.pointAt(upper.value()));
     const int thumb_bottom = anchor.scaleToPixels(scan.pointAt(1. - lower.value()));
 
-    // The thumb is a fixed-DPI pill; its probe geometry is expressed as fractions of the frame width
-    // (reference: 736 px capture, ~7 px pill) and converted to pixels through the anchor, so it scales with
-    // the capture resolution instead of assuming one. Only the sub-pixel neighbour steps below stay at 1 px.
-    const int half = std::max(1, anchor.scaleToPixels(8. / 736.));       // centroid window half-width (columns)
-    const int white_gap = std::max(1, anchor.scaleToPixels(9. / 736.));  // white reference offset, just past the pill
-    const int white_band = anchor.scaleToPixels(2. / 736.);              // white reference band width (inward)
-    const int core_half = std::max(1, anchor.scaleToPixels(2. / 736.));  // darkest-core half-width at the column
-    const int cap_skip = std::max(1, anchor.scaleToPixels(3. / 736.));   // rows skipped at each rounded cap
-    constexpr int kMaxRows = 32;          // sampled-row cap (a count, resolution-independent); keeps a tall thumb cheap
-    constexpr double kMinContrast = 20.;  // minimum white-to-core intensity gap (0-255), not a spatial constant
+    // The thumb is a fixed-DPI pill; its probe geometry (thumb_probe, from the config builder) is expressed as
+    // fractions of the frame width and converted to pixels through the anchor, so it scales with the capture
+    // resolution instead of assuming one. Only the sub-pixel neighbour steps below stay at 1 px.
+    const int half = std::max(1, anchor.scaleToPixels(thumb_probe.centroid_half_width));
+    const int white_gap = std::max(1, anchor.scaleToPixels(thumb_probe.white_reference_gap));
+    const int white_band = anchor.scaleToPixels(thumb_probe.white_reference_band);
+    const int core_half = std::max(1, anchor.scaleToPixels(thumb_probe.core_half_width));
+    const int cap_skip = std::max(1, anchor.scaleToPixels(thumb_probe.cap_skip));
+    const int kMaxRows = thumb_probe.max_sampled_rows;
+    const double kMinContrast = thumb_probe.minimum_contrast;
 
     const cv::Mat &image = frame.data();
     const int row_lo = thumb_top + cap_skip;
@@ -154,7 +156,7 @@ std::optional<double> ScrollBarOffsetEstimator::trackCenterX(const Frame &frame)
             weight_sum += coverage;
             weighted_x += coverage * x;
         }
-        if (weight_sum >= 3.) {
+        if (weight_sum >= thumb_probe.minimum_coverage) {
             centers.push_back(weighted_x / weight_sum);
         }
     }
@@ -960,7 +962,8 @@ void SceneScraper::build(const Frame &frame) {
         config.scroll_bar_scan_line,
         config.scroll_bar_margin_color,
         config.viewport,
-        config.cap_offset);
+        config.cap_offset,
+        config.scroll_bar_thumb_probe);
     const auto &scroll_bar_offset_estimator = *scroll_bar_estimator;
 
     const auto stationary_catcher = StationaryFrameCatcher(

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -1139,6 +1139,9 @@ void CharaDetailSceneScraper::buildSession(record::RecordType record_type) {
         // would share pixels with a capture source that reuses its buffer, so clone to own the pixels
         // (same hazard StationaryFrameCatcher::update guards against).
         factor_probe_reference = current_full_frame.clone();
+        // Capture the flush header position alongside the reference; both are taken on this settled, at-top frame,
+        // so maybeResetOnFactorChange can later reject a tiny scroll by comparing the header against it.
+        reference_header_y = factorHeaderTopY(current_full_frame);
         factor_change_pending_since = std::nullopt;
         on_factor_probe->send(Frame(current_full_frame), RecordInfo(current_record_info));
     });
@@ -1345,6 +1348,7 @@ void CharaDetailSceneScraper::rebuildTab(TabPage tab_page) {
             break;
         case TabPage::FactorPage:
             factor_probe_reference = {};
+            reference_header_y = std::nullopt;
             factor_change_pending_since = std::nullopt;
             factor_scraper = makeTabScraper(TabPage::FactorPage, scraping_box->resetFactorBox());
             break;
@@ -1357,14 +1361,41 @@ void CharaDetailSceneScraper::rebuildTab(TabPage tab_page) {
     on_scroll_updated->send(tab_page, 0.0);  // Zero the tab's progress in the UI.
 }
 
+std::optional<double> CharaDetailSceneScraper::factorHeaderTopY(const Frame &frame) const {
+    if (active_common == nullptr) {
+        return std::nullopt;
+    }
+    const auto &header = config.factor_header;
+    // Crop to the scroll area so the scan (and the returned y) are relative to its top -- the coordinate that
+    // moves with the content. view() shares the buffer (read-only here) and, like the diff below, degrades via
+    // the scraper try/catch if the rect ever falls outside the frame.
+    const Frame area = frame.view(active_common->scroll_area_rect);
+    const int height = area.height();
+    for (int y = 0; y < height; y++) {
+        // Row y in the crop's width-normalized coordinates (the anchor scales both axes by the crop width).
+        const double normalized_y = area.anchor().scaleFromPixels(y);
+        const Line<double> row = {{header.band_start, normalized_y}, {header.band_end, normalized_y}};
+        if (area.fractionIn(header.color_range, row) > header.green_fraction_threshold) {
+            return normalized_y;
+        }
+    }
+    return std::nullopt;
+}
+
 void CharaDetailSceneScraper::maybeResetOnFactorChange(const Frame &frame, record::RecordType record_type) {
     if (factor_probe_reference.empty() || active_common == nullptr) {
         factor_change_pending_since = std::nullopt;
         return;
     }
-    const auto top_margin = factor_scraper->topMargin(frame);
-    const bool at_top = top_margin.has_value() && top_margin.value() <= kTopMarginThreshold;
-    if (!at_top || factor_probe_reference.size() != frame.size()) {
+    // Gate the diff on the green "因子" header being flush at the very top, measured from the header itself
+    // (which moves 1:1 with the content) rather than the scroll thumb (whose travel is compressed by
+    // viewport/content, so a tiny content scroll barely moves topMargin and a same-character micro-scroll used
+    // to read as a switch). Both header positions cancel per-device layout, so compare current vs reference.
+    const auto header_y = factorHeaderTopY(frame);
+    const double tolerance = config.factor_header.flush_tolerance;
+    const bool flush =
+        header_y.has_value() && reference_header_y.has_value() && std::abs(*header_y - *reference_header_y) <= tolerance;
+    if (!flush || factor_probe_reference.size() != frame.size()) {
         factor_change_pending_since = std::nullopt;
         return;
     }
@@ -1407,6 +1438,7 @@ void CharaDetailSceneScraper::resetMonitors() {
     type_pending_value = std::nullopt;
     factor_change_pending_since = std::nullopt;
     factor_probe_reference = {};
+    reference_header_y = std::nullopt;
     last_scroll_position_emitted = std::nullopt;
 }
 

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -53,16 +53,24 @@ struct FrameDescriptor {
 
 class ScrollBarOffsetEstimator {
 public:
-    ScrollBarOffsetEstimator(const Range<Color> &scroll_bar_bg_color_range, const Line<double> &scroll_bar_scan_line);
+    ScrollBarOffsetEstimator(
+        const Range<Color> &scroll_bar_bg_color_range,
+        const Line<double> &scroll_bar_scan_line,
+        const Range<Color> &scroll_bar_margin_color_range,
+        double viewport,
+        double cap_offset);
 
     [[nodiscard]] bool hasScrollbar(const Frame &frame) const;
 
+    // Scroll position as a fraction of the scrollable range: 0 at the very top, 1 at the bottom. Derived
+    // from the true placeholder track (upper_gap / (track_span - thumb_length)), so the config scan line's
+    // deliberate overshoot past the track no longer biases it. nullopt when no scrollbar is present.
     [[nodiscard]] std::optional<double> position(const Frame &frame) const;
 
-    // Fraction of the scroll track above the thumb (distance from the top edge to the thumb's top). It is ~0
-    // when the content is scrolled to the very top and grows as the user scrolls down, independent of the
-    // thumb's length. Returns nullopt when no scrollbar is present (a short, non-scrollable page). Used to
-    // detect a completed tab snapping back to the top after a character switch.
+    // Fraction of the placeholder track above the thumb (thumb top relative to the track top). It is ~0 when
+    // the content is scrolled to the very top and grows as the user scrolls down, independent of the thumb's
+    // length. Returns nullopt when no scrollbar is present (a short, non-scrollable page). Used to detect a
+    // completed tab snapping back to the top after a character switch.
     [[nodiscard]] std::optional<double> topMargin(const Frame &frame) const;
 
     [[nodiscard]] std::optional<double> estimate(FrameDescriptor &from, FrameDescriptor &to) const;
@@ -74,12 +82,38 @@ public:
     [[nodiscard]] std::optional<double> scrollOffsetGuess(const Frame &from, const Frame &to) const;
 
 private:
+    // Placeholder-track geometry from one frame, all width-normalized. The thumb and track ends come from
+    // colour runs along the scan line: the background run reaches the (dark) thumb, the margin run reaches
+    // the (near-white) edge of the track. Measuring against the track, not the scan line, removes the
+    // scan-line overshoot; only the thumb length carries the -2c cap correction (the caps cancel in
+    // upper_gap since the thumb top and track top share the same cap geometry).
+    struct TrackGeometry {
+        double upper_gap;      // thumb_top - track_top, clamped >= 0 (overscroll pins the thumb to the top)
+        double track_span;     // track_bottom - track_top (the placeholder length)
+        double thumb_logical;  // thumb tip-to-tip length - 2 * cap_offset, guaranteed > 0
+    };
+
+    [[nodiscard]] std::optional<TrackGeometry> trackGeometry(const Frame &frame) const;
+
+    // TrackGeometry from the colour runs along one scan column. trackGeometry() picks the column
+    // (trackCenterX, falling back to the config line) and delegates here.
+    [[nodiscard]] std::optional<TrackGeometry> geometryAt(const Frame &frame, const Line<double> &scan_line) const;
+
+    // Sub-pixel thumb centre x (width-normalized) from an AA intensity-weighted centroid over the thumb's
+    // central rows, so the vertical scan self-centres on the thumb instead of trusting the fixed config x
+    // (~10x more stable than a hard threshold; tolerates layout/resolution drift). nullopt when the thumb is
+    // not found or the cap contrast is too low, so trackGeometry() falls back to the config column.
+    [[nodiscard]] std::optional<double> trackCenterX(const Frame &frame) const;
+
     [[nodiscard]] std::optional<Line1D<double>> findScrollbar(const Frame &frame) const;
 
     [[nodiscard]] std::optional<std::pair<double, double>> scanMargin(const Frame &frame) const;
 
     const Range<Color> scroll_bar_bg_color_range;
     const Line<double> scroll_bar_scan_line;
+    const Range<Color> scroll_bar_margin_color_range;
+    const double viewport;
+    const double cap_offset;
 };
 
 class ImageOffsetEstimator {

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -559,11 +559,12 @@ private:
     // re-probes). Reuses the stationary rect and its calibrated color thresholds as the change metric.
     void maybeResetOnFactorChange(const Frame &frame, record::RecordType record_type);
 
-    // Top edge y of the green "因子" section header, as a width-normalized fraction relative to the scroll-area
-    // crop (so it tracks the content, not the scroll thumb). Scans the config band top-down for the first row
-    // that is mostly header green. nullopt when the header is scrolled off or mid-animation (not flush), which
-    // maybeResetOnFactorChange treats as "not at the top". Never throws on a scrolled-away frame.
-    [[nodiscard]] std::optional<double> factorHeaderTopY(const Frame &frame) const;
+    // Top-edge pixel row of the green "因子" section header, relative to the scroll-area crop (so it tracks the
+    // content, not the scroll thumb). Scans the config band top-down for the first row that is mostly header
+    // green. nullopt when the header is scrolled off or mid-animation (not flush), which maybeResetOnFactorChange
+    // treats as "not at the top". Never throws on a scrolled-away frame. Compared against the reference in pixels,
+    // valid because both are taken on same-size frames.
+    [[nodiscard]] std::optional<int> factorHeaderTopY(const Frame &frame) const;
 
     void resetMonitors();
 
@@ -646,9 +647,9 @@ private:
     std::optional<record::RecordType> type_pending_value;
     std::optional<uint64> factor_change_pending_since;
     Frame factor_probe_reference = {};
-    // Header top y (see factorHeaderTopY) captured with factor_probe_reference; the flush gate compares the
-    // current header y against it, so per-device layout differences cancel.
-    std::optional<double> reference_header_y;
+    // Header top-edge pixel row (see factorHeaderTopY) captured with factor_probe_reference; the flush gate
+    // compares the current header row against it in pixels.
+    std::optional<int> reference_header_y;
     std::optional<std::pair<TabPage, bool>> last_scroll_position_emitted;
 };
 

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -43,7 +43,8 @@ inline bool readyAfterUpdate(T &subject, const Frame &frame) {
 }
 
 struct FrameDescriptor {
-    Frame frame;
+    Frame frame;             // content crop: image matching + capture
+    Frame scroll_bar_frame;  // full-width scrollbar band: scrollbar geometry only
     std::vector<cv::KeyPoint> key_points;
     cv::Mat descriptors;
 
@@ -352,8 +353,11 @@ enum ReadyState {
 class NonScrollableScrapingInterpreter : public ScrapingInterpreter {
 public:
     NonScrollableScrapingInterpreter(
-        const std::shared_ptr<PageScrapingBox> &scraping_box, const StationaryFrameCatcher &stationary_catcher);
+        const std::shared_ptr<PageScrapingBox> &scraping_box,
+        const StationaryFrameCatcher &stationary_catcher,
+        const Rect<double> &scroll_area_rect);
 
+    // Receives the full frame; crops the content region internally (see ScrollableScrapingInterpreter::update).
     void update(const Frame &frame) override;
 
     [[nodiscard]] bool ready() const override;
@@ -363,6 +367,7 @@ public:
 private:
     std::shared_ptr<PageScrapingBox> scraping_box;
     StationaryFrameCatcher stationary_catcher;
+    const Rect<double> scroll_area_rect;
     ReadyState state = Updatable;
     bool has_updated = false;
 };
@@ -373,11 +378,16 @@ public:
         const std::shared_ptr<PageScrapingBox> &scraping_box,
         const ScrollAreaOffsetEstimator &offset_estimator,
         const StationaryFrameCatcher &stationary_catcher,
+        const Rect<double> &scroll_area_rect,
+        const Rect<double> &scroll_bar_rect,
         double initial_scroll_threshold,
         double minimum_scroll_threshold,
         const event_util::Sender<> &on_scroll_ready,
         const event_util::Sender<double> &on_scroll_updated);
 
+    // Receives the FULL frame each update. The content crop (scroll_area_rect) drives the stationary catcher,
+    // image matcher and capture; the scroll-bar band (scroll_bar_rect) drives only the scrollbar estimator, so
+    // the two regions are decoupled.
     void update(const Frame &frame) override;
 
     [[nodiscard]] bool ready() const override;
@@ -390,7 +400,7 @@ public:
 private:
     void updateBefore(const Frame &frame);
 
-    void startScrolling(const Frame &valid_frame);
+    void startScrolling(const FrameDescriptor &valid_descriptor);
 
     void updateScrolling(const Frame &frame);
 
@@ -398,6 +408,8 @@ private:
     const event_util::Sender<double> on_scroll_updated;
 
     const ScrollAreaOffsetEstimator offset_estimator;
+    const Rect<double> scroll_area_rect;
+    const Rect<double> scroll_bar_rect;
     const double initial_scroll;
     const double minimum_scroll;
 

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -578,10 +578,18 @@ private:
     const event_util::Sender<Frame, RecordInfo> on_factor_probe;  // Factor tab scroll-ready, for dedup.
     const event_util::Sender<> on_restarted;  // Mid-scene reset (inferred character switch).
 
-    // Top margin (fraction of the scroll track above the thumb) at or below which the content is treated as
-    // scrolled to the very top. ~0 means flush with the top; the threshold tolerates a thin idle band. Verify
-    // against footage (.notes/player_standard_sequential.mp4) when calibrating.
-    static constexpr double kTopMarginThreshold = 0.03;
+    // Top margin (fraction of the true placeholder track above the thumb, from topMargin()) at or below which
+    // the content is treated as scrolled to the very top. ~0 means flush with the top; the threshold tolerates
+    // a thin idle band. Verify against footage (.notes/player_standard_sequential.mp4) when calibrating.
+    //
+    // Was 0.03 when topMargin() measured against the config scan line, whose deliberate overshoot past the
+    // track biased the reading up by ~0.007. Once topMargin() moved to the true track (commit 0b56fc44) the
+    // same physical position reads ~0.007 lower, so 0.03 admitted a thumb a hair below the top as "at top".
+    // On the factor tab that spuriously fired maybeResetOnFactorChange when the inheritance history lazily
+    // loaded: the reload re-scales the thumb to ~0.027 while the list content changes, and 0.03 gated it as a
+    // character switch (friend_inheritance golden regression). A genuine switch is instead visible at the very
+    // top (~0.002, before any reload) so it still fires; 0.02 sits in the gap between the two.
+    static constexpr double kTopMarginThreshold = 0.02;
     // How long an inferred-switch signal (record-type change, completed tab at top, factor content change) must
     // persist before it commits a reset, so a transient misread during the switch animation cannot trigger one.
     static constexpr uint64 kMonitorDwellMs = 250;

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -559,6 +559,12 @@ private:
     // re-probes). Reuses the stationary rect and its calibrated color thresholds as the change metric.
     void maybeResetOnFactorChange(const Frame &frame, record::RecordType record_type);
 
+    // Top edge y of the green "因子" section header, as a width-normalized fraction relative to the scroll-area
+    // crop (so it tracks the content, not the scroll thumb). Scans the config band top-down for the first row
+    // that is mostly header green. nullopt when the header is scrolled off or mid-animation (not flush), which
+    // maybeResetOnFactorChange treats as "not at the top". Never throws on a scrolled-away frame.
+    [[nodiscard]] std::optional<double> factorHeaderTopY(const Frame &frame) const;
+
     void resetMonitors();
 
     [[nodiscard]] bool ready() const;
@@ -640,6 +646,9 @@ private:
     std::optional<record::RecordType> type_pending_value;
     std::optional<uint64> factor_change_pending_since;
     Frame factor_probe_reference = {};
+    // Header top y (see factorHeaderTopY) captured with factor_probe_reference; the flush gate compares the
+    // current header y against it, so per-device layout differences cancel.
+    std::optional<double> reference_header_y;
     std::optional<std::pair<TabPage, bool>> last_scroll_position_emitted;
 };
 

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -58,7 +58,8 @@ public:
         const Line<double> &scroll_bar_scan_line,
         const Range<Color> &scroll_bar_margin_color_range,
         double viewport,
-        double cap_offset);
+        double cap_offset,
+        const scraper_config::ScrollBarThumbProbeConfig &thumb_probe);
 
     [[nodiscard]] bool hasScrollbar(const Frame &frame) const;
 
@@ -114,6 +115,7 @@ private:
     const Range<Color> scroll_bar_margin_color_range;
     const double viewport;
     const double cap_offset;
+    const scraper_config::ScrollBarThumbProbeConfig thumb_probe;
 };
 
 class ImageOffsetEstimator {

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -44,7 +44,6 @@ inline bool readyAfterUpdate(T &subject, const Frame &frame) {
 
 struct FrameDescriptor {
     Frame frame;
-    double scroll_bar_length = 0.0;
     std::vector<cv::KeyPoint> key_points;
     cv::Mat descriptors;
 
@@ -73,7 +72,11 @@ public:
     // completed tab snapping back to the top after a character switch.
     [[nodiscard]] std::optional<double> topMargin(const Frame &frame) const;
 
-    [[nodiscard]] std::optional<double> estimate(FrameDescriptor &from, FrameDescriptor &to) const;
+    // Content-pixel scroll offset between two frames: the placeholder-track upper_gap difference over a
+    // shared (cap-corrected) thumb length, scaled by the true viewport. The fixed track top cancels in the
+    // difference, so this delta form keeps low per-frame noise. The primary guess that seeds the image
+    // matcher for stitching. nullopt when either frame has no scrollbar or on a mid-scroll resolution change.
+    [[nodiscard]] std::optional<double> estimate(const Frame &from, const Frame &to) const;
 
     // Content-pixel scroll offset between two frames, computed from each frame's OWN thumb length, so it
     // stays correct across a thumb-length change (unlike estimate()'s shared-length delta). Used as the
@@ -104,10 +107,6 @@ private:
     // (~10x more stable than a hard threshold; tolerates layout/resolution drift). nullopt when the thumb is
     // not found or the cap contrast is too low, so trackGeometry() falls back to the config column.
     [[nodiscard]] std::optional<double> trackCenterX(const Frame &frame) const;
-
-    [[nodiscard]] std::optional<Line1D<double>> findScrollbar(const Frame &frame) const;
-
-    [[nodiscard]] std::optional<std::pair<double, double>> scanMargin(const Frame &frame) const;
 
     const Range<Color> scroll_bar_bg_color_range;
     const Line<double> scroll_bar_scan_line;

--- a/native/src/cv/frame.h
+++ b/native/src/cv/frame.h
@@ -317,6 +317,25 @@ public:
         });
     }
 
+    // Fraction of the sampled points along `line` whose colour falls in `color_range` (0-1). Mirrors isAllIn's
+    // sampling (>= 2 points, one per pixel of length) but reports the ratio instead of a hard all/any, so a
+    // caller can accept a band that is *mostly* one colour (e.g. a solid section header row) while rejecting a
+    // narrow stray run of the same colour.
+    [[nodiscard]] double fractionIn(const Range<Color> &color_range, const Line<double> &line) const {
+        const Range<BGR> &bgr_range = asBGRRange(color_range);
+        const Line<double> &mapped_line = anchor_.mapToFrame(line).cast<double>();
+
+        const int samples = std::max(2, (int) mapped_line.length());
+        int inside = 0;
+        for (const auto &ratio : linspace(0., 1., samples)) {
+            const auto &p = mapped_line.pointAt(ratio).round();
+            if (bgr_range.contains(bgrAt(p.x(), p.y()))) {
+                inside++;
+            }
+        }
+        return static_cast<double>(inside) / samples;
+    }
+
     [[nodiscard]] std::optional<double> lengthIn(const Range<Color> &color_range, const Line<double> &line) const {
         const Range<BGR> &bgr_range = asBGRRange(color_range);
         const Line<double> &mapped_line = anchor_.mapToFrame(line).cast<double>();

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -145,20 +145,42 @@ TEST_CASE("ScrollAreaOffsetEstimator delegates position and short-circuits witho
     const ImageOffsetEstimator image;  // default config
     const ScrollAreaOffsetEstimator estimator(scroll_bar, image);
 
-    const FrameDescriptor with_bar{scrollbarFrame(100, 40, 60)};
+    // FrameDescriptor carries the content crop (frame) and the scroll-bar band (scroll_bar_frame) separately;
+    // the scroll-area estimator reads geometry from scroll_bar_frame. Here they are the same synthetic frame.
+    const Frame bar = scrollbarFrame(100, 40, 60);
+    const FrameDescriptor with_bar{bar, bar};
     CHECK(estimator.position(with_bar).has_value());
 
     // Two uniform frames have no scroll bar, so the scroll-bar guess is nullopt and estimate() returns
     // before ever reaching the image matcher.
-    FrameDescriptor from{Frame::fixed(testutil::solid(100, kTrack))};
-    FrameDescriptor to{Frame::fixed(testutil::solid(100, kTrack))};
+    const Frame uniform = Frame::fixed(testutil::solid(100, kTrack));
+    FrameDescriptor from{uniform, uniform};
+    FrameDescriptor to{uniform, uniform};
     CHECK_FALSE(estimator.estimate(from, to).has_value());
+}
+
+TEST_CASE("ScrollAreaOffsetEstimator reads scrollbar geometry from scroll_bar_frame, not frame") {
+    // Guards the scroll-area / scroll-bar decoupling: geometry must come from the dedicated band, so that the
+    // content crop (frame) can change without disturbing detection.
+    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
+    const ImageOffsetEstimator image;  // default config
+    const ScrollAreaOffsetEstimator estimator(scroll_bar, image);
+
+    const Frame bar = scrollbarFrame(100, 40, 60);
+    const Frame uniform = Frame::fixed(testutil::solid(100, kTrack));
+
+    // Scrollbar present only in the band: position resolves from it even though the content frame is bare.
+    CHECK(estimator.position(FrameDescriptor{uniform, bar}).has_value());
+
+    // Scrollbar present only in the content frame: the estimator reads the band, so it sees nothing.
+    CHECK_FALSE(estimator.position(FrameDescriptor{bar, uniform}).has_value());
 }
 
 TEST_CASE("ImageOffsetEstimator returns nullopt when a frame yields no keypoints") {
     const ImageOffsetEstimator estimator;  // default config
-    FrameDescriptor from{Frame::fixed(testutil::solid(100, kTrack))};
-    FrameDescriptor to{Frame::fixed(testutil::solid(100, kTrack))};
+    const Frame uniform = Frame::fixed(testutil::solid(100, kTrack));
+    FrameDescriptor from{uniform, uniform};
+    FrameDescriptor to{uniform, uniform};
 
     // A uniform frame produces zero AKAZE features and an empty descriptor matrix; the guard rejects it
     // rather than letting FLANN throw on the empty set.

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -85,12 +85,18 @@ TEST_CASE("ScrollBarOffsetEstimator reports no scrollbar on a uniform frame") {
 
 TEST_CASE("ScrollBarOffsetEstimator estimates a nonzero pixel offset between two thumb positions") {
     const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
-    FrameDescriptor from{scrollbarFrame(100, 40, 60)};
-    FrameDescriptor to{scrollbarFrame(100, 50, 70)};  // scrolled down: the thumb moved lower
+    const Frame from = scrollbarFrame(100, 40, 60);
+    const Frame to = scrollbarFrame(100, 50, 70);  // scrolled down: the thumb moved lower
 
     const auto offset = estimator.estimate(from, to);
     REQUIRE(offset.has_value());
-    CHECK(*offset != doctest::Approx(0.0));
+    CHECK(*offset > 0.0);  // scrolled down => positive content offset
+
+    // Unified geometry: estimate() (shared-length delta) and scrollOffsetGuess() (per-frame absolute
+    // difference) now read the same trackGeometry, so for a constant thumb length they agree.
+    const auto guess = estimator.scrollOffsetGuess(from, to);
+    REQUIRE(guess.has_value());
+    CHECK(*offset == doctest::Approx(*guess));
 }
 
 TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess is zero for identical frames and positive scrolling down") {
@@ -128,8 +134,8 @@ TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess returns nullopt without a
 
 TEST_CASE("ScrollBarOffsetEstimator rejects a size change between frames") {
     const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
-    FrameDescriptor from{scrollbarFrame(100, 40, 60)};
-    FrameDescriptor to{scrollbarFrame(80, 32, 48)};
+    const Frame from = scrollbarFrame(100, 40, 60);
+    const Frame to = scrollbarFrame(80, 32, 48);
 
     CHECK_FALSE(estimator.estimate(from, to).has_value());
 }

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -39,6 +39,12 @@ const Range<Color> kMarginRange{Color(228, 228, 228), Color(255, 255, 255)};  //
 constexpr double kViewport = 1.0;
 constexpr double kCapOffset = 0.0;
 
+// Thumb-centre probe geometry. These tests render a full-width thumb, so trackCenterX finds no pill contrast
+// and falls back to the fixed scan column (see scrollbarFrame); the exact probe values are never exercised,
+// but the estimator still needs a valid config. Mirrors the builder's calibrated values.
+const scraper_config::ScrollBarThumbProbeConfig kThumbProbe{
+    8.0 / 736.0, 9.0 / 736.0, 2.0 / 736.0, 2.0 / 736.0, 3.0 / 736.0, 32, 20.0, 3.0};
+
 // A square frame with a placeholder track (an 8%-inset band) over a near-white margin, and a dark thumb
 // spanning rows [thumb_top, thumb_bottom) inside the track. The default vertical scan line at x=0.5 crosses
 // it; the margin/track boundary lets the estimator measure the thumb against the true track, not the scan
@@ -57,7 +63,7 @@ Frame scrollbarFrame(int size, int thumb_top, int thumb_bottom) {
 const Line<double> kScanLine{Point<double>(0.5, 0.0), Point<double>(0.5, 0.99)};
 
 TEST_CASE("ScrollBarOffsetEstimator reads the thumb margins from a rendered track") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const Frame frame = scrollbarFrame(100, 40, 60);
 
     CHECK(estimator.hasScrollbar(frame));
@@ -75,7 +81,7 @@ TEST_CASE("ScrollBarOffsetEstimator reads the thumb margins from a rendered trac
 }
 
 TEST_CASE("ScrollBarOffsetEstimator reports no scrollbar on a uniform frame") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const Frame frame = Frame::fixed(testutil::solid(100, kTrack));
 
     CHECK_FALSE(estimator.hasScrollbar(frame));
@@ -84,7 +90,7 @@ TEST_CASE("ScrollBarOffsetEstimator reports no scrollbar on a uniform frame") {
 }
 
 TEST_CASE("ScrollBarOffsetEstimator estimates a nonzero pixel offset between two thumb positions") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const Frame from = scrollbarFrame(100, 40, 60);
     const Frame to = scrollbarFrame(100, 50, 70);  // scrolled down: the thumb moved lower
 
@@ -100,7 +106,7 @@ TEST_CASE("ScrollBarOffsetEstimator estimates a nonzero pixel offset between two
 }
 
 TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess is zero for identical frames and positive scrolling down") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const Frame a = scrollbarFrame(100, 40, 60);
     const Frame b = scrollbarFrame(100, 55, 75);  // thumb lower (scrolled down), same length
 
@@ -116,7 +122,7 @@ TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess is zero for identical fra
 TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess works across a thumb-length change") {
     // The point of this guess: unlike estimate()'s shared-length delta, it stays valid when the thumb
     // re-scales (content lazily appended), because each frame contributes its OWN thumb length.
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const Frame before = scrollbarFrame(100, 60, 90);  // long thumb near the bottom (small content)
     const Frame after = scrollbarFrame(100, 40, 55);  // shorter thumb, lifted up (content grew)
 
@@ -124,7 +130,7 @@ TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess works across a thumb-leng
 }
 
 TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess returns nullopt without a scrollbar") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const Frame bar = scrollbarFrame(100, 40, 60);
     const Frame uniform = Frame::fixed(testutil::solid(100, kTrack));
 
@@ -133,7 +139,7 @@ TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess returns nullopt without a
 }
 
 TEST_CASE("ScrollBarOffsetEstimator rejects a size change between frames") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const Frame from = scrollbarFrame(100, 40, 60);
     const Frame to = scrollbarFrame(80, 32, 48);
 
@@ -141,7 +147,7 @@ TEST_CASE("ScrollBarOffsetEstimator rejects a size change between frames") {
 }
 
 TEST_CASE("ScrollAreaOffsetEstimator delegates position and short-circuits without a scrollbar") {
-    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
+    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const ImageOffsetEstimator image;  // default config
     const ScrollAreaOffsetEstimator estimator(scroll_bar, image);
 
@@ -162,7 +168,7 @@ TEST_CASE("ScrollAreaOffsetEstimator delegates position and short-circuits witho
 TEST_CASE("ScrollAreaOffsetEstimator reads scrollbar geometry from scroll_bar_frame, not frame") {
     // Guards the scroll-area / scroll-bar decoupling: geometry must come from the dedicated band, so that the
     // content crop (frame) can change without disturbing detection.
-    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
+    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const ImageOffsetEstimator image;  // default config
     const ScrollAreaOffsetEstimator estimator(scroll_bar, image);
 

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -27,14 +27,27 @@ using scraper_impl::ScrollAreaOffsetEstimator;
 using scraper_impl::ScrollBarOffsetEstimator;
 using scraper_impl::StationaryFrameCatcher;
 
-const Color kTrack{240, 240, 240};  // the scroll-track background
+const Color kMargin{245, 245, 245};  // near-white band flanking the placeholder track
+const Color kTrack{210, 210, 210};  // the placeholder track (background to the thumb scan, but not "white")
 const Color kThumb{60, 60, 60};  // the scroll thumb
-const Range<Color> kTrackRange{Color(200, 200, 200), Color(255, 255, 255)};
+const Range<Color> kTrackRange{Color(200, 200, 200), Color(255, 255, 255)};  // thumb vs. background
+const Range<Color> kMarginRange{Color(228, 228, 228), Color(255, 255, 255)};  // near-white margin vs. track
 
-// A square frame with a scroll track down the middle: background everywhere, with a dark thumb spanning
-// rows [thumb_top, thumb_bottom). The default vertical scan line at x=0.5 crosses it.
+// Estimator physics for the tests: a unit viewport keeps scrollOffsetGuess in frame-height pixels, and a
+// zero cap offset makes the logical thumb length exactly the measured tip-to-tip span, so the geometric
+// expectations below stay clean. The real cap correction is validated end-to-end (video harness), not here.
+constexpr double kViewport = 1.0;
+constexpr double kCapOffset = 0.0;
+
+// A square frame with a placeholder track (an 8%-inset band) over a near-white margin, and a dark thumb
+// spanning rows [thumb_top, thumb_bottom) inside the track. The default vertical scan line at x=0.5 crosses
+// it; the margin/track boundary lets the estimator measure the thumb against the true track, not the scan
+// line. The thumb spans the full width, so the per-frame track-centre-x probe finds no pill contrast and
+// falls back to the fixed scan column -- exactly the geometry these expectations assume.
 Frame scrollbarFrame(int size, int thumb_top, int thumb_bottom) {
-    cv::Mat mat = testutil::solid(size, kTrack);
+    const int track_inset = size * 8 / 100;
+    cv::Mat mat = testutil::solid(size, kMargin);
+    mat(cv::Rect(0, track_inset, size, size - 2 * track_inset)).setTo(cv::Scalar(kTrack.b(), kTrack.g(), kTrack.r()));
     mat(cv::Rect(0, thumb_top, size, thumb_bottom - thumb_top)).setTo(cv::Scalar(kThumb.b(), kThumb.g(), kThumb.r()));
     return Frame::fixed(mat);
 }
@@ -44,22 +57,25 @@ Frame scrollbarFrame(int size, int thumb_top, int thumb_bottom) {
 const Line<double> kScanLine{Point<double>(0.5, 0.0), Point<double>(0.5, 0.99)};
 
 TEST_CASE("ScrollBarOffsetEstimator reads the thumb margins from a rendered track") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
     const Frame frame = scrollbarFrame(100, 40, 60);
 
     CHECK(estimator.hasScrollbar(frame));
 
+    // Track spans rows [8, 92) (the 8% inset), thumb [40, 60). topMargin is the thumb top within the track:
+    // (40 - 8) / (92 - 8) = 0.38. position is the scrolled fraction of the movable range:
+    // (40 - 8) / ((92 - 8) - (60 - 40)) = 32 / 64 = 0.50.
     const auto top_margin = estimator.topMargin(frame);
     REQUIRE(top_margin.has_value());
-    CHECK(*top_margin == doctest::Approx(0.40).epsilon(0.03));  // track above the thumb
+    CHECK(*top_margin == doctest::Approx(0.38).epsilon(0.05));  // thumb top relative to the track top
 
     const auto position = estimator.position(frame);
     REQUIRE(position.has_value());
-    CHECK(*position == doctest::Approx(0.60).epsilon(0.03));  // 1 - (track below the thumb)
+    CHECK(*position == doctest::Approx(0.50).epsilon(0.05));  // scrolled fraction of the movable range
 }
 
 TEST_CASE("ScrollBarOffsetEstimator reports no scrollbar on a uniform frame") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
     const Frame frame = Frame::fixed(testutil::solid(100, kTrack));
 
     CHECK_FALSE(estimator.hasScrollbar(frame));
@@ -68,7 +84,7 @@ TEST_CASE("ScrollBarOffsetEstimator reports no scrollbar on a uniform frame") {
 }
 
 TEST_CASE("ScrollBarOffsetEstimator estimates a nonzero pixel offset between two thumb positions") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
     FrameDescriptor from{scrollbarFrame(100, 40, 60)};
     FrameDescriptor to{scrollbarFrame(100, 50, 70)};  // scrolled down: the thumb moved lower
 
@@ -78,7 +94,7 @@ TEST_CASE("ScrollBarOffsetEstimator estimates a nonzero pixel offset between two
 }
 
 TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess is zero for identical frames and positive scrolling down") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
     const Frame a = scrollbarFrame(100, 40, 60);
     const Frame b = scrollbarFrame(100, 55, 75);  // thumb lower (scrolled down), same length
 
@@ -94,7 +110,7 @@ TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess is zero for identical fra
 TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess works across a thumb-length change") {
     // The point of this guess: unlike estimate()'s shared-length delta, it stays valid when the thumb
     // re-scales (content lazily appended), because each frame contributes its OWN thumb length.
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
     const Frame before = scrollbarFrame(100, 60, 90);  // long thumb near the bottom (small content)
     const Frame after = scrollbarFrame(100, 40, 55);  // shorter thumb, lifted up (content grew)
 
@@ -102,7 +118,7 @@ TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess works across a thumb-leng
 }
 
 TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess returns nullopt without a scrollbar") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
     const Frame bar = scrollbarFrame(100, 40, 60);
     const Frame uniform = Frame::fixed(testutil::solid(100, kTrack));
 
@@ -111,7 +127,7 @@ TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess returns nullopt without a
 }
 
 TEST_CASE("ScrollBarOffsetEstimator rejects a size change between frames") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
     FrameDescriptor from{scrollbarFrame(100, 40, 60)};
     FrameDescriptor to{scrollbarFrame(80, 32, 48)};
 
@@ -119,7 +135,7 @@ TEST_CASE("ScrollBarOffsetEstimator rejects a size change between frames") {
 }
 
 TEST_CASE("ScrollAreaOffsetEstimator delegates position and short-circuits without a scrollbar") {
-    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine);
+    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset);
     const ImageOffsetEstimator image;  // default config
     const ScrollAreaOffsetEstimator estimator(scroll_bar, image);
 

--- a/native/test/cv/test_frame.cpp
+++ b/native/test/cv/test_frame.cpp
@@ -114,6 +114,41 @@ TEST_CASE("Frame line sampling: isIn / isAllIn / lengthIn") {
     CHECK(frame.lengthIn(in_range, inside) == doctest::Approx(1.0));  // in range all the way to the end
 }
 
+TEST_CASE("Frame::fractionIn reports the share of sampled points in range") {
+    // Left half (x < 50) is in range; right half is out of range.
+    cv::Mat mat = solid(100, 100, Color(0, 0, 0));
+    mat(cv::Rect(50, 0, 50, 100)).setTo(cv::Scalar(200, 200, 200));
+    const Frame frame = Frame::fixed(mat);
+    const Range<Color> in_range{Color(0, 0, 0), Color(50, 50, 50)};
+
+    const Line<double> left{Point<double>(0.10, 0.50), Point<double>(0.40, 0.50)};
+    CHECK(frame.fractionIn(in_range, left) == doctest::Approx(1.0));  // wholly in range
+
+    const Line<double> right{Point<double>(0.60, 0.50), Point<double>(0.90, 0.50)};
+    CHECK(frame.fractionIn(in_range, right) == doctest::Approx(0.0));  // wholly out of range
+
+    // A line split evenly across the boundary reports ~half in range (the ratio, not a hard all/any).
+    const Line<double> crossing{Point<double>(0.10, 0.50), Point<double>(0.90, 0.50)};
+    CHECK(frame.fractionIn(in_range, crossing) == doctest::Approx(0.5).epsilon(0.05));
+}
+
+TEST_CASE("Frame::fractionIn separates a solid header band from a narrow stray run") {
+    // Mirrors factorHeaderTopY's probe: a right-of-centre band is "the header" only when it is *mostly* green,
+    // so a solid header row clears a 0.5 threshold while a narrow stray green pill in the same band does not.
+    cv::Mat mat = solid(100, 100, Color(0, 0, 0));  // background is out of the green range
+    mat(cv::Rect(0, 20, 100, 1)).setTo(cv::Scalar(0, 200, 0));  // y=20: a full-width solid green header row
+    mat(cv::Rect(65, 40, 5, 1)).setTo(cv::Scalar(0, 200, 0));  // y=40: a 5px green pill inside the band
+    const Frame frame = Frame::fixed(mat);
+    const Range<Color> green{Color(0, 150, 0), Color(80, 255, 80)};
+
+    // The probe band spans x[0.65,0.88] (23px on a 100px-wide frame), matching the config right-band.
+    const Line<double> header_band{Point<double>(0.65, 0.20), Point<double>(0.88, 0.20)};
+    CHECK(frame.fractionIn(green, header_band) == doctest::Approx(1.0));  // solid header -> accepted
+
+    const Line<double> pill_band{Point<double>(0.65, 0.40), Point<double>(0.88, 0.40)};
+    CHECK(frame.fractionIn(green, pill_band) < 0.5);  // narrow pill -> below threshold, rejected
+}
+
 TEST_CASE("Frame::pixelDifference sums gated per-pixel differences") {
     const Frame black = Frame::fixed(solid(4, 4, Color(0, 0, 0)));
     const Frame reddish = Frame::fixed(solid(4, 4, Color(10, 0, 0)));  // per-pixel diff of 10

--- a/native/tool/builder/chara_detail_scene_scraper_builder.h
+++ b/native/tool/builder/chara_detail_scene_scraper_builder.h
@@ -44,6 +44,8 @@ private:
             Rect<double>{{0.0, 0.0, IS}, {0.0, 0.0, ILE}},
             Rect<double>{{0.0222, 0.7259, IS}, {0.9759, 0.8037, IS}},
             Rect<double>{{0.0000, 0.8093, IS}, {0.0000, -0.2426, {IPE, ILE}}},
+            // scroll_bar_rect: full-width band for scrollbar detection, initially identical to scroll_area_rect.
+            Rect<double>{{0.0000, 0.8093, IS}, {0.0000, -0.2426, {IPE, ILE}}},
             Rect<double>{{0.0222, 0.0000, IS}, {-0.0222, 0.0000, {ILE, IPE}}},
             Range<Color>{Color{123, 121, 140} + 30, {255, 255, 255}},
             Line<double>{{0.9676, 0.0092, IS}, {0.9676, -0.0092, {IS, ILE}}},
@@ -66,13 +68,15 @@ private:
 
     // The Friend layout differs from Standard only by shifting the tab bar and the scroll
     // area down. The scroll-bar scan line, scroll-area stationary rect and scan parameters
-    // are all relative to the cropped scroll area, so only the two absolute, top-anchored
-    // rects move; the scroll area bottom stays anchored to the screen bottom (ILE).
+    // are all relative to the cropped scroll area, so only the absolute, top-anchored rects
+    // move (tab button, scroll area and scroll-bar band); the scroll area bottom stays
+    // anchored to the screen bottom (ILE).
     [[nodiscard]] chara_detail::scraper_config::SceneScraperConfig friendCommon() const {
         auto config = common();
         const double shift = friend_layout_shift;
         config.tab_button_rect = {{0.0222, 0.7259 + shift, IS}, {0.9759, 0.8037 + shift, IS}};
         config.scroll_area_rect = {{0.0000, 0.8093 + shift, IS}, {0.0000, -0.2426, {IPE, ILE}}};
+        config.scroll_bar_rect = {{0.0000, 0.8093 + shift, IS}, {0.0000, -0.2426, {IPE, ILE}}};
         // The shorter friend scroll area has a smaller viewport: fit across friend_standard /
         // friend_standard_many_rental gives V = 407 px (0.553 width-normalized), R^2 = 1.0. cap_offset and
         // the margin colour are widget constants, unchanged from common().

--- a/native/tool/builder/chara_detail_scene_scraper_builder.h
+++ b/native/tool/builder/chara_detail_scene_scraper_builder.h
@@ -126,13 +126,14 @@ private:
     // (its travel is compressed by viewport/content). Probe a right-of-centre band x[0.65,0.88] of the scroll-area
     // crop -- solid header green there, clear of the left icon column and the diagonal stripes, so requiring green
     // across the whole band (fraction > 0.5) rejects a stray green factor pill. Same UI green as factorEndGreen.
-    // flush_tolerance is width-normalized; the header y is quantized to 1 px (1/736 = 0.00136). Live measurement
-    // (factor reset diag): a real switch snaps to EXACTLY flush (delta = 0), whereas a same-character scroll of
-    // only ~4 px (delta = 0.0055) still spikes the content diff to ~29 %. 0.002 (~1.5 px) sits in that gap --
-    // it rejects a >=2 px scroll while tolerating up to 1 px of header-edge jitter on a genuine flush frame, so
-    // a real switch is still detected. (0.006 was too loose: it admitted the ~4 px scroll as flush.)
+    // flush_tolerance_px is in capture pixels (the header top-edge row). Live measurement (factor reset diag): a
+    // real switch snaps to EXACTLY flush (0 px), whereas a same-character scroll of only ~4 px still spikes the
+    // content diff to ~29 %. 1.5 px sits in that gap -- it rejects a >=2 px scroll while tolerating up to 1 px of
+    // header-edge detection jitter on a genuine flush frame, so a real switch is still detected. Pixels, not a
+    // width fraction, so it does not drift with capture resolution (a fraction would drop below 1 px on a smaller
+    // capture and start missing real switches).
     [[nodiscard]] chara_detail::scraper_config::FactorHeaderConfig factorHeader() const {
-        return {colorRange({128, 222, 20}, 45), 0.65, 0.88, 0.5, 0.002};
+        return {colorRange({128, 222, 20}, 45), 0.65, 0.88, 0.5, 1.5};
     }
 
     [[nodiscard]] std::vector<chara_detail::scraper_config::ScanParameter> campaignScanParameters() const {

--- a/native/tool/builder/chara_detail_scene_scraper_builder.h
+++ b/native/tool/builder/chara_detail_scene_scraper_builder.h
@@ -126,9 +126,13 @@ private:
     // (its travel is compressed by viewport/content). Probe a right-of-centre band x[0.65,0.88] of the scroll-area
     // crop -- solid header green there, clear of the left icon column and the diagonal stripes, so requiring green
     // across the whole band (fraction > 0.5) rejects a stray green factor pill. Same UI green as factorEndGreen.
-    // flush_tolerance 0.006 (~4-5 px at 736 wide) sits well under the ~10 px micro-scroll signal, above jitter.
+    // flush_tolerance is width-normalized; the header y is quantized to 1 px (1/736 = 0.00136). Live measurement
+    // (factor reset diag): a real switch snaps to EXACTLY flush (delta = 0), whereas a same-character scroll of
+    // only ~4 px (delta = 0.0055) still spikes the content diff to ~29 %. 0.002 (~1.5 px) sits in that gap --
+    // it rejects a >=2 px scroll while tolerating up to 1 px of header-edge jitter on a genuine flush frame, so
+    // a real switch is still detected. (0.006 was too loose: it admitted the ~4 px scroll as flush.)
     [[nodiscard]] chara_detail::scraper_config::FactorHeaderConfig factorHeader() const {
-        return {colorRange({128, 222, 20}, 45), 0.65, 0.88, 0.5, 0.006};
+        return {colorRange({128, 222, 20}, 45), 0.65, 0.88, 0.5, 0.002};
     }
 
     [[nodiscard]] std::vector<chara_detail::scraper_config::ScanParameter> campaignScanParameters() const {

--- a/native/tool/builder/chara_detail_scene_scraper_builder.h
+++ b/native/tool/builder/chara_detail_scene_scraper_builder.h
@@ -29,6 +29,7 @@ public:
             lineToY({0.8259, 60.0 / 736.0, {IS, SS}}, 40.0 / 736.0),
             colorRange({139, 221, 13}, 44),
             100,
+            factorHeader(),
         };
     }
 
@@ -118,6 +119,16 @@ private:
     // WinRT green (G>=177), same UI green as header_color_range.
     [[nodiscard]] chara_detail::scraper_config::ScanParameter factorEndGreen() const {
         return {0.6017, 5.0 / 736.0, colorRange({128, 222, 20}, 45)};
+    }
+
+    // The green "因子" section header is a precise "flush at the very top" sensor for maybeResetOnFactorChange:
+    // it moves 1:1 with the factor list, so a tiny scroll shifts it ~10 px where the scroll thumb barely moves
+    // (its travel is compressed by viewport/content). Probe a right-of-centre band x[0.65,0.88] of the scroll-area
+    // crop -- solid header green there, clear of the left icon column and the diagonal stripes, so requiring green
+    // across the whole band (fraction > 0.5) rejects a stray green factor pill. Same UI green as factorEndGreen.
+    // flush_tolerance 0.006 (~4-5 px at 736 wide) sits well under the ~10 px micro-scroll signal, above jitter.
+    [[nodiscard]] chara_detail::scraper_config::FactorHeaderConfig factorHeader() const {
+        return {colorRange({128, 222, 20}, 45), 0.65, 0.88, 0.5, 0.006};
     }
 
     [[nodiscard]] std::vector<chara_detail::scraper_config::ScanParameter> campaignScanParameters() const {

--- a/native/tool/builder/chara_detail_scene_scraper_builder.h
+++ b/native/tool/builder/chara_detail_scene_scraper_builder.h
@@ -52,6 +52,15 @@ private:
             200,
             18,
             100,
+            // Viewport V and cap offset c fit across player_standard/player_inheritance/friend_inheritance
+            // (common layout): tip_len = 2c + V*slope, R^2 = 1.0 -> V = 543 px, c = 0.94 px at 736 px width.
+            // Stored width-normalized: 543/736 = 0.738, 0.94/736 = 0.00126. c is a widget constant (shared).
+            0.738,
+            0.00126,
+            // Placeholder track is faintly coloured (satisfies R < 228 or G < 228); the near-white scroll-area
+            // margin flanking it is all channels >= 228. This box catches that margin and excludes the track,
+            // so the top/bottom margin runs locate the fixed track ends.
+            Range<Color>{{228, 228, 228}, {255, 255, 255}},
         };
     }
 
@@ -64,6 +73,10 @@ private:
         const double shift = friend_layout_shift;
         config.tab_button_rect = {{0.0222, 0.7259 + shift, IS}, {0.9759, 0.8037 + shift, IS}};
         config.scroll_area_rect = {{0.0000, 0.8093 + shift, IS}, {0.0000, -0.2426, {IPE, ILE}}};
+        // The shorter friend scroll area has a smaller viewport: fit across friend_standard /
+        // friend_standard_many_rental gives V = 407 px (0.553 width-normalized), R^2 = 1.0. cap_offset and
+        // the margin colour are widget constants, unchanged from common().
+        config.viewport = 0.553;
         return config;
     }
 

--- a/native/tool/builder/chara_detail_scene_scraper_builder.h
+++ b/native/tool/builder/chara_detail_scene_scraper_builder.h
@@ -66,6 +66,27 @@ private:
             // margin flanking it is all channels >= 228. This box catches that margin and excludes the track,
             // so the top/bottom margin runs locate the fixed track ends.
             Range<Color>{{228, 228, 228}, {255, 255, 255}},
+            thumbProbe(),
+        };
+    }
+
+    // Sub-pixel thumb-centre probe geometry for trackCenterX (self-centres the vertical scan on the thumb
+    // instead of trusting the fixed config column). The spatial fields are fractions of the scroll-area crop
+    // width, calibrated on 736 px footage where the pill is ~7 px wide: the centroid window spans 8 px, the
+    // white reference sits 9 px out (2 px band), the darkest core is 2 px, and 3 px is skipped at each rounded
+    // cap. max_sampled_rows (32) caps the row loop so a tall thumb stays cheap; minimum_contrast (20/255) is
+    // the white-to-core gap a row needs to contribute; minimum_coverage (3) is the summed AA coverage a row's
+    // centroid needs to be kept. The last three are counts/intensities, not spatial, so they do not scale.
+    [[nodiscard]] chara_detail::scraper_config::ScrollBarThumbProbeConfig thumbProbe() const {
+        return {
+            8.0 / 736.0,
+            9.0 / 736.0,
+            2.0 / 736.0,
+            2.0 / 736.0,
+            3.0 / 736.0,
+            32,
+            20.0,
+            3.0,
         };
     }
 

--- a/native/tool/builder/chara_detail_scene_scraper_builder.h
+++ b/native/tool/builder/chara_detail_scene_scraper_builder.h
@@ -48,7 +48,9 @@ private:
             Rect<double>{{0.0000, 0.8093, IS}, {0.0000, -0.2426, {IPE, ILE}}},
             Rect<double>{{0.0222, 0.0000, IS}, {-0.0222, 0.0000, {ILE, IPE}}},
             Range<Color>{Color{123, 121, 140} + 30, {255, 255, 255}},
-            Line<double>{{0.9676, 0.0092, IS}, {0.9676, -0.0092, {IS, ILE}}},
+            // scroll_bar_scan_line.x sits on the thumb's true horizontal center (trackCenterX centroid across
+            // 11 screenshots, width-normalized 0.96927); this is also the config-column fallback.
+            Line<double>{{0.9693, 0.0092, IS}, {0.9693, -0.0092, {IS, ILE}}},
             0.01,
             0.05,
             200,


### PR DESCRIPTION
## Summary

Reworks the character-detail scroll pipeline so every scrollbar/factor geometry lives in the scene config instead of being hard-coded or piggy-backing on the content crop. Along the way it fixes two live-capture regressions: a compressed-thumb "at top" gate that mis-reset the factor tab on tiny scrolls, and a scroll-offset guess that drifted because it read the thumb against the config scan line rather than the true track.

## What changed

### 1. Decouple scrollbar detection from the content crop
- **`scroll_bar_rect`** — a dedicated full-width band the scrollbar is detected in, split out from **`scroll_area_rect`** (the content/stitch crop). The crop can now move without shifting the scan geometry. The band must stay full width (only its y-range is meant to diverge); the constraint is documented on the field.
- **Single scroll-offset geometry** — the offset guess is driven from one `trackGeometry`, with the legacy `findScrollbar` / `scanMargin` / `scroll_bar_length` latch paths removed so detection is a single source of truth.

### 2. Sub-pixel thumb-centre probe
- **`ScrollBarThumbProbeConfig`** — the vertical scan self-centres on the thumb via an AA intensity-weighted centroid. All spatial fields are fractions of the crop width (converted through the frame anchor) so they scale with capture resolution instead of assuming one; `max_sampled_rows` / `minimum_contrast` / `minimum_coverage` are resolution-independent thresholds.
- **True-track measurement** — `scroll_bar_margin_color` isolates the near-white band flanking the placeholder track, so the position is measured against the fixed track ends rather than the (slightly longer) config scan line. `viewport` and `cap_offset` (rounded-cap depth `c`, so the logical thumb length is `tip - 2c`) are width-normalized and carried per layout.

### 3. Gate the factor-tab reset on the green header
- **`FactorHeaderConfig`** — locates the green "因子" section header, whose top edge moves 1:1 with the factor list (unlike the thumb, whose travel is viewport-compressed). `maybeResetOnFactorChange` now runs the same-character content diff only when the header sits flush at its reference y, so a tiny scroll of the same character no longer reads as a switch.
- **`flush_tolerance_px`** — the flush tolerance is expressed in capture pixels (not a width fraction) on purpose: it discriminates ~1 px header-row jitter from the ~2 px scroll at which the diff already spikes, both pixel-scale quantities. Falls back to the thumb top-margin when the header isn't detected.
- Adds `Frame::fractionIn` (with tests) to express the probe geometry against the frame anchor.

## Testing

- `native/test` scraper-estimator and frame unit tests updated/added; ctest green.
- `integration_golden` — all 5 cases pass, including the previously failing `friend_inheritance` case (the tiny-scroll false reset it exercised is now gated by the green header on both the header and top-margin fallback paths).

## Risk / scope

Native-only change scoped to `chara_detail`; the scene config (`scene_scraper.json`) gains the new geometry blocks. No Dart/UI surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
