### PR TITLE
feat(chara-detail): show inheritance evaluation/rank as empty, not minimum

### DIFF
--- a/lib/src/chara_detail/chara_detail_record.dart
+++ b/lib/src/chara_detail/chara_detail_record.dart
@@ -238,6 +238,11 @@ extension RecordTypeTranslation on RecordType {
   };
 }
 
+/// Placeholder shown where a record has no value for a field (e.g. the
+/// evaluation value and rank of an inheritance-only / friend-inheritance record).
+/// A neutral symbol, not localized text: it means "no value", not "minimum".
+const String absentValueLabel = "-";
+
 /// Sentinel `trainer_id` for records whose owner is unknown.
 ///
 /// A friend's record captured from the player's own game exposes no recoverable
@@ -377,6 +382,21 @@ class CharaDetailRecord extends JsonEquatable with CharaDetailRecordMappable {
   /// Whether this is a friend's (practice-partner) record, full or inheritance-only.
   bool get isFriend =>
       metadata.recordType == RecordType.friendStandard || metadata.recordType == RecordType.friendInheritance;
+
+  /// Whether this record carries no evaluation value (nor a derived rank).
+  ///
+  /// The inheritance-only and friend-inheritance layouts have no evaluation value
+  /// on screen, so the native recognizer never reads one and leaves it at the
+  /// default 0. Mirrors `isInheritanceOnly` in the native recognizer so display
+  /// code can render an empty ([absentValueLabel]) cell instead of a spurious
+  /// minimum. Friend (non-inheritance) records do carry a real value.
+  bool get isInheritanceOnly =>
+      metadata.recordType == RecordType.inheritanceOnly || metadata.recordType == RecordType.friendInheritance;
+
+  /// The evaluation value formatted for display, or [absentValueLabel] when the
+  /// record has none ([isInheritanceOnly]). Shared by the single-record dialogs
+  /// (archive/delete/rating/memo) so they all render the absent case identically.
+  String get evaluationValueLabel => isInheritanceOnly ? absentValueLabel : evaluationValue.toNumberString();
 
   FilePath get traineeIconPath => DirectoryPath(id).filePath(traineeIconFileName);
 

--- a/lib/src/chara_detail/spec/chara_rank.dart
+++ b/lib/src/chara_detail/spec/chara_rank.dart
@@ -1,4 +1,5 @@
 import 'package:dart_mappable/dart_mappable.dart';
+import 'package:trina_grid/trina_grid.dart';
 import 'package:uuid/uuid.dart';
 
 import '/src/chara_detail/chara_detail_record.dart';
@@ -34,6 +35,12 @@ class CharaRankColumnSpec extends RangedLabelColumnSpec with CharaRankColumnSpec
     final charaRankBorder = ref.watch(charaRankBorderProvider);
     return List<int>.from(
       records.map(parser.parse).map((evaluation) {
+        // Records with no evaluation value (inheritance-only / friend-inheritance)
+        // have no rank either: pass the sentinel through so plutoCell renders an
+        // empty cell instead of the lowest rank.
+        if (evaluation == evaluationValueAbsent) {
+          return evaluationValueAbsent;
+        }
         // indexWhere returns -1 when the evaluation exceeds every border, i.e. the
         // top-most bucket. Map it to the last rank index instead so the highest rank
         // (e.g. LS24) stays reachable for both display and filtering.
@@ -41,6 +48,16 @@ class CharaRankColumnSpec extends RangedLabelColumnSpec with CharaRankColumnSpec
         return index < 0 ? charaRankBorder.length : index;
       }),
     );
+  }
+
+  @override
+  TrinaCell plutoCell(RefBase ref, int value) {
+    // The rank sentinel is not a valid label index, so it must not reach the base
+    // `labels[value]` lookup (which would throw). Render an empty cell instead.
+    if (value == evaluationValueAbsent) {
+      return TrinaCell(value: value)..setUserData(RangedLabelCellData(absentValueLabel));
+    }
+    return super.plutoCell(ref, value);
   }
 
   @override

--- a/lib/src/chara_detail/spec/memo.dart
+++ b/lib/src/chara_detail/spec/memo.dart
@@ -262,7 +262,7 @@ class _RecordMemoDialogState extends ConsumerState<_RecordMemoDialog> {
                 errorBuilder: (context, error, stackTrace) =>
                     Icon(Symbols.hide_image_rounded, size: 64, color: theme.colorScheme.onSurfaceVariant),
               ),
-              Text(record.evaluationValue.toNumberString(), style: theme.textTheme.titleMedium),
+              Text(record.evaluationValueLabel, style: theme.textTheme.titleMedium),
               const SizedBox(height: 16),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/src/chara_detail/spec/parser.dart
+++ b/lib/src/chara_detail/spec/parser.dart
@@ -5,6 +5,13 @@ import '/src/core/utils.dart';
 
 part 'parser.mapper.dart';
 
+/// Value returned by [EvaluationValueParser] for records that have no evaluation
+/// value (inheritance-only / friend-inheritance). The evaluation and rank columns
+/// detect it and render an empty ([absentValueLabel]) cell instead of a spurious
+/// minimum. Real evaluation values (and derived rank indices) are non-negative,
+/// so -1 never collides with a genuine value.
+const int evaluationValueAbsent = -1;
+
 @MappableClass(discriminatorKey: 'type')
 abstract class Parser<T> with ParserMappable<T> {
   String get type => runtimeType.toString();
@@ -15,7 +22,7 @@ abstract class Parser<T> with ParserMappable<T> {
 @MappableClass(discriminatorValue: 'EvaluationValueParser')
 class EvaluationValueParser extends Parser<int> with EvaluationValueParserMappable {
   @override
-  int parse(CharaDetailRecord record) => record.evaluationValue;
+  int parse(CharaDetailRecord record) => record.isInheritanceOnly ? evaluationValueAbsent : record.evaluationValue;
 }
 
 @MappableClass(discriminatorValue: 'CharaCardParser')

--- a/lib/src/chara_detail/spec/ranged_integer.dart
+++ b/lib/src/chara_detail/spec/ranged_integer.dart
@@ -44,7 +44,7 @@ class RangedIntegerCellData implements CellData {
   RangedIntegerCellData(this.value);
 
   @override
-  String get csv => value.toString();
+  String get csv => value == evaluationValueAbsent ? absentValueLabel : value.toString();
 
   @override
   CellSelectedCallback? get onSelected => null;
@@ -149,7 +149,8 @@ class RangedIntegerColumnSpec extends ColumnSpec<int> with RangedIntegerColumnSp
       enableEditingMode: false,
       renderer: (TrinaColumnRendererContext context) {
         final data = context.cell.getUserData<RangedIntegerCellData>()!;
-        return CellText(data.value.toNumberString(), textAlign: TextAlign.center);
+        final text = data.value == evaluationValueAbsent ? absentValueLabel : data.value.toNumberString();
+        return CellText(text, textAlign: TextAlign.center);
       },
     )..setUserData(this);
   }
@@ -182,7 +183,10 @@ class _RangedIntegerSelector extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final spec = _clonedSpecProvider.watch(ref, specId);
     final records = ref.watch(charaDetailRecordStorageProvider);
-    final range = records.isEmpty ? Range<double>(min: 0, max: 0) : spec.parse(ref.base, records).range().toDouble();
+    // Drop the "no value" sentinel (inheritance-only evaluation) so the slider's
+    // minimum is a real value rather than -1. Inert for parsers that never emit it.
+    final values = spec.parse(ref.base, records).where((e) => e != evaluationValueAbsent).toList();
+    final range = values.isEmpty ? Range<double>(min: 0, max: 0) : values.range().toDouble();
     return FormGroup(
       title: Text("$tr_ranged_integer.range.label".tr()),
       description: Text("$tr_ranged_integer.range.description".tr()),

--- a/lib/src/chara_detail/spec/ranged_label.dart
+++ b/lib/src/chara_detail/spec/ranged_label.dart
@@ -180,7 +180,12 @@ class _RangedLabelSelector extends ConsumerWidget {
     final spec = _clonedSpecProvider.watch(ref, specId);
     final labels = ref.watch(labelMapProvider)[spec.labelKey]!;
     final records = ref.watch(charaDetailRecordStorageProvider);
-    final range = records.isEmpty ? Range<double>(min: 0, max: 0) : spec.parse(ref.base, records).range().toDouble();
+    // Drop the "no value" sentinel (e.g. an inheritance-only record's absent rank)
+    // before computing the range: it is not a valid label index, so leaving it in
+    // would make range.min -1 and crash the slider formatter's `labels[-1]` lookup.
+    // Inert for label columns that never emit it.
+    final values = spec.parse(ref.base, records).where((e) => e != evaluationValueAbsent).toList();
+    final range = values.isEmpty ? Range<double>(min: 0, max: 0) : values.range().toDouble();
     return FormGroup(
       title: Text("$tr_ranged_label.range.label".tr()),
       description: Text("$tr_ranged_label.range.description".tr()),

--- a/lib/src/chara_detail/spec/rating.dart
+++ b/lib/src/chara_detail/spec/rating.dart
@@ -274,7 +274,7 @@ class _RecordRatingDialogState extends ConsumerState<_RecordRatingDialog> {
                 errorBuilder: (context, error, stackTrace) =>
                     Icon(Symbols.hide_image_rounded, size: 64, color: theme.colorScheme.onSurfaceVariant),
               ),
-              Text(record.evaluationValue.toNumberString(), style: theme.textTheme.titleMedium),
+              Text(record.evaluationValueLabel, style: theme.textTheme.titleMedium),
               const SizedBox(height: 16),
               RatingBar.builder(
                 initialRating: widget.initialRating,

--- a/lib/src/gui/chara_detail/archive_record_dialog.dart
+++ b/lib/src/gui/chara_detail/archive_record_dialog.dart
@@ -152,7 +152,7 @@ class _ArchiveRecordDialogState extends ConsumerState<ArchiveRecordDialog> {
                       Icon(Symbols.hide_image_rounded, size: 64, color: theme.colorScheme.onSurfaceVariant),
                 ),
               ),
-              Text(record.evaluationValue.toNumberString(), style: theme.textTheme.titleMedium),
+              Text(record.evaluationValueLabel, style: theme.textTheme.titleMedium),
               const SizedBox(height: 8),
               RadioGroup<ArchiveImageOption>(
                 groupValue: _option,

--- a/lib/src/gui/chara_detail/delete_record_dialog.dart
+++ b/lib/src/gui/chara_detail/delete_record_dialog.dart
@@ -96,7 +96,7 @@ class DeleteRecordDialog extends ConsumerWidget {
                 errorBuilder: (context, error, stackTrace) =>
                     Icon(Symbols.hide_image_rounded, size: 64, color: theme.colorScheme.onSurfaceVariant),
               ),
-              Text(record.evaluationValue.toNumberString(), style: theme.textTheme.titleMedium),
+              Text(record.evaluationValueLabel, style: theme.textTheme.titleMedium),
               const SizedBox(height: 8),
               WarningCard(message: "$tr_delete_record.dialog.description".tr()),
             ],

--- a/test/evaluation_rank_absent_test.dart
+++ b/test/evaluation_rank_absent_test.dart
@@ -1,0 +1,153 @@
+// Covers the "no evaluation value" handling for inheritance-only and
+// friend-inheritance records: their evaluation and rank columns must render an
+// empty (absentValueLabel) cell instead of a spurious minimum, while standard
+// and friend (non-inheritance) records keep their real value.
+//
+// The native recognizer never reads an evaluation value for the inheritance
+// layouts and leaves it at 0; here every record carries a non-zero value so a
+// leaked 0 could not masquerade as "absent".
+//
+// Run: .fvm/flutter_sdk/bin/flutter test test/evaluation_rank_absent_test.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/chara_detail/chara_detail_record.dart';
+import 'package:umacapture/src/chara_detail/spec/base.dart';
+import 'package:umacapture/src/chara_detail/spec/chara_rank.dart';
+import 'package:umacapture/src/chara_detail/spec/loader.dart';
+import 'package:umacapture/src/chara_detail/spec/parser.dart';
+import 'package:umacapture/src/chara_detail/spec/ranged_integer.dart';
+import 'package:umacapture/src/chara_detail/spec/ranged_label.dart';
+import 'package:umacapture/src/core/mapper_init.dart';
+import 'package:umacapture/src/core/utils.dart';
+
+import 'support/riverpod.dart';
+
+// A synthetic rank ladder: evaluation < 300 -> index 0, < 1000 -> 1, < 5000 -> 2,
+// otherwise the top index 3.
+const _rankBorder = [300, 1000, 5000];
+
+Character _chara(int card) => Character(0, 0, card, 0);
+
+Parent _parent(int card) => Parent(_chara(card), _chara(0), _chara(0), null);
+
+CharaDetailRecord _record({required RecordType type, required int evaluationValue}) {
+  final metadata = Metadata(
+    '1.0.0',
+    'JPN',
+    RecordId('id-${type.name}', null, null),
+    'trainer',
+    '2026-01-01T00:00:00+0900',
+    '2026-01-01T00:00:00+0900',
+    RecordStage.active,
+    0,
+    null,
+    type,
+  );
+  return CharaDetailRecord(
+    metadata,
+    _chara(1),
+    evaluationValue,
+    const CharacterStatus(0, 0, 0, 0, 0),
+    const AptitudeSet(GroundAptitude(0, 0), DistanceAptitude(0, 0, 0, 0), StyleAptitude(0, 0, 0, 0)),
+    const <Skill>[],
+    const FactorSet([], [], []),
+    const <SupportCard>[],
+    Family(_parent(0), _parent(0)),
+    0,
+    const Scenario(0),
+    '2026/01/01',
+    const <Race>[],
+  );
+}
+
+RangedIntegerColumnSpec _evaluationSpec() {
+  return RangedIntegerColumnSpec(
+    id: 'eval-id',
+    title: 'Evaluation',
+    parser: EvaluationValueParser(),
+    predicate: IsInRangeIntegerPredicate(),
+  );
+}
+
+CharaRankColumnSpec _rankSpec() {
+  return CharaRankColumnSpec(
+    id: 'rank-id',
+    title: 'Rank',
+    parser: EvaluationValueParser(),
+    labelKey: LabelKeys.charaRank,
+    predicate: IsInRangeIntegerPredicate(),
+  );
+}
+
+RefBase _refWithBorder() {
+  final container = ProviderContainer.test(overrides: [charaRankBorderProvider.overrideWithValue(_rankBorder)]);
+  addTearDown(container.dispose);
+  return container.read(refBaseProvider);
+}
+
+void main() {
+  setUpAll(initializeMappers);
+
+  group('isInheritanceOnly', () {
+    test('is true only for inheritance-only and friend-inheritance', () {
+      expect(_record(type: RecordType.standard, evaluationValue: 1).isInheritanceOnly, isFalse);
+      expect(_record(type: RecordType.inheritanceOnly, evaluationValue: 1).isInheritanceOnly, isTrue);
+      expect(_record(type: RecordType.friendStandard, evaluationValue: 1).isInheritanceOnly, isFalse);
+      expect(_record(type: RecordType.friendInheritance, evaluationValue: 1).isInheritanceOnly, isTrue);
+    });
+  });
+
+  group('evaluation column parse', () {
+    test('yields the sentinel for inheritance records and the real value otherwise', () {
+      final ref = _refWithBorder();
+      final records = [
+        _record(type: RecordType.standard, evaluationValue: 4200),
+        _record(type: RecordType.inheritanceOnly, evaluationValue: 4200),
+        _record(type: RecordType.friendStandard, evaluationValue: 4200),
+        _record(type: RecordType.friendInheritance, evaluationValue: 4200),
+      ];
+      expect(_evaluationSpec().parse(ref, records), [4200, evaluationValueAbsent, 4200, evaluationValueAbsent]);
+    });
+  });
+
+  group('rank column parse', () {
+    test('yields the sentinel for inheritance records and the computed index otherwise', () {
+      final ref = _refWithBorder();
+      final records = [
+        _record(type: RecordType.standard, evaluationValue: 4200), // < 5000 -> index 2
+        _record(type: RecordType.inheritanceOnly, evaluationValue: 4200),
+        _record(type: RecordType.friendStandard, evaluationValue: 250), // < 300 -> index 0
+        _record(type: RecordType.friendInheritance, evaluationValue: 4200),
+        _record(type: RecordType.standard, evaluationValue: 9000), // above every border -> top index 3
+      ];
+      expect(_rankSpec().parse(ref, records), [2, evaluationValueAbsent, 0, evaluationValueAbsent, 3]);
+    });
+
+    test('renders an empty cell for the sentinel without touching the label map', () {
+      final ref = _refWithBorder();
+      // The sentinel path must short-circuit before the base `labels[value]`
+      // lookup, so no labelMapProvider override is needed here.
+      final cell = _rankSpec().plutoCell(ref, evaluationValueAbsent);
+      expect(cell.getUserData<RangedLabelCellData>()!.label, absentValueLabel);
+    });
+  });
+
+  group('single-record display', () {
+    test('evaluationValueLabel is the placeholder for inheritance records only', () {
+      expect(_record(type: RecordType.standard, evaluationValue: 4200).evaluationValueLabel, 4200.toNumberString());
+      expect(_record(type: RecordType.inheritanceOnly, evaluationValue: 4200).evaluationValueLabel, absentValueLabel);
+      expect(
+        _record(type: RecordType.friendStandard, evaluationValue: 4200).evaluationValueLabel,
+        4200.toNumberString(),
+      );
+      expect(_record(type: RecordType.friendInheritance, evaluationValue: 4200).evaluationValueLabel, absentValueLabel);
+    });
+  });
+
+  group('csv export', () {
+    test('the ranged-integer cell exports the placeholder for the sentinel', () {
+      expect(RangedIntegerCellData(evaluationValueAbsent).csv, absentValueLabel);
+      expect(RangedIntegerCellData(4200).csv, '4200');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Inheritance-only and friend-inheritance records have no evaluation value on
screen, so the native recognizer never reads one and leaves it at the default
`0`. Previously the evaluation and rank columns (and the single-record dialogs)
rendered that `0` as a real **minimum** value/rank, which is misleading. This
change renders those cells as an empty placeholder (`-`) instead.

## What changed

- **`isInheritanceOnly` on `CharaDetailRecord`** — mirrors the native
  recognizer: true for `inheritanceOnly` and `friendInheritance` record types.
  Friend (non-inheritance) records still carry a real value.
- **`evaluationValueAbsent` sentinel (`-1`)** — `EvaluationValueParser` emits it
  for inheritance records. Real values and derived rank indices are
  non-negative, so `-1` never collides with a genuine value.
- **Column rendering** — the ranged-integer (evaluation) and chara-rank columns
  detect the sentinel and render `absentValueLabel` (`-`) instead of a spurious
  minimum. `CharaRankColumnSpec.plutoCell` short-circuits before the base
  `labels[value]` lookup so the sentinel can't throw.
- **Range sliders** — the ranged-integer and ranged-label selectors drop the
  sentinel before computing the slider range, so `range.min` is a real value
  rather than `-1` (which would also crash the label formatter's `labels[-1]`).
- **Single-record dialogs** — archive/delete/rating/memo share the new
  `evaluationValueLabel` getter so they all render the absent case identically.
- **CSV export** — the ranged-integer cell exports `-` for the sentinel.

## Testing

- `.fvm/flutter_sdk/bin/flutter test test/evaluation_rank_absent_test.dart` —
  6/6 pass. Covers `isInheritanceOnly`, evaluation/rank column parse, the
  empty-cell render path (no label-map lookup), `evaluationValueLabel`, and CSV
  export. Every fixture carries a non-zero value so a leaked `0` could not
  masquerade as "absent".

## Follow-up

- The statistics page (`_evaluationValueOf` / `_rankLabelOf`) still treats
  inheritance records as `evaluationValue == 0`, so they appear at `0` in the
  evaluation distribution and are classified into the lowest rank. Left out of
  this change's scope; worth a separate pass for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
