### PR TITLE
feat(native): FFV1 lossless capture recorder/replay and factor-tab termination refactor

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,6 +17,25 @@ Runtime/user-facing strings (e.g. localized UI text under `assets/translations/`
 - Run code generation with `dart run build_runner build --force-jit`. The `--force-jit` flag is required because a transitive native build hook (`objective_c`, via `package_info_plus`) is incompatible with build_runner's default AOT compilation.
 - The Dart MCP server (`dart` in `.mcp.json`) does **not** run code generation — it exposes no `build_runner` tool, and its `pub` tool only edits `pubspec`. After adding a codegen package or editing annotated sources (`dart_mappable`, `auto_route`), run `build_runner` manually with the command above. Do not assume the MCP tools regenerate outputs.
 
+## Never reuse a build artifact you did not build this session
+
+- **Do not run, measure, diagnose, or draw conclusions from any executable (or
+  other build output) that was not produced by a build in the current session.**
+  This applies to **both** the native CLI (`native/cmake-build-*/umacapture_cli.exe`)
+  and the Flutter Windows app (`build/windows/.../*.exe`), and to any stitched /
+  captured artifacts they emit.
+- Before the first run of a session — and after any source change, `git`
+  checkout / pull / stash, or branch switch — **rebuild from the current working
+  tree** and run only that fresh binary. A pre-existing binary can be stale: built
+  from an older commit, another branch, or an uncommitted state, so its output
+  does not reflect the code under review.
+- If provenance is ever in doubt (e.g. an `.exe` whose mtime predates recent
+  commits), treat it as stale and rebuild rather than trusting it. When it
+  matters, cross-check the artifact's build time against `git log` dates.
+- Rationale: reusing a stale `umacapture_cli.exe` (built before a merged tail-trim
+  fix) once produced misleading factor-tab output and sent a whole diagnosis
+  chasing a bug that no longer existed on `HEAD`.
+
 ## Formatting
 
 - The repo complies with standard `dart format`; run it freely. The page width

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -6,6 +6,14 @@ the user explicitly asks**.
 ## Branching
 
 - Never commit or push directly to `develop` (the default / main branch).
+- **If a non-`develop` branch is already checked out, work on it — do not create
+  a new branch on your own.** A branch that is already prepared is the intended
+  workspace; assume the current work belongs there unless the user says otherwise.
+  Only create a new branch when you are on `develop`, or when the user explicitly
+  asks for one.
+- When a new branch is genuinely needed, **base it on the currently checked-out
+  branch**, not on `develop`, unless the user says otherwise (the current branch
+  may carry unmerged work the new task builds on).
 - Before making changes that will be committed, create a feature branch first
   (e.g. `feature/<topic>`, `fix/<topic>`), then commit there.
 - Open pull requests against `develop`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,28 @@ jobs:
           path: windows/opencv
           key: opencv-4.13.0-windows-slim
 
-      # uv runs tool/fetch_deps.py (stdlib-only); only needed on a cache miss.
+      # FFmpeg (BtbN n7.1.5 LGPL shared) is linked only by umacapture_ffv1_tests (the FFV1 recorder/reader
+      # round-trip); umacapture_tests stays opencv-only. Cached like OpenCV; the "-slim" key matches the
+      # pruned layout. Bump this key when the ffmpeg pin in tool/fetch_deps.py changes.
+      - name: Cache FFmpeg n7.1.5
+        id: cache-ffmpeg
+        uses: actions/cache@v4
+        with:
+          path: windows/ffmpeg
+          key: ffmpeg-n7.1.5-lgpl-shared-slim
+
+      # uv runs tool/fetch_deps.py (stdlib-only); only needed when a dependency must be provisioned.
       - name: Set up uv
-        if: steps.cache-opencv.outputs.cache-hit != 'true'
+        if: steps.cache-opencv.outputs.cache-hit != 'true' || steps.cache-ffmpeg.outputs.cache-hit != 'true'
         uses: astral-sh/setup-uv@v6
 
       - name: Provision OpenCV 4.13.0
         if: steps.cache-opencv.outputs.cache-hit != 'true'
         run: uv run tool/fetch_deps.py --only opencv --slim
+
+      - name: Provision FFmpeg n7.1.5
+        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
+        run: uv run tool/fetch_deps.py --only ffmpeg --slim
 
       # Ninja + Debug are required (see native/test/README.md); asserts are live in Debug.
       - name: Configure (CMake + Ninja, Debug)
@@ -62,6 +76,10 @@ jobs:
 
       - name: Build umacapture_tests
         run: cmake --build native/cmake-build-tests --target umacapture_tests
+
+      # Separate libav-linked target for the FFV1 recorder/reader round-trip (bit-exact color + timestamps).
+      - name: Build umacapture_ffv1_tests
+        run: cmake --build native/cmake-build-tests --target umacapture_ffv1_tests
 
       # integration_golden self-skips (exit 77) here: we build only umacapture_tests, not the
       # ONNX-linked cli it drives, and the local-only clips/models are absent too -- so ctest

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -23,6 +23,13 @@ set(OpenCV_FFMPEG_DLL "${OpenCV_DIR}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/bin/opencv
 
 set(ONNX_DIR "${CMAKE_CURRENT_LIST_DIR}/../windows/onnxruntime")
 
+# FFmpeg (BtbN LGPL shared, provisioned by tool/fetch_deps.py into windows/ffmpeg). Only the CLI target
+# links it, for the lossless FFV1 capture recorder / replay reader (src/cv/ffv1_*). Its versioned runtime
+# DLLs are copied next to the exe by the POST_BUILD step below. The Flutter Windows app target
+# (windows/runner/CMakeLists.txt) deliberately does NOT link ffmpeg, since it never compiles cli.cpp; wiring
+# recording into the app (via native_api.cpp) would require adding this include/lib/DLL there too.
+set(FFMPEG_DIR "${CMAKE_CURRENT_LIST_DIR}/../windows/ffmpeg")
+
 set(
         SOURCE_FILES
         src/core/cli.cpp
@@ -34,6 +41,8 @@ set(
         src/chara_detail/chara_detail_scene_scraper.cpp
         src/chara_detail/chara_detail_scene_stitcher.cpp
         src/condition/serializer.cpp
+        src/cv/ffv1_recorder.cpp
+        src/cv/ffv1_reader.cpp
         src/util/logger_util.cpp
 )
 
@@ -81,12 +90,16 @@ target_include_directories(
         "${CMAKE_CURRENT_LIST_DIR}/tool"
         "${OpenCV_INCLUDE_DIRS}"
         "${ONNX_DIR}/include"
+        "${FFMPEG_DIR}/include"
 )
 
 target_link_libraries(
         ${PROJECT_NAME} PRIVATE
         "${OpenCV_LIBS}"
         "${ONNX_DIR}/lib/onnxruntime.lib"
+        "${FFMPEG_DIR}/lib/avformat.lib"
+        "${FFMPEG_DIR}/lib/avcodec.lib"
+        "${FFMPEG_DIR}/lib/avutil.lib"
         windowsapp.lib
         dwmapi.lib
 )
@@ -110,6 +123,17 @@ add_custom_command(
         TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E
         copy
         ${OpenCV_FFMPEG_DLL}
+        $<TARGET_FILE_DIR:${PROJECT_NAME}>
+)
+
+# The FFV1 recorder/reader link libav directly, so its versioned runtime DLLs (avutil/avcodec/avformat and
+# their transitive swresample/swscale) must sit next to the exe. Globbed to stay version-agnostic across
+# ffmpeg bumps; these names are distinct from OpenCV's opencv_videoio_ffmpeg plugin, so they coexist.
+file(GLOB FFMPEG_DLLS "${FFMPEG_DIR}/bin/av*.dll" "${FFMPEG_DIR}/bin/sw*.dll")
+add_custom_command(
+        TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E
+        copy_if_different
+        ${FFMPEG_DLLS}
         $<TARGET_FILE_DIR:${PROJECT_NAME}>
 )
 
@@ -216,6 +240,71 @@ target_link_libraries(
 )
 
 add_test(NAME umacapture_tests COMMAND umacapture_tests)
+
+# ---------------------------------------------------------------------------
+# FFV1 recorder/reader round-trip test. Kept as a SEPARATE target from umacapture_tests because it links
+# libav (ffmpeg), which the pristine opencv-only umacapture_tests must not pull in. It reuses the same
+# opencv-old-toolset STL guard (_USE_STD_VECTOR_ALGORITHMS=0). CI provisions windows/ffmpeg for this.
+# ---------------------------------------------------------------------------
+add_executable(
+        umacapture_ffv1_tests
+        test/test_main.cpp
+        test/cv/test_ffv1_roundtrip.cpp
+        src/cv/ffv1_recorder.cpp
+        src/cv/ffv1_reader.cpp
+)
+
+target_compile_options(
+        umacapture_ffv1_tests PRIVATE
+        /wd4068
+        /wd4819
+        /wd4996
+        /wd5285
+)
+
+target_compile_definitions(
+        umacapture_ffv1_tests PRIVATE
+        USE_CUSTOM_ASSERT
+        WINVER=0x0A00
+        _WIN32_WINNT=0x0A00
+        _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS
+        _USE_STD_VECTOR_ALGORITHMS=0
+)
+
+target_include_directories(
+        umacapture_ffv1_tests PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/src"
+        "${CMAKE_CURRENT_LIST_DIR}/test"
+        "${CMAKE_CURRENT_LIST_DIR}/vendor"
+        "${OpenCV_INCLUDE_DIRS}"
+        "${FFMPEG_DIR}/include"
+)
+
+target_link_libraries(
+        umacapture_ffv1_tests PRIVATE
+        "${OpenCV_LIBS}"
+        "${FFMPEG_DIR}/lib/avformat.lib"
+        "${FFMPEG_DIR}/lib/avcodec.lib"
+        "${FFMPEG_DIR}/lib/avutil.lib"
+)
+
+add_test(NAME umacapture_ffv1_tests COMMAND umacapture_ffv1_tests)
+
+add_custom_command(
+        TARGET umacapture_ffv1_tests POST_BUILD COMMAND ${CMAKE_COMMAND} -E
+        copy
+        $<$<CONFIG:Debug>:${OpenCV_DEBUG_DLL}>
+        $<$<CONFIG:Release>:${OpenCV_RELEASE_DLL}>
+        $<TARGET_FILE_DIR:umacapture_ffv1_tests>
+)
+
+file(GLOB FFMPEG_TEST_DLLS "${FFMPEG_DIR}/bin/av*.dll" "${FFMPEG_DIR}/bin/sw*.dll")
+add_custom_command(
+        TARGET umacapture_ffv1_tests POST_BUILD COMMAND ${CMAKE_COMMAND} -E
+        copy_if_different
+        ${FFMPEG_TEST_DLLS}
+        $<TARGET_FILE_DIR:umacapture_ffv1_tests>
+)
 
 # ---------------------------------------------------------------------------
 # Integration (golden) test -- drives the real umacapture_cli over recorded clips

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -612,14 +612,41 @@ bool PageScrapingBox::detectGreenTerminator(const Frame &frame, int offset_pixel
     return false;
 }
 
+int PageScrapingBox::latchUpToGreenTerminator(const Frame &frame, int offset_pixels) {
+    if (!end_green_fired || green_terminator_top_pixels < 0) {
+        return offset_pixels;
+    }
+    // Rows of tab content above the bar that scrolled in on this frame but were never latched (the green
+    // branch in updateScrolling returns before the regular addScrollArea). Nothing to do when the bar sits
+    // at or above the frontier: everything above it is already in the stack.
+    const int revealed_above_bar = green_terminator_top_pixels - (frame.height() - offset_pixels);
+    if (revealed_above_bar < 1) {
+        return offset_pixels;
+    }
+    // Latch only up to the bar top. The bar and whatever lies below it get trimmed anyway, and latching
+    // them would record post-bar background transitions that push the last factor's gap out of the
+    // two-deep frontier history trimScrollAreaToFactorEnd validates -- degrading its evidence-based crop
+    // to the bar-top fail-safe (a longer, uneven tail).
+    const auto &anchor = frame.anchor();
+    const Rect<double> above_bar = {
+        Point<double>{0., 0.},
+        Point<double>{1., anchor.scaleFromPixels(green_terminator_top_pixels)},
+    };
+    addScrollArea(frame.view(above_bar), revealed_above_bar);
+    // The stack bottom is now the bar top; the trim's "stack bottom == height - offset" invariant needs
+    // the offset that maps it there.
+    return frame.height() - green_terminator_top_pixels;
+}
+
 void PageScrapingBox::trimScrollAreaToFactorEnd(const Frame &frame, int offset_pixels) {
     if (!end_green_fired || green_terminator_top_pixels < 0) {
         return;
     }
     const auto &anchor = frame.anchor();
     const int margin_pixels = anchor.expand({0., kFactorEndBottomMargin}).y();
-    // The stack bottom corresponds to the scroll frontier (height - offset_pixels); the terminating frame is
-    // not saved on the green path. Map the live bar top into stack coordinates: it exceeds stack_rows when
+    // The stack bottom corresponds to the scroll frontier (height - offset_pixels); when the caller latched
+    // part of the terminating frame first (latchUpToGreenTerminator), offset_pixels is the adjusted value
+    // that keeps this invariant. Map the live bar top into stack coordinates: it exceeds stack_rows when
     // the bar sits below the frontier (the normal lazy render, never latched) and caps the crop when part of
     // the bar was latched.
     const int ceiling_stack_rows = stack_rows - ((frame.height() - offset_pixels) - green_terminator_top_pixels);
@@ -981,11 +1008,15 @@ void ScrollableScrapingInterpreter::updateScrolling(const Frame &frame) {
     // offset (rescale non-match); the bar stays visible ~1 s (30+ frames), so a valid frame always comes.
     if (offset.has_value()
         && scraping_box->detectGreenTerminator(current_fragment.frame, std::lround(offset.value()))) {
-        // Crop the saved fragments to the same bottom line the gray-completion path uses, so the trailing
-        // background below the last factor is a fixed margin regardless of which terminator ended the tab.
-        // The last fragment otherwise runs to the frame bottom (addScrollArea's fallback save), leaving a
-        // variable gap above the footer.
-        scraping_box->trimScrollAreaToFactorEnd(current_fragment.frame, std::lround(offset.value()));
+        // The bar can fire on the very frame the last factor scrolled in (and the return below skips the
+        // regular addScrollArea latch), so without latching first the last card's bottom rows exist only
+        // in the live frame and the crop cannot recover them -- the stitcher then papers over the gap with
+        // background, clipping the last card. Latch the revealed rows above the bar, then crop the saved
+        // fragments to the same bottom line the gray-completion path uses, so the trailing background
+        // below the last factor is a fixed margin regardless of which terminator ended the tab.
+        const int trim_offset_pixels =
+            scraping_box->latchUpToGreenTerminator(current_fragment.frame, std::lround(offset.value()));
+        scraping_box->trimScrollAreaToFactorEnd(current_fragment.frame, trim_offset_pixels);
         // Report the final position before going Ready so the UI progress reaches 100% for the tab,
         // matching the gray-completion path below (which emits via addScrollArea). Without this, a
         // short-history factor tab that ends via the green terminator would stall one update short.

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -19,29 +19,28 @@ bool closeEnough(const std::vector<double> &a, const std::vector<double> &b, dou
     return true;
 }
 
-// Bottom margin kept below the last factor when cropping the terminating factor fragment, as a fraction of
-// the frame width (the project's length unit). The scan's color run that follows the last factor starts a
-// few px below its stars; a small margin below that leaves a clean, constant gap -- matching the normal
-// (no inheritance history) look and independent of the green 継承履歴 header that may follow. Both terminator
-// paths crop through factorEndCropY with this margin, so it is the single knob for the tail space above the
-// footer; calibrated so the stitched factor image leaves ~22 px below the last card (≈16 px at the ~736 px
-// capture width, plus the stitcher's fixed arrangement).
+// Bottom margin kept below the last factor when cropping the factor tab, as a fraction of the frame width
+// (the project's length unit). The background run that follows the last factor starts a few px below its
+// stars; a small margin below that leaves a clean, constant gap -- matching the normal (no inheritance
+// history) look and independent of the green 継承履歴 header that may follow. Both terminator paths crop at
+// frontier_stack_rows + this margin, so it is the single knob for the tail space above the footer;
+// calibrated so the stitched factor image leaves ~22 px below the last card (≈16 px at the ~736 px capture
+// width, plus the stitcher's fixed arrangement).
 constexpr double kFactorEndBottomMargin = 0.0217;
 
-// Distance (fraction of frame width) to scan up from the green "継承履歴" bar to reach the last factor in
-// trimScrollAreaToFactorEnd. The last factor sits a FIXED distance above the bar -- a game-layout constant
-// (sub-pixel jitter aside): the bar's ~2 px anti-aliased edge plus a constant background gap, together
-// ~0.05 of the width. This bound clears that fixed span with headroom yet stays under one factor-row pitch
-// (~0.12 of the width), so if the factor column is empty at the last row the scan falls back to the bar top
-// instead of cropping into the previous row.
+// Maximum distance (fraction of frame width) from the green "継承履歴" bar top up to the last factor. The
+// last factor sits a FIXED distance above the bar -- a game-layout constant (sub-pixel jitter aside): the
+// bar's ~2 px anti-aliased edge plus a constant background gap, together ~0.05 of the width. This bound
+// clears that fixed span with headroom yet stays under one factor-row pitch (~0.12 of the width), so
+// frontier evidence farther above the bar than this cannot be the last factor's gap (a stale transition
+// from a green early fire) and is rejected in favor of the fail-safe bar-top crop. Also feeds the
+// delayed-commit holdback in addScrollArea.
 constexpr double kFactorEndGreenSearchSpan = 0.08;
 
-// Upward-scan bound (fraction of frame width) for the GRAY-completion trim. Unlike the green path -- whose
-// bar sits a FIXED ~0.05 of the width below the last factor, so 0.08 suffices -- the gray path scans from the
-// scroll frontier up through the accumulated end-of-list overscroll background to the last factor, a distance
-// measured at up to ~0.145 of the width on 736 px footage. 0.16 covers that with headroom. The walk stops at
-// the first non-background pixel (the last factor), so this is only a runaway floor: an overshoot (an empty
-// last-row column at the scan x) falls through to the not-found fallback and yields a safe no-op trim.
+// Worst-case depth (fraction of frame width) of trailing end-of-list overscroll background below the last
+// factor on the GRAY-completion path, measured at up to ~0.145 of the width on 736 px footage; 0.16 covers
+// that with headroom. Feeds the delayed-commit holdback in addScrollArea so the whole trimmable tail is
+// still staged in RAM when the terminator fires.
 constexpr double kFactorEndGraySearchSpan = 0.16;
 
 // Thumb-bottom "clip" tolerance in pixels: at/below the true bottom the game pins the thumb bottom to the
@@ -512,10 +511,6 @@ void PageScrapingBox::addScrollArea(const Frame &frame, int offset_pixels) {
     }
     const Point<int> &top_left = {0, frame.height() - offset_pixels};
     const Point<double> &scaled_top_left = anchor.mapFromFrame(top_left);
-    // Default the run-start to this strip's top: a color run already in progress from a prior strip has its
-    // true start in an already-saved fragment, so treat it as starting at the boundary. This keeps
-    // factorEndCropY referencing only coordinates within the current frame.
-    current_run_start_scaled = scaled_top_left.y();
 
     for (int y_pixels = top_left.y(); y_pixels < frame.height(); y_pixels++) {
         const double scaled_y = anchor.scaleFromPixels(y_pixels);
@@ -529,7 +524,16 @@ void PageScrapingBox::addScrollArea(const Frame &frame, int offset_pixels) {
             continue;
         }
         if (current_length_pixels == 0) {
-            current_run_start_scaled = scaled_y;  // start of this color run
+            // Start of a color run. For the terminating (background) scan of the factor box this is a
+            // non-background -> background transition: the frontier the terminators crop from. A run whose
+            // first matching row is the strip top counts too -- current_length_pixels survives across
+            // frames, so it is zero here only if the previous strip's bottom row was non-background, i.e.
+            // the transition sits exactly on the strip boundary. A run carried over from the previous strip
+            // (current_length_pixels > 0) keeps the frontier recorded when it started.
+            if (end_green && current_scan == std::prev(scan_parameters.end())) {
+                previous_frontier_stack_rows = frontier_stack_rows;
+                frontier_stack_rows = stack_rows + (y_pixels - top_left.y());
+            }
         }
         const int length_pixels = anchor.expand({0., current_scan->length}).y();
         if (++current_length_pixels < length_pixels) {
@@ -547,37 +551,22 @@ void PageScrapingBox::addScrollArea(const Frame &frame, int offset_pixels) {
             }
             return;
         }
-        // Factor box (reached only with enough inheritance history to accumulate the gray tail): keep a fixed
-        // margin below the last factor (see factorEndCropY) so the bottom margin is constant across long
-        // histories. Short histories terminate via detectGreenTerminator() instead, which does not pass here.
-        //
-        // The gray run's start discriminates two cases. If it began below the strip top (current_run_start >
-        // frontier), the last factor sits inside THIS frame's new content and the stack is clean up to the
-        // frontier (a phantom cannot precede the first reveal of the last factor): crop and save the strip, as
-        // before. If it began at the strip top, the whole new strip is trailing background and the real last
-        // factor is already in the saved stack above the frontier -- possibly with an overscroll phantom or
-        // ghost strip between (latched by earlier frames whose gray run had not yet completed). Do NOT save the
-        // phantom; scan this settled frame up from the frontier to the real last factor and trim the fragment
-        // stack to the same crop line the green terminator uses, so the tail below the last factor is a fixed
-        // margin regardless of overscroll. The ghost lives only in the saved stack, so scanning the live frame
-        // reaches the real factor and the ghost is removed positionally (it sits below the crop line).
-        if (current_run_start_scaled > scaled_top_left.y()) {
-            const double crop_y = factorEndCropY(current_run_start_scaled, scaled_top_left.y(), scaled_y);
-            if (const Rect<double> rect = {scaled_top_left, Point<double>{1., crop_y}}; !rect.empty()) {
-                saveIncremental(frame.view(rect));
-            }
-            flushAll();  // terminal exit: the staged tail is final
-            return;
+        // Factor box (reached only with enough inheritance history to accumulate the gray tail): stage this
+        // strip down to the completion row, then crop the whole stack a fixed margin below the frontier --
+        // the terminating run's own start, so it is always set here. Whether the last factor sits in this
+        // strip or the trailing background spans earlier overscroll strips, the crop is the same
+        // stack-coordinate arithmetic; the staged tail absorbs it entirely (see tail_holdback_pixels), so
+        // trailing background never reaches disk. Short histories terminate via detectGreenTerminator()
+        // instead, which does not pass here.
+        if (const Rect<double> rect = {scaled_top_left, Point<double>{1., anchor.scaleFromPixels(y_pixels + 1)}};
+            !rect.empty()) {
+            saveIncremental(frame.view(rect));
         }
-        trimStackToLastFactor(
-            frame, top_left.y(), top_left.y(), y_pixels, /*skip_leading_bar=*/false, kFactorEndGraySearchSpan);
+        const int margin_pixels = anchor.expand({0., kFactorEndBottomMargin}).y();
+        cropStackTo(frontier_stack_rows >= 0 ? frontier_stack_rows + margin_pixels : stack_rows);
         return;
     }
     saveIncremental(frame.view({scaled_top_left, anchor.mapFromFrame(frame.rect().bottomRight())}));
-}
-
-double PageScrapingBox::factorEndCropY(double run_start_scaled, double scaled_top, double terminator_scaled_y) const {
-    return std::clamp(run_start_scaled + kFactorEndBottomMargin, scaled_top, terminator_scaled_y);
 }
 
 bool PageScrapingBox::detectGreenTerminator(const Frame &frame, int offset_pixels) {
@@ -627,65 +616,38 @@ void PageScrapingBox::trimScrollAreaToFactorEnd(const Frame &frame, int offset_p
     if (!end_green_fired || green_terminator_top_pixels < 0) {
         return;
     }
-    // The saved fragment stack ends at the scroll frontier (height - offset_pixels); the terminating frame is
-    // not saved on the green path. Scan up from the green bar (skipping the bar + its anti-aliased edge) and
-    // clamp/fall back to the bar top so it stays out of the factor image.
-    trimStackToLastFactor(
-        frame,
-        /*anchor_pixels=*/green_terminator_top_pixels,
-        /*stack_bottom_pixels=*/frame.height() - offset_pixels,
-        /*ceiling_pixels=*/green_terminator_top_pixels,
-        /*skip_leading_bar=*/true,
-        /*search_span=*/kFactorEndGreenSearchSpan);
+    const auto &anchor = frame.anchor();
+    const int margin_pixels = anchor.expand({0., kFactorEndBottomMargin}).y();
+    // The stack bottom corresponds to the scroll frontier (height - offset_pixels); the terminating frame is
+    // not saved on the green path. Map the live bar top into stack coordinates: it exceeds stack_rows when
+    // the bar sits below the frontier (the normal lazy render, never latched) and caps the crop when part of
+    // the bar was latched.
+    const int ceiling_stack_rows = stack_rows - ((frame.height() - offset_pixels) - green_terminator_top_pixels);
+    const int span_pixels = anchor.expand({0., kFactorEndGreenSearchSpan}).y();
+
+    // The frontier is trustworthy only if it is the last factor's gap: within the fixed factor-to-bar span
+    // above the bar top. Two ways it can fail: the bar rendered early enough to be latched, so the
+    // background BELOW the bar stole the last transition (fall back to the previous one); or the bar fired
+    // before the last factor's gap was ever latched (green early fire), leaving only a stale transition
+    // far above -- then crop at the bar top / no-op rather than cutting into latched factors.
+    const auto valid = [&](int candidate) {
+        return candidate >= 0 && candidate + margin_pixels <= ceiling_stack_rows
+            && ceiling_stack_rows - candidate <= span_pixels;
+    };
+    int crop_stack_rows = std::min(ceiling_stack_rows, stack_rows);
+    if (valid(frontier_stack_rows)) {
+        crop_stack_rows = frontier_stack_rows + margin_pixels;
+    } else if (valid(previous_frontier_stack_rows)) {
+        crop_stack_rows = previous_frontier_stack_rows + margin_pixels;
+    }
+    cropStackTo(crop_stack_rows);
 }
 
-void PageScrapingBox::trimStackToLastFactor(
-    const Frame &frame,
-    int anchor_pixels,
-    int stack_bottom_pixels,
-    int ceiling_pixels,
-    bool skip_leading_bar,
-    double search_span) {
-    const auto &anchor = frame.anchor();
-    const auto &background = scan_parameters.back();
-
-    // Locate the last factor's bottom (the top of the page-background run just below the last factor -- the same
-    // point the gray-completion path records as current_run_start_scaled). Scan up a bounded span from the
-    // anchor to the first non-background pixel: the last factor's bottom edge. When skip_leading_bar is set,
-    // first skip the run of non-background above the anchor (the green bar and its anti-aliased edge). The span
-    // bounds the walk and also stops a runaway if the factor column is empty at the last row; if the factor is
-    // not reached within it, fall back to the ceiling as the crop line rather than over-trimming.
-    const int search_floor = std::max(0, anchor_pixels - anchor.expand({0., search_span}).y());
-    int y = anchor_pixels - 1;
-    if (skip_leading_bar) {
-        while (y >= search_floor && !frame.isIn(background.color_range, {background.x, anchor.scaleFromPixels(y)})) {
-            y--;  // skip the green bar and its anti-aliased edge
-        }
-    }
-    int run_start_pixels = ceiling_pixels;
-    bool found_factor = false;
-    for (; y >= search_floor; y--) {  // walk up the background gap to the last factor
-        if (!frame.isIn(background.color_range, {background.x, anchor.scaleFromPixels(y)})) {
-            found_factor = true;
-            break;
-        }
-        run_start_pixels = y;
-    }
-    if (!found_factor) {
-        run_start_pixels = ceiling_pixels;
-    }
-
-    // A fixed margin below the last factor, clamped so it never dips past the ceiling (the green bar on the
-    // green path; the gray run's completion row on the gray path).
-    const double crop_scaled = factorEndCropY(
-        anchor.scaleFromPixels(run_start_pixels), anchor.scaleFromPixels(0), anchor.scaleFromPixels(ceiling_pixels));
-    const int crop_pixels = anchor.expand({0., crop_scaled}).y();
-
-    // stack_bottom_pixels is the frame-y the current stack bottom corresponds to; anything below the crop line
-    // is trailing background/phantom to remove. Resolution is constant here, so stack_bottom - crop is exactly
-    // the number of rows to drop from the bottom of the stack. The overshoot was latched within the holdback
-    // window, so the peel is a pure in-RAM operation; flush afterwards -- this is a terminal exit.
-    trimTail(stack_bottom_pixels - crop_pixels);
+void PageScrapingBox::cropStackTo(int crop_stack_rows) {
+    // Anything below the crop line is trailing background / bar remnants to remove; resolution is constant
+    // within a capture, so the difference is exactly the rows to drop. The overshoot was latched within the
+    // holdback window, so the peel is a pure in-RAM operation; flush afterwards -- this is a terminal exit.
+    trimTail(stack_rows - std::min(crop_stack_rows, stack_rows));
     flushAll();
 }
 
@@ -719,6 +681,7 @@ void PageScrapingBox::saveIncremental(const Frame &frame) {
     // clone(): the strip is usually a view sharing the source frame's buffer, which does not outlive this call.
     pending_strips.push_back(frame.data().clone());
     pending_rows += pending_strips.back().rows;
+    stack_rows += pending_strips.back().rows;
     flushExcess();
 }
 
@@ -751,10 +714,12 @@ void PageScrapingBox::trimTail(int trim) {
         if (trim < last.rows || fragmentCount() == 1) {
             const int kept = std::max(1, last.rows - trim);
             pending_rows -= last.rows - kept;
+            stack_rows -= last.rows - kept;
             last = last.rowRange(0, kept).clone();
             trim = 0;
         } else {
             pending_rows -= last.rows;
+            stack_rows -= last.rows;
             trim -= last.rows;
             pending_strips.pop_back();
         }
@@ -765,10 +730,13 @@ void PageScrapingBox::trimTail(int trim) {
         const auto path = image_dir / path_config.scroll_area.withNumber(committed_count - 1, 5).filename();
         const cv::Mat last = Frame::decodeBgr(path);
         if (trim < last.rows || committed_count == 1) {
-            Frame::fixed(last.rowRange(0, std::max(1, last.rows - trim)).clone()).save(path);
+            const int kept = std::max(1, last.rows - trim);
+            Frame::fixed(last.rowRange(0, kept).clone()).save(path);
+            stack_rows -= last.rows - kept;
             trim = 0;
         } else {
             std::filesystem::remove(path);
+            stack_rows -= last.rows;
             trim -= last.rows;
             committed_count--;
         }

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -501,6 +501,15 @@ void PageScrapingBox::addScrollArea(const Frame &frame, int offset_pixels) {
     }
 
     const auto &anchor = frame.anchor();
+    if (end_green) {
+        // Worst-case rows a terminator can trim below the pre-existing stack bottom, kept staged in RAM:
+        // gray trims at most kFactorEndGraySearchSpan above the frontier; green fires within back() of the
+        // frontier and trims at most kFactorEndGreenSearchSpan above the bar top. Recomputed per latch
+        // (idempotent -- resolution is constant within a capture).
+        tail_holdback_pixels =
+            anchor.expand({0., scan_parameters.back().length + std::max(kFactorEndGraySearchSpan, kFactorEndGreenSearchSpan)})
+                .y();
+    }
     const Point<int> &top_left = {0, frame.height() - offset_pixels};
     const Point<double> &scaled_top_left = anchor.mapFromFrame(top_left);
     // Default the run-start to this strip's top: a color run already in progress from a prior strip has its
@@ -557,6 +566,7 @@ void PageScrapingBox::addScrollArea(const Frame &frame, int offset_pixels) {
             if (const Rect<double> rect = {scaled_top_left, Point<double>{1., crop_y}}; !rect.empty()) {
                 saveIncremental(frame.view(rect));
             }
+            flushAll();  // terminal exit: the staged tail is final
             return;
         }
         trimStackToLastFactor(
@@ -584,7 +594,7 @@ bool PageScrapingBox::detectGreenTerminator(const Frame &frame, int offset_pixel
     // catches the terminator and structurally excludes the top header, without a frame region or scrollbar
     // position. back() is that terminating gray gap for the factor box (the only box with end_green);
     // reaching this line implies current_scan != begin(), so scan_parameters is non-empty.
-    if (!end_green || current_scan == scan_parameters.begin() || image_count == 0) {
+    if (!end_green || current_scan == scan_parameters.begin() || fragmentCount() == 0) {
         return false;
     }
     const auto &anchor = frame.anchor();
@@ -673,36 +683,28 @@ void PageScrapingBox::trimStackToLastFactor(
 
     // stack_bottom_pixels is the frame-y the current stack bottom corresponds to; anything below the crop line
     // is trailing background/phantom to remove. Resolution is constant here, so stack_bottom - crop is exactly
-    // the number of rows to drop from the bottom of the stack. Peel whole fragments, then crop the one that
-    // straddles the line; never delete the sole remaining fragment (scrollAreaReady must stay satisfied).
-    int trim = stack_bottom_pixels - crop_pixels;
-    while (trim > 0 && image_count > 0) {
-        const auto path = image_dir / path_config.scroll_area.withNumber(image_count - 1, 5).filename();
-        const cv::Mat last = Frame::decodeBgr(path);
-        if (trim < last.rows || image_count == 1) {
-            Frame::fixed(last.rowRange(0, std::max(1, last.rows - trim)).clone()).save(path);
-            trim = 0;
-        } else {
-            std::filesystem::remove(path);
-            trim -= last.rows;
-            image_count--;
-        }
-    }
+    // the number of rows to drop from the bottom of the stack. The overshoot was latched within the holdback
+    // window, so the peel is a pure in-RAM operation; flush afterwards -- this is a terminal exit.
+    trimTail(stack_bottom_pixels - crop_pixels);
+    flushAll();
 }
 
 void PageScrapingBox::addScrollArea(const Frame &frame) {
-    assert_(image_count == 0);
+    assert_(fragmentCount() == 0);
     addScrollArea(frame, frame.height());
 }
 
 void PageScrapingBox::setScrollArea(const Frame &frame) {
-    assert_(image_count == 0);
+    assert_(fragmentCount() == 0);
     saveIncremental(frame);
+    // A factor box normally scrolls, but if the page has no scrollbar this is its terminal save: commit it
+    // so the sole strip cannot be stranded in the staged tail.
+    flushAll();
     current_scan = scan_parameters.end();
 }
 
 bool PageScrapingBox::scrollAreaReady() const {
-    return image_count > 0 && (current_scan == scan_parameters.end() || end_green_fired);
+    return fragmentCount() > 0 && (current_scan == scan_parameters.end() || end_green_fired);
 }
 
 bool PageScrapingBox::ready() const {
@@ -710,7 +712,67 @@ bool PageScrapingBox::ready() const {
 }
 
 void PageScrapingBox::saveIncremental(const Frame &frame) {
-    frame.save(image_dir / path_config.scroll_area.withNumber(image_count++, 5).filename());
+    if (!end_green) {  // skill/campaign and setScrollArea write through: no trim can follow, nothing to stage
+        frame.save(image_dir / path_config.scroll_area.withNumber(committed_count++, 5).filename());
+        return;
+    }
+    // clone(): the strip is usually a view sharing the source frame's buffer, which does not outlive this call.
+    pending_strips.push_back(frame.data().clone());
+    pending_rows += pending_strips.back().rows;
+    flushExcess();
+}
+
+int PageScrapingBox::fragmentCount() const {
+    return committed_count + static_cast<int>(pending_strips.size());
+}
+
+void PageScrapingBox::flushFront() {
+    Frame::fixed(pending_strips.front())
+        .save(image_dir / path_config.scroll_area.withNumber(committed_count++, 5).filename());
+    pending_rows -= pending_strips.front().rows;
+    pending_strips.pop_front();
+}
+
+void PageScrapingBox::flushExcess() {
+    while (!pending_strips.empty() && pending_rows - pending_strips.front().rows >= tail_holdback_pixels) {
+        flushFront();
+    }
+}
+
+void PageScrapingBox::flushAll() {
+    while (!pending_strips.empty()) {
+        flushFront();
+    }
+}
+
+void PageScrapingBox::trimTail(int trim) {
+    while (trim > 0 && !pending_strips.empty()) {
+        cv::Mat &last = pending_strips.back();
+        if (trim < last.rows || fragmentCount() == 1) {
+            const int kept = std::max(1, last.rows - trim);
+            pending_rows -= last.rows - kept;
+            last = last.rowRange(0, kept).clone();
+            trim = 0;
+        } else {
+            pending_rows -= last.rows;
+            trim -= last.rows;
+            pending_strips.pop_back();
+        }
+    }
+    // Disk fallback: unreachable while tail_holdback_pixels over-covers the trim bounds (see addScrollArea),
+    // kept as the safety net -- degrades to the pre-delayed-commit decode/crop/re-save, never to a wrong trim.
+    while (trim > 0 && committed_count > 0) {
+        const auto path = image_dir / path_config.scroll_area.withNumber(committed_count - 1, 5).filename();
+        const cv::Mat last = Frame::decodeBgr(path);
+        if (trim < last.rows || committed_count == 1) {
+            Frame::fixed(last.rowRange(0, std::max(1, last.rows - trim)).clone()).save(path);
+            trim = 0;
+        } else {
+            std::filesystem::remove(path);
+            trim -= last.rows;
+            committed_count--;
+        }
+    }
 }
 
 SceneScrapingBox::SceneScrapingBox(

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -227,6 +227,15 @@ public:
     // returns true once a green run of end_green->length is present there.
     bool detectGreenTerminator(const Frame &frame, int offset_pixels);
 
+    // Latch the terminating frame's newly revealed rows ABOVE the fired green bar, so the last factor and
+    // its gap enter the stack even when the bar fired on the very frame they scrolled in (the green branch
+    // returns before the regular addScrollArea latch). Rows at/below the bar are deliberately excluded:
+    // they are trimmed anyway, and latching them would push post-bar background transitions into the
+    // frontier history that trimScrollAreaToFactorEnd validates. Returns the offset the subsequent
+    // trimScrollAreaToFactorEnd call must use (the latch moves the stack bottom to the bar top; without a
+    // latch the passed offset is returned unchanged).
+    [[nodiscard]] int latchUpToGreenTerminator(const Frame &frame, int offset_pixels);
+
     // Crop the factor fragments to the same bottom line the gray-completion path uses, once the green
     // terminator has fired. detectGreenTerminator only marks readiness; the last fragment still runs down
     // to the frame bottom (the fallback save in addScrollArea), leaving a variable amount of trailing

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <deque>
 #include <filesystem>
 #include <memory>
 #include <optional>
@@ -240,7 +241,32 @@ public:
     [[nodiscard]] bool ready() const;
 
 private:
+    // Stage (factor box) or write (other boxes) one scroll-area strip. The factor box delays its commit:
+    // strips are staged as owning clones in pending_strips and only flushed to disk once they can no longer
+    // be trimmed (flushExcess) or the tab terminates (flushAll), so trailing background latched during the
+    // gray-run recognition lag never reaches disk and the terminator-time trim is a pure in-RAM operation.
     void saveIncremental(const Frame &frame);
+
+    // Committed fragments on disk plus strips staged in RAM: the logical fragment count both terminator
+    // paths and readiness reason about (the pre-delayed-commit image_count).
+    [[nodiscard]] int fragmentCount() const;
+
+    // Write the oldest staged strip as the next numbered fragment and pop it.
+    void flushFront();
+
+    // Flush staged strips down to tail_holdback_pixels. Strips older than the maximum possible
+    // terminator-time trim can never be peeled, so committing them keeps memory bounded without
+    // giving up the in-RAM trim.
+    void flushExcess();
+
+    // Terminal commit: drain the staged tail to disk. Must run before readiness is observable so the
+    // stitcher (triggered on completion) sees the final fragment set.
+    void flushAll();
+
+    // Remove trim_rows from the bottom of the fragment stack: peel/crop the staged tail first, then fall
+    // back to the on-disk fragments (unreachable while tail_holdback_pixels over-covers the trim bounds,
+    // kept as a safety net). Never drops the sole remaining fragment (scrollAreaReady must stay satisfied).
+    void trimTail(int trim_rows);
 
     // Scaled y at which the terminating fragment should be cropped for the factor box: a fixed margin below
     // run_start_scaled (the bottom of the last factor). Clamped within [scaled_top, terminator] so the rect
@@ -249,10 +275,10 @@ private:
     // end-bar) feed their own last-factor-bottom through this one function so they crop to the same line.
     [[nodiscard]] double factorEndCropY(double run_start_scaled, double scaled_top, double terminator_scaled_y) const;
 
-    // Shared core for both factor-end terminator paths: trim the saved fragment stack so its bottom lands a
+    // Shared core for both factor-end terminator paths: trim the fragment stack so its bottom lands a
     // fixed margin below the last factor. Scans `frame` upward from `anchor_pixels` (a frame-y row that sits in
     // the page-background gap below the last factor) to the last factor's bottom, computes factorEndCropY, and
-    // peels/crops the saved fragments below that crop line. `stack_bottom_pixels` is the frame-y the current
+    // trims the stack below that crop line via trimTail, then flushes. `stack_bottom_pixels` is the frame-y the current
     // stack bottom corresponds to (the scroll frontier). `ceiling_pixels` lower-bounds the crop line and is the
     // not-found fallback (green: the bar top; gray: the gray run's completion row -> a safe non-positive trim).
     // `skip_leading_bar` first skips a leading run of non-background above the anchor (the green bar + its
@@ -276,7 +302,17 @@ private:
     // strip top each frame. For the factor box the run that follows the last factor is the page-background
     // gap just below it, so this marks the bottom of the last factor.
     double current_run_start_scaled = 0.0;
-    int image_count = 0;
+
+    // Delayed-commit tail (factor box only; other boxes write through). Owning clones -- Frame views share
+    // the source buffer (see frame.h), and a staged strip outlives its source frame. Dropped, NOT flushed,
+    // when the box is discarded: recreate()/release() abandon uncommitted strips by design, matching the
+    // rmdir of the committed ones.
+    std::deque<cv::Mat> pending_strips;
+    int pending_rows = 0;
+    // Fragments on disk; doubles as the next flush filename index so committed names stay contiguous.
+    int committed_count = 0;
+    // Minimum staged rows retained in RAM; set per-latch in addScrollArea from the worst-case trim depth.
+    int tail_holdback_pixels = 0;
 
     bool tab_button_ready = false;
 

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -227,13 +227,14 @@ public:
     // returns true once a green run of end_green->length is present there.
     bool detectGreenTerminator(const Frame &frame, int offset_pixels);
 
-    // Crop the saved factor fragments to the same bottom line the gray-completion path uses, once the green
-    // terminator has fired. detectGreenTerminator only marks readiness; the last saved fragment still runs
-    // down to the frame bottom (the fallback save in addScrollArea), leaving a variable amount of trailing
-    // background below the last factor. This scans up from the recorded green-bar top to the last factor's
-    // bottom and trims the fragment stack to factorEndCropY(that), so the bottom margin is identical to the
-    // gray-completion path regardless of which terminator ends the tab. A no-op unless the green terminator
-    // fired and the saved content overshoots the crop line.
+    // Crop the factor fragments to the same bottom line the gray-completion path uses, once the green
+    // terminator has fired. detectGreenTerminator only marks readiness; the last fragment still runs down
+    // to the frame bottom (the fallback save in addScrollArea), leaving a variable amount of trailing
+    // background below the last factor. The crop line comes from the maintained frontier
+    // (frontier_stack_rows + the fixed margin), validated against the live bar top: the bar caps the crop,
+    // and frontier evidence inconsistent with the bar position falls back to the previous transition (the
+    // bar rendered early and its trailing background stole the last transition) or, failing that, to a
+    // fail-safe crop at the bar top -- never past latched factor content. Ends in a full flush.
     void trimScrollAreaToFactorEnd(const Frame &frame, int offset_pixels);
 
     [[nodiscard]] bool scrollAreaReady() const;
@@ -268,40 +269,30 @@ private:
     // kept as a safety net). Never drops the sole remaining fragment (scrollAreaReady must stay satisfied).
     void trimTail(int trim_rows);
 
-    // Scaled y at which the terminating fragment should be cropped for the factor box: a fixed margin below
-    // run_start_scaled (the bottom of the last factor). Clamped within [scaled_top, terminator] so the rect
-    // stays valid; the caller skips an empty one. Keeps the bottom margin constant regardless of whether
-    // inheritance history follows the list. Both terminator paths (gray-sequence completion and the green
-    // end-bar) feed their own last-factor-bottom through this one function so they crop to the same line.
-    [[nodiscard]] double factorEndCropY(double run_start_scaled, double scaled_top, double terminator_scaled_y) const;
-
-    // Shared core for both factor-end terminator paths: trim the fragment stack so its bottom lands a
-    // fixed margin below the last factor. Scans `frame` upward from `anchor_pixels` (a frame-y row that sits in
-    // the page-background gap below the last factor) to the last factor's bottom, computes factorEndCropY, and
-    // trims the stack below that crop line via trimTail, then flushes. `stack_bottom_pixels` is the frame-y the current
-    // stack bottom corresponds to (the scroll frontier). `ceiling_pixels` lower-bounds the crop line and is the
-    // not-found fallback (green: the bar top; gray: the gray run's completion row -> a safe non-positive trim).
-    // `skip_leading_bar` first skips a leading run of non-background above the anchor (the green bar + its
-    // anti-aliased edge); false when the anchor already sits inside the background gap (gray). `search_span`
-    // bounds the upward walk as a fraction of the frame width. Both terminator paths route through here so the
-    // bottom margin below the last factor is identical regardless of which one ends the tab.
-    void trimStackToLastFactor(
-        const Frame &frame,
-        int anchor_pixels,
-        int stack_bottom_pixels,
-        int ceiling_pixels,
-        bool skip_leading_bar,
-        double search_span);
+    // Shared core for both factor-end terminator paths: crop the fragment stack so its bottom lands the
+    // fixed margin below the last factor, then flush. `crop_stack_rows` is the target stack height
+    // (frontier + margin, already validated by the caller), clamped to the current stack so a stale or
+    // overshooting value degrades to a no-op rather than an over-trim.
+    void cropStackTo(int crop_stack_rows);
 
     const std::filesystem::path image_dir;
     const std::vector<scraper_config::ScanParameter> scan_parameters;
 
     std::vector<scraper_config::ScanParameter>::const_iterator current_scan;
     int current_length_pixels = 0;
-    // Scaled y where the current scan's run of matching color began (its 0->1 transition), reset to the
-    // strip top each frame. For the factor box the run that follows the last factor is the page-background
-    // gap just below it, so this marks the bottom of the last factor.
-    double current_run_start_scaled = 0.0;
+
+    // Maintained frontier (factor box only): the stack row where the page-background run below the last
+    // factor begins -- the crop reference both terminator paths reason from. Updated at latch time, on each
+    // observed non-background -> background transition of the terminating scan: in-strip transitions record
+    // the exact row, and a transition at a strip boundary (the run starts at the strip top while the
+    // previous strip ended non-background) records the boundary, so a factor row ending exactly at a strip
+    // edge is never over-trimmed. A run carried over from the previous strip does not move it. The previous
+    // transition is kept because the green bar can render early enough to be latched, in which case the
+    // background below the bar steals the last transition (see trimScrollAreaToFactorEnd). -1 = no evidence.
+    int frontier_stack_rows = -1;
+    int previous_frontier_stack_rows = -1;
+    // Total rows in the fragment stack (staged + committed): the coordinate system of the frontier.
+    int stack_rows = 0;
 
     // Delayed-commit tail (factor box only; other boxes write through). Owning clones -- Frame views share
     // the source buffer (see frame.h), and a staged strip outlives its source frame. Dropped, NOT flushed,
@@ -322,7 +313,7 @@ private:
     const std::optional<scraper_config::ScanParameter> end_green;
     bool end_green_fired = false;
     // Top y (frame pixels) of the green run that fired detectGreenTerminator, or -1 if it has not fired.
-    // trimScrollAreaToFactorEnd scans up from here to locate the last factor and crop the fragment stack.
+    // trimScrollAreaToFactorEnd uses it as the crop ceiling and to validate the frontier evidence.
     int green_terminator_top_pixels = -1;
 };
 

--- a/native/src/core/cli.cpp
+++ b/native/src/core/cli.cpp
@@ -1,8 +1,10 @@
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <mutex>
+#include <optional>
 #include <stdexcept>
 #include <thread>
 
@@ -17,6 +19,8 @@
 #include "builder/chara_detail_scene_stitcher_builder.h"
 #include "condition/serializer.h"
 #include "core/native_api.h"
+#include "cv/ffv1_reader.h"
+#include "cv/ffv1_recorder.h"
 #include "cv/video_loader.h"
 #include "util/json_util.h"
 #include "util/logger_util.h"
@@ -59,6 +63,23 @@ void runUntilIdleThenJoin(app::NativeApi &api, ActivityMonitor &monitor) {
             api.joinEventLoop();
             break;
         }
+    }
+}
+
+// Live `capture` runs an unbounded loop, so it needs a clean stop signal: a hard kill would skip the
+// recorder's flush + matroska trailer and leave a `--record` file unfinalized. This console handler lets
+// Ctrl-C (and console close / logoff) break the loop so teardown runs. Set from the handler thread, polled
+// by the capture loop.
+std::atomic<bool> g_capture_stop_requested{false};
+
+BOOL WINAPI captureConsoleHandler(DWORD ctrl_type) {
+    switch (ctrl_type) {
+        case CTRL_C_EVENT:
+        case CTRL_BREAK_EVENT:
+        case CTRL_CLOSE_EVENT:
+        case CTRL_LOGOFF_EVENT:
+        case CTRL_SHUTDOWN_EVENT: g_capture_stop_requested.store(true); return TRUE;
+        default: return FALSE;
     }
 }
 
@@ -114,7 +135,10 @@ json_util::Json createConfig(bool video_mode, const PipelinePaths &paths = {}) {
     };
 }
 
-void captureFromScreen() {
+void captureFromScreen(
+    const std::optional<std::filesystem::path> &record_path = std::nullopt,
+    int duration_seconds = 0,
+    const std::filesystem::path &stop_file = {}) {
     const auto recorder_runner =
         event_util::makeSingleThreadRunner(event_util::QueueLimitMode::Discard, nullptr, "recorder");
     const auto connection = recorder_runner->makeConnection<Frame, Size<int>>();
@@ -122,7 +146,29 @@ void captureFromScreen() {
 
     auto &api = app::NativeApi::instance();
     api.setNotifyCallback([](const auto &message) { log_debug("CLI: {}", message); });
-    connection->listen([&api](const auto &frame, const auto &original_size) { api.updateFrame(frame, original_size); });
+
+    // Optional debug recorder: tee every captured frame to a lossless FFV1 .mkv for later replay. Built
+    // lazily on the first frame (its size is not known before capture starts); a construction failure is
+    // logged once and disables recording rather than aborting the capture.
+    std::unique_ptr<video::Ffv1Recorder> recorder;
+    bool recorder_failed = false;
+    connection->listen([&](const auto &frame, const auto &original_size) {
+        if (record_path && !recorder_failed) {
+            if (!recorder) {
+                try {
+                    recorder = std::make_unique<video::Ffv1Recorder>(*record_path, frame.size());
+                    log_info("Recording captured frames to {}", record_path->string());
+                } catch (const std::exception &e) {
+                    recorder_failed = true;
+                    log_error("Failed to start frame recording: {}", e.what());
+                }
+            }
+            if (recorder) {
+                recorder->push(frame);
+            }
+        }
+        api.updateFrame(frame, original_size);
+    });
 
     const auto config = createConfig(false);
     api.startEventLoop(config.dump());
@@ -133,8 +179,43 @@ void captureFromScreen() {
     recorder_runner->start();
     window_recorder->startRecord();
 
-    while (api.isRunning()) {
+    // Ctrl-C / console close breaks the loop cleanly so the recorder can finalize (see captureConsoleHandler).
+    g_capture_stop_requested.store(false);
+    SetConsoleCtrlHandler(&captureConsoleHandler, TRUE);
+    // Clear any stale stop-file so a leftover from a previous run cannot end this one immediately.
+    if (!stop_file.empty()) {
+        std::error_code ec;
+        std::filesystem::remove(stop_file, ec);
+    }
+    if (record_path) {
+        log_info(
+            "Recording... stop with Ctrl-C{}{}.",
+            stop_file.empty() ? "" : " or by creating the stop-file",
+            duration_seconds > 0 ? " (or wait for --duration)" : "");
+    }
+    const auto start = std::chrono::steady_clock::now();
+    while (api.isRunning() && !g_capture_stop_requested.load()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (duration_seconds > 0
+            && std::chrono::steady_clock::now() - start >= std::chrono::seconds(duration_seconds)) {
+            break;
+        }
+        if (!stop_file.empty()) {
+            std::error_code ec;
+            if (std::filesystem::exists(stop_file, ec)) {
+                log_info("Stop-file detected; finalizing recording.");
+                break;
+            }
+        }
+    }
+    SetConsoleCtrlHandler(&captureConsoleHandler, FALSE);
+
+    // Stop producing frames and drain the connection before finalizing the file, so no late listener call
+    // races the recorder's trailer write.
+    window_recorder->stopRecord();
+    recorder_runner->join();
+    if (recorder) {
+        recorder->close();
     }
 }
 
@@ -187,6 +268,34 @@ void captureFromVideo(const std::vector<std::filesystem::path> &video_path_list,
         return profile.has_value() ? profile->crop_rect : std::nullopt;
     });
     video.runBatch(video_path_list);
+
+    runUntilIdleThenJoin(api, monitor);
+}
+
+void replayFromRecording(const std::filesystem::path &record_path, const PipelinePaths &paths) {
+    const auto recorder_runner =
+        event_util::makeSingleThreadRunner(event_util::QueueLimitMode::Block, nullptr, "recorder");
+    const auto connection = recorder_runner->makeConnection<Frame, Size<int>>();
+
+    ActivityMonitor monitor;
+    auto &api = app::NativeApi::instance();
+    api.setNotifyCallback([&monitor](const auto &message) {
+        monitor.touch();
+        log_debug("CLI: {}", message);
+    });
+    connection->listen([&api](const auto &frame, const auto &size) { api.updateFrame(frame, size); });
+
+    // video_mode=true gives the pipeline a Block queue (no dropped frames) and disables the frame-stall
+    // watchdog, so the replay is deterministic -- the recorded frames drive the recognition exactly as the
+    // failed live capture did, paced by the queue rather than by wall-clock. No crop: recorded frames are
+    // already pipeline-input form.
+    const auto config = createConfig(true, paths);
+    api.startEventLoop(config.dump());
+
+    recorder_runner->start();
+
+    video::Ffv1Reader reader(record_path, connection);
+    reader.run();
 
     runUntilIdleThenJoin(api, monitor);
 }
@@ -250,6 +359,15 @@ int main(int argc, char **argv) {
         build_command->add_option("--assets_dir", assets_dir)->required();
 
         auto capture_command = command.add_subcommand("capture", "run capture mode");
+        std::filesystem::path capture_record_path;
+        capture_command->add_option(
+            "--record", capture_record_path, "record every captured frame to a lossless FFV1 .mkv for replay");
+        int capture_duration_seconds = 0;
+        capture_command->add_option(
+            "--duration", capture_duration_seconds, "stop capture automatically after N seconds (0 = until Ctrl-C)");
+        std::filesystem::path capture_stop_file;
+        capture_command->add_option(
+            "--stop-file", capture_stop_file, "stop capture cleanly when this file appears (for scripted control)");
 
         auto screenshot_command =
             command.add_subcommand("screenshot", "capture a single screenshot from the game window");
@@ -270,6 +388,13 @@ int main(int argc, char **argv) {
         video_command->add_option("--video_path_list", video_path_list)->required();
         uma::cli::PipelinePaths video_paths;
         addPipelinePathOptions(video_command, video_paths);
+
+        auto replay_command =
+            command.add_subcommand("replay", "replay a recorded FFV1 .mkv through the recognition pipeline");
+        std::filesystem::path replay_path;
+        replay_command->add_option("--record", replay_path, "path to the recorded .mkv")->required();
+        uma::cli::PipelinePaths replay_paths;
+        addPipelinePathOptions(replay_command, replay_paths);
 
         auto stitch_command = command.add_subcommand("stitch", "run capture mode from scraped images");
         std::string stitch_id;
@@ -316,7 +441,9 @@ int main(int argc, char **argv) {
         }
 
         if (capture_command->parsed()) {
-            uma::cli::captureFromScreen();
+            std::optional<std::filesystem::path> record =
+                capture_command->count("--record") > 0 ? std::optional{capture_record_path} : std::nullopt;
+            uma::cli::captureFromScreen(record, capture_duration_seconds, capture_stop_file);
         }
 
         if (screenshot_command->parsed()) {
@@ -325,6 +452,10 @@ int main(int argc, char **argv) {
 
         if (video_command->parsed()) {
             uma::cli::captureFromVideo(video_path_list, video_paths);
+        }
+
+        if (replay_command->parsed()) {
+            uma::cli::replayFromRecording(replay_path, replay_paths);
         }
 
         if (stitch_command->parsed()) {

--- a/native/src/core/cli.cpp
+++ b/native/src/core/cli.cpp
@@ -69,16 +69,29 @@ void runUntilIdleThenJoin(app::NativeApi &api, ActivityMonitor &monitor) {
 // Live `capture` runs an unbounded loop, so it needs a clean stop signal: a hard kill would skip the
 // recorder's flush + matroska trailer and leave a `--record` file unfinalized. This console handler lets
 // Ctrl-C (and console close / logoff) break the loop so teardown runs. Set from the handler thread, polled
-// by the capture loop.
+// by the capture loop; g_capture_finalized is set by the capture loop once teardown is done, so the
+// handler can hold the process alive for the terminating events (see below).
 std::atomic<bool> g_capture_stop_requested{false};
+std::atomic<bool> g_capture_finalized{false};
 
 BOOL WINAPI captureConsoleHandler(DWORD ctrl_type) {
     switch (ctrl_type) {
+        // The process survives these: signal the loop and return so it finalizes on its own.
         case CTRL_C_EVENT:
-        case CTRL_BREAK_EVENT:
+        case CTRL_BREAK_EVENT: g_capture_stop_requested.store(true); return TRUE;
+        // Windows terminates the process as soon as the handler returns for these, so returning right after
+        // setting the flag would kill the process before the 100 ms capture poll ever sees it. Block this
+        // (handler-only) thread until the main thread reports teardown done; the OS enforces its own grace
+        // deadline (~5 s close / ~20 s logoff-shutdown) regardless, so this is best-effort -- a worst-case
+        // encoder drain (bounded at 30 s in Ffv1Recorder::close) can still be cut short.
         case CTRL_CLOSE_EVENT:
         case CTRL_LOGOFF_EVENT:
-        case CTRL_SHUTDOWN_EVENT: g_capture_stop_requested.store(true); return TRUE;
+        case CTRL_SHUTDOWN_EVENT:
+            g_capture_stop_requested.store(true);
+            while (!g_capture_finalized.load()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            return TRUE;
         default: return FALSE;
     }
 }
@@ -181,6 +194,7 @@ void captureFromScreen(
 
     // Ctrl-C / console close breaks the loop cleanly so the recorder can finalize (see captureConsoleHandler).
     g_capture_stop_requested.store(false);
+    g_capture_finalized.store(false);
     SetConsoleCtrlHandler(&captureConsoleHandler, TRUE);
     // Clear any stale stop-file so a leftover from a previous run cannot end this one immediately.
     if (!stop_file.empty()) {
@@ -217,6 +231,9 @@ void captureFromScreen(
     if (recorder) {
         recorder->close();
     }
+    // Release a console handler blocked on a terminating event (close/logoff/shutdown); the file is
+    // finalized, so the process may die now.
+    g_capture_finalized.store(true);
 }
 
 void screenshotFromScreen(const std::filesystem::path &output_path) {

--- a/native/src/cv/ffv1_avio.h
+++ b/native/src/cv/ffv1_avio.h
@@ -67,6 +67,11 @@ private:
     static int readPacket(void *opaque, uint8_t *buf, int buf_size) {
         auto *self = static_cast<FileAvio *>(opaque);
         self->file_.read(reinterpret_cast<char *>(buf), buf_size);
+        // badbit is a real I/O failure (not end-of-data): report EIO so a corrupted read aborts the replay
+        // instead of silently truncating it as EOF.
+        if (self->file_.bad()) {
+            return AVERROR(EIO);
+        }
         const auto count = static_cast<int>(self->file_.gcount());
         if (count == 0) {
             return AVERROR_EOF;

--- a/native/src/cv/ffv1_avio.h
+++ b/native/src/cv/ffv1_avio.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+
+extern "C" {
+#include <libavformat/avio.h>
+#include <libavutil/error.h>
+#include <libavutil/mem.h>
+}
+
+namespace uma::video::ffv1_detail {
+
+// Bridges an AVIOContext to a std::fstream opened on the wide std::filesystem::path, so ffmpeg's I/O goes
+// through the same non-ASCII-safe path handling the rest of the codebase uses for images
+// (Frame::save/decodeBgr, frame.h). The matroska muxer seeks back to patch its header/cues at trailer
+// time, so the write stream is opened in|out (seekable), not append-only. One instance is either a reader
+// or a writer; it owns the AVIOContext, which the caller assigns to AVFormatContext::pb.
+class FileAvio {
+public:
+    FileAvio(const std::filesystem::path &path, bool write)
+        : write_(write) {
+        const auto base = std::ios::binary;
+        if (write_) {
+            std::filesystem::create_directories(path.parent_path().empty() ? "." : path.parent_path());
+            file_.open(path, base | std::ios::in | std::ios::out | std::ios::trunc);
+        } else {
+            file_.open(path, base | std::ios::in);
+        }
+        if (!file_) {
+            throw std::runtime_error("FileAvio: failed to open: " + path.generic_string());
+        }
+        constexpr int buffer_size = 1 << 16;
+        auto *buffer = static_cast<unsigned char *>(av_malloc(buffer_size));
+        if (buffer == nullptr) {
+            throw std::runtime_error("FileAvio: av_malloc failed");
+        }
+        ctx_ = avio_alloc_context(
+            buffer,
+            buffer_size,
+            write_ ? 1 : 0,
+            this,
+            write_ ? nullptr : &FileAvio::readPacket,
+            write_ ? &FileAvio::writePacket : nullptr,
+            &FileAvio::seek);
+        if (ctx_ == nullptr) {
+            av_free(buffer);
+            throw std::runtime_error("FileAvio: avio_alloc_context failed");
+        }
+    }
+
+    ~FileAvio() {
+        if (ctx_ != nullptr) {
+            // The buffer may have been reallocated internally; free the current one, then the context.
+            av_freep(&ctx_->buffer);
+            avio_context_free(&ctx_);
+        }
+    }
+
+    FileAvio(const FileAvio &) = delete;
+    FileAvio &operator=(const FileAvio &) = delete;
+
+    [[nodiscard]] AVIOContext *context() const { return ctx_; }
+
+private:
+    static int readPacket(void *opaque, uint8_t *buf, int buf_size) {
+        auto *self = static_cast<FileAvio *>(opaque);
+        self->file_.read(reinterpret_cast<char *>(buf), buf_size);
+        const auto count = static_cast<int>(self->file_.gcount());
+        if (count == 0) {
+            return AVERROR_EOF;
+        }
+        // A partial read sets failbit alongside eofbit; clear it so subsequent seeks/reads still work.
+        self->file_.clear();
+        return count;
+    }
+
+    static int writePacket(void *opaque, const uint8_t *buf, int buf_size) {
+        auto *self = static_cast<FileAvio *>(opaque);
+        self->file_.write(reinterpret_cast<const char *>(buf), buf_size);
+        if (!self->file_) {
+            return AVERROR(EIO);
+        }
+        return buf_size;
+    }
+
+    static int64_t seek(void *opaque, int64_t offset, int whence) {
+        auto *self = static_cast<FileAvio *>(opaque);
+        if (whence & AVSEEK_SIZE) {
+            return self->size();
+        }
+        const std::ios_base::seekdir dir = (whence == SEEK_CUR) ? std::ios::cur
+                                         : (whence == SEEK_END) ? std::ios::end
+                                                                : std::ios::beg;
+        self->file_.clear();
+        if (self->write_) {
+            self->file_.seekp(offset, dir);
+            return static_cast<int64_t>(self->file_.tellp());
+        }
+        self->file_.seekg(offset, dir);
+        return static_cast<int64_t>(self->file_.tellg());
+    }
+
+    int64_t size() {
+        file_.clear();
+        if (write_) {
+            const auto cur = file_.tellp();
+            file_.seekp(0, std::ios::end);
+            const auto end = file_.tellp();
+            file_.seekp(cur);
+            return static_cast<int64_t>(end);
+        }
+        const auto cur = file_.tellg();
+        file_.seekg(0, std::ios::end);
+        const auto end = file_.tellg();
+        file_.seekg(cur);
+        return static_cast<int64_t>(end);
+    }
+
+    const bool write_;
+    std::fstream file_;
+    AVIOContext *ctx_ = nullptr;
+};
+
+}  // namespace uma::video::ffv1_detail

--- a/native/src/cv/ffv1_pixfmt.h
+++ b/native/src/cv/ffv1_pixfmt.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstring>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+#include <opencv2/opencv.hpp>
+#pragma clang diagnostic pop
+
+extern "C" {
+#include <libavutil/frame.h>
+#include <libavutil/pixfmt.h>
+}
+
+// Bit-exact BGR <-> FFV1 conversion, defined once so the recorder's encode mapping and the reader's decode
+// mapping can never drift apart. FFV1 is stored as AV_PIX_FMT_BGR0: packed 8-bit B,G,R plus an ignored 4th
+// byte, full resolution, no chroma subsampling and no YUV matrix -- so the B/G/R samples survive untouched,
+// unlike yuv420p/yuv444p which apply a lossy RGB->YUV transform. (This ffmpeg build's FFV1 encoder does not
+// accept the 8-bit planar gbrp format; bgr0 is its lossless 8-bit RGB path.) A cv::Mat BGR image maps
+// directly: BGR -> BGRA (padding the ignored channel) on the way in, BGRA -> BGR on the way out. Every copy
+// is row-by-row honoring AVFrame::linesize (SIMD-padded, generally != cv::Mat::step).
+namespace uma::video::ffv1_detail {
+
+constexpr AVPixelFormat kFrameFormat = AV_PIX_FMT_BGR0;
+
+// Write a CV_8UC3 BGR image into a writable BGR0 AVFrame of matching size.
+inline void bgrToFrame(const cv::Mat &bgr, AVFrame *frame) {
+    cv::Mat bgra;
+    cv::cvtColor(bgr, bgra, cv::COLOR_BGR2BGRA);  // 4th channel is ignored by bgr0; value is irrelevant
+    const int height = bgra.rows;
+    const size_t row_bytes = static_cast<size_t>(bgra.cols) * 4;
+    for (int y = 0; y < height; ++y) {
+        std::memcpy(frame->data[0] + static_cast<size_t>(y) * frame->linesize[0], bgra.ptr(y), row_bytes);
+    }
+}
+
+// Read a BGR0 AVFrame back into a fresh CV_8UC3 BGR image.
+inline cv::Mat frameToBgr(const AVFrame *frame) {
+    const cv::Mat bgra(frame->height, frame->width, CV_8UC4, frame->data[0], static_cast<size_t>(frame->linesize[0]));
+    cv::Mat bgr;
+    cv::cvtColor(bgra, bgr, cv::COLOR_BGRA2BGR);  // drops the ignored 4th channel; B/G/R are exact
+    return bgr;
+}
+
+}  // namespace uma::video::ffv1_detail

--- a/native/src/cv/ffv1_reader.cpp
+++ b/native/src/cv/ffv1_reader.cpp
@@ -1,0 +1,174 @@
+#include <string>
+
+#include "cv/ffv1_avio.h"
+#include "cv/ffv1_pixfmt.h"
+#include "cv/ffv1_reader.h"
+#include "util/logger_util.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/avutil.h>
+}
+
+namespace uma::video {
+
+namespace {
+
+std::string avError(int code) {
+    char buffer[AV_ERROR_MAX_STRING_SIZE] = {};
+    av_strerror(code, buffer, sizeof(buffer));
+    return buffer;
+}
+
+constexpr AVRational kMillisTimeBase = {1, 1000};
+
+}  // namespace
+
+struct Ffv1Reader::Impl {
+    Impl(const std::filesystem::path &path, const event_util::Sender<Frame, Size<int>> &on_frame_captured)
+        : on_frame_captured(on_frame_captured) {
+        try {
+            open(path);
+        } catch (...) {
+            freeDecoder();
+            throw;
+        }
+    }
+
+    ~Impl() { freeDecoder(); }
+
+    void run() const {
+        AVPacket *packet = av_packet_alloc();
+        AVFrame *frame = av_frame_alloc();
+        if (packet == nullptr || frame == nullptr) {
+            if (packet != nullptr) {
+                av_packet_free(&packet);
+            }
+            if (frame != nullptr) {
+                av_frame_free(&frame);
+            }
+            throw std::runtime_error("ffv1: av_packet_alloc / av_frame_alloc failed");
+        }
+
+        try {
+            while (av_read_frame(format_ctx, packet) >= 0) {
+                if (packet->stream_index == stream_index) {
+                    decodePacket(packet, frame);
+                }
+                av_packet_unref(packet);
+            }
+            decodePacket(nullptr, frame);  // flush
+        } catch (...) {
+            av_packet_free(&packet);
+            av_frame_free(&frame);
+            throw;
+        }
+        av_packet_free(&packet);
+        av_frame_free(&frame);
+    }
+
+private:
+    void open(const std::filesystem::path &path) {
+        file_avio = std::make_unique<ffv1_detail::FileAvio>(path, /*write=*/false);
+
+        format_ctx = avformat_alloc_context();
+        if (format_ctx == nullptr) {
+            throw std::runtime_error("ffv1: avformat_alloc_context failed");
+        }
+        format_ctx->pb = file_avio->context();
+        // Tell libav the pb is caller-owned so close_input never frees our FileAvio's AVIOContext.
+        format_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
+
+        int ret = avformat_open_input(&format_ctx, nullptr, nullptr, nullptr);
+        if (ret < 0) {
+            // On failure avformat_open_input frees format_ctx and nulls it; drop our dangling pb reference.
+            format_ctx = nullptr;
+            throw std::runtime_error("ffv1: avformat_open_input failed: " + avError(ret));
+        }
+        ret = avformat_find_stream_info(format_ctx, nullptr);
+        if (ret < 0) {
+            throw std::runtime_error("ffv1: avformat_find_stream_info failed: " + avError(ret));
+        }
+
+        const AVCodec *codec = nullptr;
+        stream_index = av_find_best_stream(format_ctx, AVMEDIA_TYPE_VIDEO, -1, -1, &codec, 0);
+        if (stream_index < 0) {
+            throw std::runtime_error("ffv1: no video stream found");
+        }
+        stream = format_ctx->streams[stream_index];
+        if (stream->codecpar->codec_id != AV_CODEC_ID_FFV1) {
+            throw std::runtime_error("ffv1: stream is not FFV1");
+        }
+
+        codec_ctx = avcodec_alloc_context3(codec);
+        if (codec_ctx == nullptr) {
+            throw std::runtime_error("ffv1: avcodec_alloc_context3 failed");
+        }
+        ret = avcodec_parameters_to_context(codec_ctx, stream->codecpar);
+        if (ret < 0) {
+            throw std::runtime_error("ffv1: avcodec_parameters_to_context failed: " + avError(ret));
+        }
+        ret = avcodec_open2(codec_ctx, codec, nullptr);
+        if (ret < 0) {
+            throw std::runtime_error("ffv1: avcodec_open2 failed: " + avError(ret));
+        }
+    }
+
+    void decodePacket(AVPacket *packet, AVFrame *frame) const {
+        int ret = avcodec_send_packet(codec_ctx, packet);
+        if (ret < 0 && ret != AVERROR_EOF) {
+            throw std::runtime_error("ffv1: avcodec_send_packet failed: " + avError(ret));
+        }
+        for (;;) {
+            ret = avcodec_receive_frame(codec_ctx, frame);
+            if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+                break;
+            }
+            if (ret < 0) {
+                throw std::runtime_error("ffv1: avcodec_receive_frame failed: " + avError(ret));
+            }
+            emitFrame(frame);
+            av_frame_unref(frame);
+        }
+    }
+
+    void emitFrame(const AVFrame *frame) const {
+        const int64_t pts = (frame->pts == AV_NOPTS_VALUE) ? 0 : frame->pts;
+        const int64_t ts_ms = av_rescale_q(pts, stream->time_base, kMillisTimeBase);
+        cv::Mat bgr = ffv1_detail::frameToBgr(frame);
+        const Frame emitted{bgr, static_cast<uint64>(ts_ms < 0 ? 0 : ts_ms)};
+        on_frame_captured->send(emitted, emitted.size());
+    }
+
+    void freeDecoder() {
+        if (codec_ctx != nullptr) {
+            avcodec_free_context(&codec_ctx);
+        }
+        if (format_ctx != nullptr) {
+            // AVFMT_FLAG_CUSTOM_IO keeps this from freeing our FileAvio's AVIOContext.
+            avformat_close_input(&format_ctx);
+        }
+        file_avio.reset();
+    }
+
+    const event_util::Sender<Frame, Size<int>> on_frame_captured;
+
+    std::unique_ptr<ffv1_detail::FileAvio> file_avio;
+    AVFormatContext *format_ctx = nullptr;
+    AVStream *stream = nullptr;
+    AVCodecContext *codec_ctx = nullptr;
+    int stream_index = -1;
+};
+
+Ffv1Reader::Ffv1Reader(const std::filesystem::path &path, const event_util::Sender<Frame, Size<int>> &on_frame_captured)
+    : impl_(std::make_unique<Impl>(path, on_frame_captured)) {
+}
+
+Ffv1Reader::~Ffv1Reader() = default;
+
+void Ffv1Reader::run() const {
+    impl_->run();
+}
+
+}  // namespace uma::video

--- a/native/src/cv/ffv1_reader.h
+++ b/native/src/cv/ffv1_reader.h
@@ -12,7 +12,7 @@ namespace uma::video {
 // Replays an FFV1 `.mkv` produced by Ffv1Recorder back into the recognition pipeline. Each decoded frame
 // is emitted through the same event_util::Sender the live capture and VideoLoader use, carrying its
 // original millisecond timestamp (recovered from the container PTS) so the scene begin/end debounce fires
-// on exactly the frames it did during the failed capture. Pixels round-trip bit-exact (GBRP -> BGR).
+// on exactly the frames it did during the failed capture. Pixels round-trip bit-exact (BGR0 -> BGR).
 //
 // Frames are already pipeline-input form (post capture-resize/crop), so no cropping is applied here.
 // Ingestion is paced by the downstream Block-mode queue, not by wall-clock, matching VideoLoader.

--- a/native/src/cv/ffv1_reader.h
+++ b/native/src/cv/ffv1_reader.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+
+#include "cv/frame.h"
+#include "types/shape.h"
+#include "util/event_util.h"
+
+namespace uma::video {
+
+// Replays an FFV1 `.mkv` produced by Ffv1Recorder back into the recognition pipeline. Each decoded frame
+// is emitted through the same event_util::Sender the live capture and VideoLoader use, carrying its
+// original millisecond timestamp (recovered from the container PTS) so the scene begin/end debounce fires
+// on exactly the frames it did during the failed capture. Pixels round-trip bit-exact (GBRP -> BGR).
+//
+// Frames are already pipeline-input form (post capture-resize/crop), so no cropping is applied here.
+// Ingestion is paced by the downstream Block-mode queue, not by wall-clock, matching VideoLoader.
+class Ffv1Reader {
+public:
+    Ffv1Reader(const std::filesystem::path &path, const event_util::Sender<Frame, Size<int>> &on_frame_captured);
+    ~Ffv1Reader();
+
+    Ffv1Reader(const Ffv1Reader &) = delete;
+    Ffv1Reader &operator=(const Ffv1Reader &) = delete;
+
+    // Decodes every frame and sends it downstream, returning at end-of-stream. Throws std::runtime_error if
+    // the file cannot be opened or is not an FFV1 stream.
+    void run() const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace uma::video

--- a/native/src/cv/ffv1_recorder.cpp
+++ b/native/src/cv/ffv1_recorder.cpp
@@ -1,0 +1,309 @@
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include "cv/ffv1_avio.h"
+#include "cv/ffv1_pixfmt.h"
+#include "cv/ffv1_recorder.h"
+#include "util/event_util.h"
+#include "util/logger_util.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/dict.h>
+#include <libavutil/opt.h>
+}
+
+namespace uma::video {
+
+namespace {
+
+std::string avError(int code) {
+    char buffer[AV_ERROR_MAX_STRING_SIZE] = {};
+    av_strerror(code, buffer, sizeof(buffer));
+    return buffer;
+}
+
+// Millisecond time base for both the codec and the informational metadata; matches the epoch-ms domain of
+// Frame::timestamp() so PTS deltas reproduce the exact inter-frame gaps the recognition debounce keys off.
+constexpr AVRational kMillisTimeBase = {1, 1000};
+
+}  // namespace
+
+struct Ffv1Recorder::Impl {
+    Impl(const std::filesystem::path &path, const Size<int> &size, int fps_hint)
+        : width(size.width())
+        , height(size.height()) {
+        try {
+            initEncoder(path, fps_hint);
+        } catch (...) {
+            freeEncoder();
+            throw;
+        }
+
+        encode_runner = event_util::makeSingleThreadRunner(event_util::QueueLimitMode::Block, nullptr, "ffv1");
+        encode_conn = encode_runner->makeConnection<Frame>();
+        encode_conn->listen([this](const Frame &frame) {
+            encodeOne(frame);
+            processed_count.fetch_add(1);
+        });
+        encode_runner->start();
+    }
+
+    ~Impl() {
+        close();
+        freeEncoder();
+    }
+
+    void push(const Frame &frame) {
+        if (closed.load()) {
+            return;
+        }
+        // Clone: Frame is a shallow cv::Mat handle, and the encode happens on another thread, so hand the
+        // encoder an independently owned buffer (see the Frame ownership contract in frame.h). Block-mode
+        // send() applies backpressure, so at most a few frames are ever in flight.
+        encode_conn->send(frame.clone());
+        pushed_count.fetch_add(1);
+    }
+
+    void close() {
+        if (closed.exchange(true)) {
+            return;
+        }
+        // Drain every pushed frame through the encode worker before touching libav on this thread. join()
+        // stops the worker WITHOUT flushing its queue (processIf halts as soon as isRunning() is false), so
+        // wait for the processed counter to catch up first. Bounded so a wedged encoder can't hang teardown.
+        if (encode_runner != nullptr) {
+            for (int i = 0; i < 30000 && processed_count.load() < pushed_count.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            if (processed_count.load() < pushed_count.load()) {
+                log_warning(
+                    "ffv1: encoder did not drain in time ({}/{} frames)", processed_count.load(), pushed_count.load());
+            }
+            encode_runner->join();
+        }
+        if (failed || !header_written) {
+            if (!header_written) {
+                log_warning("ffv1: no frames recorded; output file is empty");
+            }
+            return;
+        }
+        try {
+            flushEncoder();
+            const int ret = av_write_trailer(format_ctx);
+            if (ret < 0) {
+                log_error("ffv1: av_write_trailer failed: {}", avError(ret));
+            } else {
+                log_info("ffv1: finalized recording ({} frames)", frame_count);
+            }
+        } catch (const std::exception &e) {
+            log_error("ffv1: finalize failed: {}", e.what());
+        }
+    }
+
+private:
+    void initEncoder(const std::filesystem::path &path, int fps_hint) {
+        file_avio = std::make_unique<ffv1_detail::FileAvio>(path, /*write=*/true);
+
+        int ret = avformat_alloc_output_context2(&format_ctx, nullptr, "matroska", nullptr);
+        if (ret < 0 || format_ctx == nullptr) {
+            throw std::runtime_error("ffv1: avformat_alloc_output_context2 failed: " + avError(ret));
+        }
+        format_ctx->pb = file_avio->context();
+        // Tell libav the pb is caller-owned so nothing here frees our FileAvio's AVIOContext.
+        format_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
+
+        const AVCodec *codec = avcodec_find_encoder(AV_CODEC_ID_FFV1);
+        if (codec == nullptr) {
+            throw std::runtime_error("ffv1: FFV1 encoder not found in this ffmpeg build");
+        }
+
+        stream = avformat_new_stream(format_ctx, nullptr);
+        if (stream == nullptr) {
+            throw std::runtime_error("ffv1: avformat_new_stream failed");
+        }
+
+        codec_ctx = avcodec_alloc_context3(codec);
+        if (codec_ctx == nullptr) {
+            throw std::runtime_error("ffv1: avcodec_alloc_context3 failed");
+        }
+        codec_ctx->width = width;
+        codec_ctx->height = height;
+        codec_ctx->pix_fmt = ffv1_detail::kFrameFormat;  // bit-exact BGR round-trip (see ffv1_pixfmt.h)
+        codec_ctx->color_range = AVCOL_RANGE_JPEG;  // full-range 0..255
+        codec_ctx->time_base = kMillisTimeBase;
+        codec_ctx->thread_count = 0;  // auto (one per core)
+        // Slice-based parallelism so a 30fps stream of full frames keeps up on multiple cores. Only enabled
+        // for reasonably large frames: FFV1 rejects a fine slice grid on tiny images (avcodec_open2 EINVAL),
+        // and the parallelism is pointless there anyway.
+        if (width >= 128 && height >= 128) {
+            codec_ctx->slices = 16;  // a 4x4 grid
+            codec_ctx->thread_type = FF_THREAD_SLICE;
+        }
+        // FFV1 private tuning; non-fatal if a build lacks an option.
+        av_opt_set_int(codec_ctx->priv_data, "coder", 1, 0);  // range coder
+        av_opt_set_int(codec_ctx->priv_data, "context", 1, 0);
+        av_opt_set_int(codec_ctx->priv_data, "slicecrc", 1, 0);
+        if ((format_ctx->oformat->flags & AVFMT_GLOBALHEADER) != 0) {
+            codec_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        }
+
+        ret = avcodec_open2(codec_ctx, codec, nullptr);
+        if (ret < 0) {
+            throw std::runtime_error("ffv1: avcodec_open2 failed: " + avError(ret));
+        }
+        ret = avcodec_parameters_from_context(stream->codecpar, codec_ctx);
+        if (ret < 0) {
+            throw std::runtime_error("ffv1: avcodec_parameters_from_context failed: " + avError(ret));
+        }
+        stream->time_base = kMillisTimeBase;
+        stream->avg_frame_rate = {fps_hint, 1};
+
+        av_frame = av_frame_alloc();
+        packet = av_packet_alloc();
+        if (av_frame == nullptr || packet == nullptr) {
+            throw std::runtime_error("ffv1: av_frame_alloc / av_packet_alloc failed");
+        }
+        av_frame->format = ffv1_detail::kFrameFormat;
+        av_frame->width = width;
+        av_frame->height = height;
+        ret = av_frame_get_buffer(av_frame, 0);
+        if (ret < 0) {
+            throw std::runtime_error("ffv1: av_frame_get_buffer failed: " + avError(ret));
+        }
+    }
+
+    void encodeOne(const Frame &frame) {
+        if (failed) {
+            return;
+        }
+        const cv::Mat &image = frame.data();
+        if (image.cols != width || image.rows != height) {
+            log_warning(
+                "ffv1: dropping frame with mismatched size {}x{} (stream is {}x{})",
+                image.cols,
+                image.rows,
+                width,
+                height);
+            return;
+        }
+        try {
+            if (!header_written) {
+                t0 = frame.timestamp();
+                av_dict_set(&format_ctx->metadata, "UMA_EPOCH_MS_T0", std::to_string(t0).c_str(), 0);
+                const int ret = avformat_write_header(format_ctx, nullptr);
+                if (ret < 0) {
+                    throw std::runtime_error("avformat_write_header failed: " + avError(ret));
+                }
+                header_written = true;
+            }
+
+            int64_t pts = static_cast<int64_t>(frame.timestamp()) - static_cast<int64_t>(t0);
+            if (pts <= last_pts && frame_count > 0) {
+                log_warning("ffv1: non-monotonic timestamp {} -> bumping pts to {}", frame.timestamp(), last_pts + 1);
+                pts = last_pts + 1;
+            }
+            last_pts = pts;
+
+            const int ret = av_frame_make_writable(av_frame);
+            if (ret < 0) {
+                throw std::runtime_error("av_frame_make_writable failed: " + avError(ret));
+            }
+            ffv1_detail::bgrToFrame(image, av_frame);
+            av_frame->pts = pts;
+
+            encodeAndWrite(av_frame);
+            frame_count++;
+        } catch (const std::exception &e) {
+            // A mid-stream failure disables further encoding but never propagates out of the runner thread.
+            failed = true;
+            log_error("ffv1: encode failed, stopping recording: {}", e.what());
+        }
+    }
+
+    void encodeAndWrite(AVFrame *frame) {
+        int ret = avcodec_send_frame(codec_ctx, frame);
+        if (ret < 0) {
+            throw std::runtime_error("avcodec_send_frame failed: " + avError(ret));
+        }
+        for (;;) {
+            ret = avcodec_receive_packet(codec_ctx, packet);
+            if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+                break;
+            }
+            if (ret < 0) {
+                throw std::runtime_error("avcodec_receive_packet failed: " + avError(ret));
+            }
+            av_packet_rescale_ts(packet, codec_ctx->time_base, stream->time_base);
+            packet->stream_index = stream->index;
+            ret = av_interleaved_write_frame(format_ctx, packet);  // consumes/unrefs the packet
+            if (ret < 0) {
+                throw std::runtime_error("av_interleaved_write_frame failed: " + avError(ret));
+            }
+        }
+    }
+
+    void flushEncoder() { encodeAndWrite(nullptr); }
+
+    void freeEncoder() {
+        if (av_frame != nullptr) {
+            av_frame_free(&av_frame);
+        }
+        if (packet != nullptr) {
+            av_packet_free(&packet);
+        }
+        if (codec_ctx != nullptr) {
+            avcodec_free_context(&codec_ctx);
+        }
+        if (format_ctx != nullptr) {
+            // AVFMT_FLAG_CUSTOM_IO keeps avformat_free_context from touching our FileAvio's AVIOContext.
+            avformat_free_context(format_ctx);
+            format_ctx = nullptr;
+        }
+        file_avio.reset();
+    }
+
+    const int width;
+    const int height;
+
+    std::unique_ptr<ffv1_detail::FileAvio> file_avio;
+    AVFormatContext *format_ctx = nullptr;
+    AVStream *stream = nullptr;
+    AVCodecContext *codec_ctx = nullptr;
+    AVFrame *av_frame = nullptr;
+    AVPacket *packet = nullptr;
+
+    // Touched only on the encode runner thread (encodeOne) and, after join(), on the closing thread.
+    uint64 t0 = 0;
+    int64_t last_pts = 0;
+    uint64 frame_count = 0;
+    bool header_written = false;
+    bool failed = false;
+
+    std::atomic<bool> closed = false;
+    // Drain accounting across the push (producer) and encode (worker) threads; see close().
+    std::atomic<uint64> pushed_count = 0;
+    std::atomic<uint64> processed_count = 0;
+
+    event_util::SingleThreadMultiEventRunner encode_runner;
+    event_util::Connection<Frame> encode_conn;
+};
+
+Ffv1Recorder::Ffv1Recorder(const std::filesystem::path &path, const Size<int> &size, int fps_hint)
+    : impl_(std::make_unique<Impl>(path, size, fps_hint)) {
+}
+
+Ffv1Recorder::~Ffv1Recorder() = default;
+
+void Ffv1Recorder::push(const Frame &frame) {
+    impl_->push(frame);
+}
+
+void Ffv1Recorder::close() {
+    impl_->close();
+}
+
+}  // namespace uma::video

--- a/native/src/cv/ffv1_recorder.h
+++ b/native/src/cv/ffv1_recorder.h
@@ -11,7 +11,7 @@ namespace uma::video {
 // Records every pushed Frame into a single lossless FFV1 matroska (`.mkv`) file, preserving each frame's
 // millisecond timestamp as a variable-frame-rate PTS. Built for reproducing a failed live capture: the
 // exact frame stream (and its inter-frame timing, which drives the recognition debounce) can be replayed
-// later via Ffv1Reader. Pixels round-trip bit-exact (GBRP planar RGB; see ffv1_pixfmt.h).
+// later via Ffv1Reader. Pixels round-trip bit-exact (BGR0 packed RGB; see ffv1_pixfmt.h).
 //
 // Encoding runs on its own thread (an event_util Block-mode runner), so it never stalls the capture
 // thread beyond brief backpressure. Push is safe to call from the capture listener; the Frame is cloned

--- a/native/src/cv/ffv1_recorder.h
+++ b/native/src/cv/ffv1_recorder.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+
+#include "cv/frame.h"
+#include "types/shape.h"
+
+namespace uma::video {
+
+// Records every pushed Frame into a single lossless FFV1 matroska (`.mkv`) file, preserving each frame's
+// millisecond timestamp as a variable-frame-rate PTS. Built for reproducing a failed live capture: the
+// exact frame stream (and its inter-frame timing, which drives the recognition debounce) can be replayed
+// later via Ffv1Reader. Pixels round-trip bit-exact (GBRP planar RGB; see ffv1_pixfmt.h).
+//
+// Encoding runs on its own thread (an event_util Block-mode runner), so it never stalls the capture
+// thread beyond brief backpressure. Push is safe to call from the capture listener; the Frame is cloned
+// internally, so the caller keeps ownership of its buffer. libav is hidden behind a PIMPL so translation
+// units that only *drive* the recorder (e.g. cli.cpp) never include the ffmpeg headers.
+class Ffv1Recorder {
+public:
+    // Opens `path` for a stream of `size`-sized frames. `fps_hint` is only a nominal AVStream metadata
+    // value; real timing comes from per-frame PTS. Throws std::runtime_error if the file/codec cannot be
+    // opened. The parent directory is created if missing.
+    Ffv1Recorder(const std::filesystem::path &path, const Size<int> &size, int fps_hint = 30);
+
+    // Finalizes the file (flush + trailer) if close() was not called explicitly.
+    ~Ffv1Recorder();
+
+    Ffv1Recorder(const Ffv1Recorder &) = delete;
+    Ffv1Recorder &operator=(const Ffv1Recorder &) = delete;
+
+    // Enqueues a copy of `frame` for encoding. Frames whose size differs from the stream size are dropped
+    // with a warning (FFV1 streams are fixed-size). No-op after close().
+    void push(const Frame &frame);
+
+    // Drains the encode queue, flushes the encoder, and writes the matroska trailer. Idempotent.
+    void close();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace uma::video

--- a/native/src/cv/ffv1_recorder.h
+++ b/native/src/cv/ffv1_recorder.h
@@ -15,8 +15,11 @@ namespace uma::video {
 //
 // Encoding runs on its own thread (an event_util Block-mode runner), so it never stalls the capture
 // thread beyond brief backpressure. Push is safe to call from the capture listener; the Frame is cloned
-// internally, so the caller keeps ownership of its buffer. libav is hidden behind a PIMPL so translation
-// units that only *drive* the recorder (e.g. cli.cpp) never include the ffmpeg headers.
+// internally, so the caller keeps ownership of its buffer. The producer must be stopped (its runner
+// joined) BEFORE close(): push() concurrent with close() is unsupported -- a frame enqueued after the
+// drain check would be silently dropped, or block a full queue whose worker is already gone (see the
+// cli.cpp capture teardown: recorder_runner->join(), then close()). libav is hidden behind a PIMPL so
+// translation units that only *drive* the recorder (e.g. cli.cpp) never include the ffmpeg headers.
 class Ffv1Recorder {
 public:
     // Opens `path` for a stream of `size`-sized frames. `fps_hint` is only a nominal AVStream metadata

--- a/native/test/chara_detail/test_scraping_box.cpp
+++ b/native/test/chara_detail/test_scraping_box.cpp
@@ -311,6 +311,64 @@ TEST_CASE("trimScrollAreaToFactorEnd falls back to the previous transition when 
     CHECK(cropped.rows == 83);
 }
 
+TEST_CASE("latchUpToGreenTerminator captures the last factor above the bar and the trim crops from it") {
+    HookRecorder recorder;
+    const auto dir = freshTempDir("uma_factor_end_latch_then_trim");
+    scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
+
+    // Arm with a stack that ends INSIDE the last factor: gray 2 px consumes kArmScan, a mid-list gap
+    // [70, 80) records stale frontier evidence (the second-to-last factor's gap), and factor fill runs to
+    // the frame bottom -- the last card is only partially latched, as when the bar fires on the very frame
+    // the card scrolled in.
+    cv::Mat arm = testutil::solid(100, Color(200, 200, 200));
+    arm(cv::Rect(0, 0, 100, 2)).setTo(cv::Scalar(130, 130, 130));
+    arm(cv::Rect(0, 70, 100, 10)).setTo(cv::Scalar(243, 243, 243));
+    box.addScrollArea(Frame::fixed(arm));  // stack 100, frontier 70 (stale), stack bottom mid-factor
+
+    // The terminating frame, scrolled 16 px: its new strip [84, 100) carries the last factor's bottom
+    // [84, 86), its gap [86, 89), the anti-aliased edge [89, 91), the green bar [91, 96), and post-bar
+    // background broken by a dark streak at 97 -- two post-bar transitions, like the shadow/footer
+    // structure under a real bar. Latching them would evict the gap (102) from the two-deep frontier
+    // history; the latch must stop at the bar top.
+    cv::Mat probe_mat = testutil::solid(100, Color(243, 243, 243));
+    probe_mat(cv::Rect(0, 0, 100, 86)).setTo(cv::Scalar(200, 200, 200));
+    probe_mat(cv::Rect(0, 89, 100, 2)).setTo(cv::Scalar(180, 240, 220));
+    probe_mat(cv::Rect(0, 91, 100, 5)).setTo(cv::Scalar(20, 222, 128));
+    probe_mat(cv::Rect(0, 97, 100, 1)).setTo(cv::Scalar(200, 200, 200));
+    const Frame probe = Frame::fixed(probe_mat);
+    REQUIRE(box.detectGreenTerminator(probe, 16));
+    const int trim_offset = box.latchUpToGreenTerminator(probe, 16);
+    CHECK(trim_offset == 9);  // 100 - bar top (91): the stack bottom is now the bar top
+    box.trimScrollAreaToFactorEnd(probe, trim_offset);
+
+    // The latch stages only [84, 91): the gap start becomes the frontier (102), the stale 70 shifts into
+    // the previous slot, and no post-bar run is recorded. The trim maps the bar top to 107 (= stack), the
+    // frontier is within the 8 px span -> crop at 102 + margin (2) = 104: the whole last factor survives
+    // with the fixed margin and the bar never enters the stack.
+    const cv::Mat frag0 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
+    CHECK(frag0.rows == 100);
+    const cv::Mat frag1 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(1, 5).filename());
+    CHECK(frag1.rows == 4);
+}
+
+TEST_CASE("latchUpToGreenTerminator is a no-op when the bar sits at or above the scroll frontier") {
+    HookRecorder recorder;
+    const auto dir = freshTempDir("uma_factor_end_latch_noop");
+    scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
+    box.addScrollArea(structuredArmFrame(82));  // stack 100, frontier 82
+
+    // Bar at [79, 84): fully above the frame's new-content boundary (height - offset = 90), so everything
+    // above the bar is already latched. The offset must pass through unchanged and nothing new is staged.
+    const Frame probe = factorEndFrame(72, 5);
+    REQUIRE(box.detectGreenTerminator(probe, 10));
+    CHECK(box.latchUpToGreenTerminator(probe, 10) == 10);
+    box.trimScrollAreaToFactorEnd(probe, 10);
+
+    // Identical outcome to the plain frontier-crop case: crop at 82 + margin (2) = 84.
+    const cv::Mat cropped = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
+    CHECK(cropped.rows == 84);
+}
+
 // --- gray-completion trim: sequence completion crops at the frontier -----------------------------------
 //
 // The gray-completion path (addScrollArea, scan sequence consumed) terminates a LONG-inheritance factor tab

--- a/native/test/chara_detail/test_scraping_box.cpp
+++ b/native/test/chara_detail/test_scraping_box.cpp
@@ -175,19 +175,20 @@ TEST_CASE("detectGreenTerminator ignores a green run shorter than the required l
     CHECK_FALSE(box.scrollAreaReady());
 }
 
-// --- trimScrollAreaToFactorEnd: unify the factor-end crop across both terminator paths -----------------
+// --- trimScrollAreaToFactorEnd: the green terminator crops from the maintained frontier ----------------
 //
-// The gray-completion path crops the terminating fragment a fixed margin below the last factor
-// (factorEndCropY). The green terminator path used to leave the last fragment running to the frame bottom,
-// so the trailing background below the last factor was variable. trimScrollAreaToFactorEnd scans up from the
-// recorded green-bar top to the last factor and trims the fragment stack to the same crop line, so the
-// bottom margin matches regardless of which terminator ended the tab.
+// Both terminator paths crop the stack a fixed margin below frontier_stack_rows: the last observed
+// non-background -> background transition of the terminating scan, recorded in stack coordinates at latch
+// time. The green path validates that evidence against the live bar top (the last factor sits a fixed
+// distance above the bar, bounded by kFactorEndGreenSearchSpan) and falls back to the previous transition
+// (the bar rendered early and its trailing background stole the last one) or to a fail-safe bar-top crop /
+// no-op when the evidence cannot be the last factor's gap.
 //
-// Fixture: kArmScan (consumed on arm) matches solid kArmGray; the back scan kGapScan matches the page
-// background gap. Because kArmGray is not in the gap range, arm frames keep the box armed while a probe
-// frame's gap region is recognized as the space below the last factor. On a 100 px frame the margin (0.0217)
-// is 2 px, the probe back-scan K (0.2) is 20 px, and the factor search span (0.08) is 8 px -- so the fixed
-// factor-to-bar distance below must stay under 8 px.
+// Fixture: kArmScan (consumed on arm) matches kArmGray; the back scan kGapScan matches the page background
+// gap. structuredArmFrame latches real factor + gap structure so the frontier holds evidence that is
+// scroll-consistent with the live probes. On a 100 px frame the margin (0.0217) is 2 px, the probe
+// back-scan K (0.2) is 20 px, and the factor search span (0.08) is 8 px -- so the fixed factor-to-bar
+// distance must stay under 8 px.
 const Color kArmGray{130, 130, 130};
 const scraper_config::ScanParameter kArmScan{0.5, 0.02, {Color(120, 120, 120), Color(140, 140, 140)}};
 const scraper_config::ScanParameter kGapScan{0.5, 0.2, {Color(233, 233, 233), Color(253, 253, 253)}};
@@ -206,34 +207,54 @@ Frame factorEndFrame(int factor_bottom, int gap_height) {
     return Frame::fixed(mat);
 }
 
+// Arms the box with solid arm-gray: kArmScan consumed, no factor/gap structure latched (frontier stays -1).
 void armFactorBox(scraper_impl::PageScrapingBox &box) {
     box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)));  // consume kArmScan; kGapScan stays parked
 }
 
-TEST_CASE("trimScrollAreaToFactorEnd crops the green-terminated tab to the last factor plus the fixed margin") {
+// Arms the box with scroll-consistent structure: 2 px of arm-gray consume kArmScan, factor fill down to
+// factor_bottom, page-background gap below -- so the frontier records factor_bottom at latch time. The
+// latched gap run (100 - factor_bottom) must stay under the 20 px terminating length or the gray sequence
+// would complete during the arm latch: factor_bottom >= 81.
+Frame structuredArmFrame(int factor_bottom) {
+    cv::Mat mat = testutil::solid(100, Color(243, 243, 243));                  // page-background gap
+    mat(cv::Rect(0, 0, 100, factor_bottom)).setTo(cv::Scalar(200, 200, 200));  // factor fill
+    mat(cv::Rect(0, 0, 100, 2)).setTo(cv::Scalar(130, 130, 130));              // kArmGray consumes kArmScan
+    return Frame::fixed(mat);
+}
+
+// A pure page-background strip: the trailing background revealed by end-of-list overscroll.
+Frame gapFrame() {
+    return Frame::fixed(testutil::solid(100, Color(243, 243, 243)));
+}
+
+TEST_CASE("trimScrollAreaToFactorEnd crops the green-terminated tab at the frontier plus the fixed margin") {
     HookRecorder recorder;
     const auto dir = freshTempDir("uma_factor_end_crop");
     scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
-    armFactorBox(box);  // fragment 00000 = 100 px
+    box.addScrollArea(structuredArmFrame(82));  // stack 100, frontier 82, latched gap 82..99 (18 px < 20)
 
-    // Last factor bottom 70, gap [70, 74), anti-alias [74, 76), green bar [76, 81). offset 10 -> frontier 90.
-    const Frame probe = factorEndFrame(70, 4);
+    // Live probe, scrolled 10 px past the arm frame (content = frame + 10): factor bottom 72 (content 82,
+    // matching the frontier), gap [72, 77), anti-alias [77, 79), bar [79, 84). The bar's content rows were
+    // latched as background before it lazily popped in, so it exists only in the live frame.
+    const Frame probe = factorEndFrame(72, 5);
     REQUIRE(box.detectGreenTerminator(probe, 10));
     box.trimScrollAreaToFactorEnd(probe, 10);
 
-    // The scan skips the bar edge and walks the gap to the last factor (70); crop = 70 + margin (2 px) = 72.
-    // The fragment bottom sat at the frontier (90), so 90 - 72 = 18 rows are trimmed: 100 -> 82.
+    // Bar top in stack coordinates = 100 - (90 - 79) = 89; frontier 82 is within the 8 px span above it and
+    // 82 + margin (2) = 84 <= 89, so the frontier is trusted: trim = 100 - 84 = 16 rows.
     const cv::Mat cropped = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
-    CHECK(cropped.rows == 82);
+    CHECK(cropped.rows == 84);
 }
 
-TEST_CASE("trimScrollAreaToFactorEnd leaves fragments untouched when nothing overshoots the crop line") {
+TEST_CASE("trimScrollAreaToFactorEnd is a no-op on a green early fire without frontier evidence") {
     HookRecorder recorder;
     const auto dir = freshTempDir("uma_factor_end_noop");
     scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
-    armFactorBox(box);
+    armFactorBox(box);  // no factor/gap structure latched: frontier stays -1
 
-    // Crop line at/above the frontier: last factor 69 + margin 2 = 71 >= frontier 70 (offset 30) -> trim <= 0.
+    // The bar fires before the last factor's gap was ever latched. With no latch evidence the trim must
+    // fail safe; the bar (75) sits below the stack bottom (70), so the bar-top fallback is a no-op.
     const Frame probe = factorEndFrame(69, 4);  // gap [69, 73), anti-alias [73, 75), green [75, 80)
     REQUIRE(box.detectGreenTerminator(probe, 30));
     box.trimScrollAreaToFactorEnd(probe, 30);
@@ -242,73 +263,98 @@ TEST_CASE("trimScrollAreaToFactorEnd leaves fragments untouched when nothing ove
     CHECK(kept.rows == 100);
 }
 
-TEST_CASE("trimScrollAreaToFactorEnd peels whole fragments when the trim exceeds the last one") {
+TEST_CASE("trimScrollAreaToFactorEnd peels whole staged strips when the trim spans them") {
     HookRecorder recorder;
     const auto dir = freshTempDir("uma_factor_end_spill");
     scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
-    armFactorBox(box);  // fragment 00000 = 100 px
-    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 20);  // fragment 00001 = 20 px strip
+    box.addScrollArea(structuredArmFrame(93));  // stack 100, frontier 93, latched gap 7 px
+    box.addScrollArea(gapFrame(), 6);           // trailing background strip: stack 106, gap run 13 px < 20
 
-    // Last factor 64, gap [64, 68), anti-alias [68, 70), green [70, 75); offset 10 -> frontier 90 -> crop 66
-    // -> trim 24.
-    const Frame probe = factorEndFrame(64, 4);
+    // Probe scrolled 16 px past the arm frame (content = frame + 16): factor bottom 77 (content 93), gap
+    // [77, 82), anti-alias [82, 84), bar [84, 89) at content 100 -- latched as background by the 6 px strip
+    // before the bar popped in.
+    const Frame probe = factorEndFrame(77, 5);
     REQUIRE(box.detectGreenTerminator(probe, 10));
     box.trimScrollAreaToFactorEnd(probe, 10);
 
-    // trim 24 > fragment1 (20 px): fragment1 removed, remaining 4 px trimmed off fragment0 (100 -> 96).
+    // Bar top in stack coordinates = 106 - (90 - 84) = 100; frontier 93 valid (span 7 <= 8): crop 95,
+    // trim 11 -> the 6 px strip is peeled entirely in RAM (never written), the arm strip crops 100 -> 95.
     CHECK_FALSE(std::filesystem::exists(dir / path_config.scroll_area.withNumber(1, 5).filename()));
     const cv::Mat frag0 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
-    CHECK(frag0.rows == 96);
+    CHECK(frag0.rows == 95);
 }
 
-// --- gray-completion trim: the factor gray-sequence path shares the same tail-trim ---------------------
+TEST_CASE("trimScrollAreaToFactorEnd falls back to the previous transition when the early bar was latched") {
+    HookRecorder recorder;
+    const auto dir = freshTempDir("uma_factor_end_early_bar");
+    scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
+
+    // A short history whose bar rendered before the arm latch, so the bar itself was latched: the column
+    // reads factor [2, 81), gap [81, 86), anti-alias [86, 88), bar [88, 93), background [93, 100). The
+    // post-bar background steals the last transition (93); the factor's own gap start (81) survives as the
+    // previous one.
+    cv::Mat arm = testutil::solid(100, Color(243, 243, 243));
+    arm(cv::Rect(0, 0, 100, 81)).setTo(cv::Scalar(200, 200, 200));
+    arm(cv::Rect(0, 0, 100, 2)).setTo(cv::Scalar(130, 130, 130));
+    arm(cv::Rect(0, 86, 100, 2)).setTo(cv::Scalar(180, 240, 220));
+    arm(cv::Rect(0, 88, 100, 5)).setTo(cv::Scalar(20, 222, 128));
+    box.addScrollArea(Frame::fixed(arm));
+
+    // Probe scrolled 10 px (content = frame + 10): bar [78, 83) -> bar top in stack coordinates 88. The
+    // last transition (93) lies below the bar and is rejected; the previous one (81) is within the span.
+    const Frame probe = factorEndFrame(71, 5);
+    REQUIRE(box.detectGreenTerminator(probe, 10));
+    box.trimScrollAreaToFactorEnd(probe, 10);
+
+    // crop = 81 + margin (2) = 83, trim = 100 - 83 = 17: the latched bar and its trailing rows are removed.
+    const cv::Mat cropped = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
+    CHECK(cropped.rows == 83);
+}
+
+// --- gray-completion trim: sequence completion crops at the frontier -----------------------------------
 //
 // The gray-completion path (addScrollArea, scan sequence consumed) terminates a LONG-inheritance factor tab
-// whose green bar is not near the bottom. End-of-list overscroll used to leave phantom trailing-background (and
-// occasionally a duplicate "ghost" row) strips below the last factor. The path now routes through the same
-// trimStackToLastFactor core as the green terminator: when the terminating frame's gray run began at the strip
-// top (the whole new strip is trailing background, the real last factor already saved above the frontier), it
-// does NOT save the phantom but scans the frame up from the frontier and trims the fragment stack to the last
-// factor + fixed margin. When the run began below the strip top (the last factor is in this frame), it saves
-// the cropped strip exactly as before (no phantom can precede the first reveal of the last factor).
+// whose green bar is not near the bottom. The terminating run's own start IS the frontier -- recorded when
+// the run began, possibly strips earlier -- so on completion the box stages the strip down to the completion
+// row and crops the whole stack at frontier + margin, one path regardless of where the last factor sits.
+// The run accumulates across strips (current_length_pixels survives frames), so trailing background latched
+// during the recognition lag counts toward the 20 px threshold and is peeled from the staged tail.
 //
 // Fixture: a clean factor-fill over a page-background gap, no anti-aliased edge or green bar, so kGapScan
-// completes on a continuous run. On a 100 px frame the margin (0.0217) is 2 px and the gray search span
-// (0.16) is 16 px. Phantom fragments are built with an arm-gray strip (out of the gap range) so
-// current_length_pixels stays 0 and the terminating frame completes the 20 px gray run on its own -> Case A.
+// completes on a continuous run. On a 100 px frame the margin (0.0217) is 2 px.
 Frame factorThenGapFrame(int factor_bottom) {
     cv::Mat mat = testutil::solid(100, Color(243, 243, 243));                  // page-background gap
     mat(cv::Rect(0, 0, 100, factor_bottom)).setTo(cv::Scalar(200, 200, 200));  // factor fill (out of gap range)
     return Frame::fixed(mat);
 }
 
-TEST_CASE("gray-completion trims a phantom fragment latched below the last factor (Case A)") {
+TEST_CASE("gray-completion trims the trailing background latched during the recognition lag") {
     HookRecorder recorder;
     const auto dir = freshTempDir("uma_gray_trim_peel");
     scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
-    armFactorBox(box);                                                    // fragment 00000 = 100 px
-    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 6);   // fragment 00001 = 6 px phantom
+    box.addScrollArea(structuredArmFrame(91));  // stack 100, frontier 91, gap run 9 px
+    box.addScrollArea(gapFrame(), 6);           // lag strip: all background, run 15 px, stack 106
 
-    // Terminating frame: factor [0, 68), gap [68, 100). offset 20 -> frontier 80; the strip [80, 100] is all
-    // gap, so the gray run begins at the strip top -> Case A. The gap frontier(80)->factor(68) is 12 px, within
-    // the 16 px (0.16 w) search span. Scan up 79..68 (gap), factor at 67 -> last factor bottom 68 -> crop 70.
-    // trim = 80 - 70 = 10: phantom (6) removed, 4 more off fragment0 (100 -> 96).
-    box.addScrollArea(factorThenGapFrame(68), 20);
+    // The 20 px gray run completes 5 rows into this strip (15 + 5): rows [80, 85) are staged, stack 111.
+    // crop = frontier (91) + margin (2) = 93 -> trim 18: the 5 staged rows and the 6 px lag strip are
+    // peeled entirely in RAM (never written), and the arm strip crops 100 -> 93.
+    box.addScrollArea(gapFrame(), 20);
 
     CHECK(box.scrollAreaReady());
     CHECK_FALSE(std::filesystem::exists(dir / path_config.scroll_area.withNumber(1, 5).filename()));
     const cv::Mat frag0 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
-    CHECK(frag0.rows == 96);
+    CHECK(frag0.rows == 93);
 }
 
-TEST_CASE("gray-completion saves the cropped strip and does not trim when the last factor is in-frame (Case B)") {
+TEST_CASE("gray-completion crops the terminating strip when the last factor is in-frame") {
     HookRecorder recorder;
     const auto dir = freshTempDir("uma_gray_trim_caseb");
     scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
     armFactorBox(box);  // fragment 00000 = 100 px
 
-    // Terminating frame: factor [0, 75), gap [75, 100). offset 30 -> frontier 70; the gray run begins at 75
-    // (below the strip top 70) -> Case B. Save strip [70, 75 + margin(2)] = [70, 77] = 7 px; fragment0 stays.
+    // Terminating frame: factor [0, 75), gap [75, 100). offset 30 -> the transition at 75 sets the frontier
+    // to stack row 105; the 20 px run completes at row 94, staging [70, 95) = 25 rows. crop = 105 + 2 = 107
+    // -> trim 18: the staged strip crops to 7 rows; fragment0 stays.
     box.addScrollArea(factorThenGapFrame(75), 30);
 
     CHECK(box.scrollAreaReady());
@@ -318,38 +364,68 @@ TEST_CASE("gray-completion saves the cropped strip and does not trim when the la
     CHECK(frag0.rows == 100);
 }
 
-TEST_CASE("gray-completion crops within the phantom fragment, preserving earlier ones (Case A)") {
+TEST_CASE("gray-completion crops within a middle strip, preserving earlier fragments") {
     HookRecorder recorder;
     const auto dir = freshTempDir("uma_gray_trim_partial");
     scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
-    armFactorBox(box);                                                     // fragment 00000 = 100 px
-    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 30);   // fragment 00001 = 30 px phantom
+    box.addScrollArea(structuredArmFrame(100));   // all factor: stack 100, no transition yet
+    box.addScrollArea(factorThenGapFrame(82), 25);  // strip [75, 100): factor to 81, transition at 82
 
-    // factor [0, 65), gap [65, 100). offset 20 -> frontier 80; Case A. last factor 65 -> crop 67 ->
-    // trim = 80 - 67 = 13 (< phantom's 30): phantom cropped to 30 - 13 = 17, fragment0 untouched.
-    box.addScrollArea(factorThenGapFrame(65), 20);
+    // The transition at frame row 82 puts the frontier at stack row 107; the gap run is 18 px so the box
+    // stays armed (stack 125). The next background strip completes the run 2 rows in (staging 2, stack 127).
+    // crop = 107 + 2 = 109 -> trim 18: the 2 staged rows peel, the 25 px strip crops to 9, the arm strip
+    // (pure factor) is untouched.
+    box.addScrollArea(gapFrame(), 6);
 
     const cv::Mat frag1 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(1, 5).filename());
-    CHECK(frag1.rows == 17);
+    CHECK(frag1.rows == 9);
     const cv::Mat frag0 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
     CHECK(frag0.rows == 100);
+    CHECK_FALSE(std::filesystem::exists(dir / path_config.scroll_area.withNumber(2, 5).filename()));
 }
 
-TEST_CASE("gray-completion is a no-op when the last factor sits at the frontier (Case A)") {
+TEST_CASE("gray-completion never over-trims a factor ending exactly at a strip boundary") {
     HookRecorder recorder;
-    const auto dir = freshTempDir("uma_gray_trim_noop");
+    const auto dir = freshTempDir("uma_gray_trim_boundary");
     scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
-    armFactorBox(box);                                                     // fragment 00000 = 100 px
-    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 10);   // fragment 00001 = 10 px
+    box.addScrollArea(structuredArmFrame(100));  // all factor: the last factor row is the strip's bottom row
 
-    // factor [0, 78), gap [78, 100). offset 20 -> frontier 80; Case A. last factor 78 -> crop 78 + 2 = 80 ==
-    // frontier -> trim 0: nothing peeled.
-    box.addScrollArea(factorThenGapFrame(78), 20);
+    // The background run starts exactly at the next strip's top. current_length_pixels survives across
+    // frames and is zero here (the previous strip ended non-background), so the transition is recorded at
+    // the boundary: frontier = stack row 100.
+    box.addScrollArea(gapFrame(), 18);  // gap run 18 px < 20, stack 118
+
+    // The run completes 2 rows into the next strip (staging 2, stack 120). crop = 100 + 2 = 102 -> trim 18:
+    // the staged rows peel, the 18 px strip crops to 2 margin rows, and the factor strip is fully kept.
+    box.addScrollArea(gapFrame(), 6);
 
     const cv::Mat frag0 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
     CHECK(frag0.rows == 100);
     const cv::Mat frag1 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(1, 5).filename());
-    CHECK(frag1.rows == 10);
+    CHECK(frag1.rows == 2);
+}
+
+TEST_CASE("gray-completion keeps a stray non-background strip below the factor (ghost repair out of scope)") {
+    HookRecorder recorder;
+    const auto dir = freshTempDir("uma_gray_trim_stray");
+    scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
+    box.addScrollArea(structuredArmFrame(91));                            // stack 100, frontier 91
+    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 6);  // stray non-background strip
+
+    // The stray strip resets the run, so the terminating strip's top row is a boundary transition: the
+    // frontier moves to stack row 106, below the stray. Latch evidence alone cannot tell a stray from a
+    // factor ending at the boundary (see the boundary test above), so the crop refuses to reach past the
+    // transition: the stray survives and factor rows are never cut. Repairing mis-latched (ghost) strips is
+    // an alignment concern, out of scope here. The full 20 px run stages [80, 100), stack 126; crop = 108
+    // -> trim 18 crops the staged rows to 2.
+    box.addScrollArea(gapFrame(), 20);
+
+    const cv::Mat frag0 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
+    CHECK(frag0.rows == 100);
+    const cv::Mat frag1 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(1, 5).filename());
+    CHECK(frag1.rows == 6);
+    const cv::Mat frag2 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(2, 5).filename());
+    CHECK(frag2.rows == 2);
 }
 
 // --- delayed commit: the factor box stages its tail in RAM and flushes on terminal exits ----------------
@@ -376,42 +452,45 @@ TEST_CASE("delayed commit stages the factor tail and flushes strips past the hol
     const auto dir = freshTempDir("uma_delayed_stage");
     scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
 
-    // The arm strip (100 px) is the whole tail: nothing on disk yet.
-    armFactorBox(box);
+    // The arm strip (100 px, pure factor) is the whole tail: nothing on disk yet.
+    box.addScrollArea(structuredArmFrame(100));
     CHECK(scrollAreaFileCount(dir) == 0);
 
     // A second 50 px strip pushes the arm strip past the 36 px holdback: it flushes as 00000, while the
-    // 50 px strip itself stays staged.
-    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 50);
+    // 50 px strip itself stays staged. Factor to frame row 90, transition at 91 -> frontier stack row 141,
+    // gap run 9 px (< 20, still armed).
+    box.addScrollArea(factorThenGapFrame(91), 50);
     CHECK(std::filesystem::exists(dir / path_config.scroll_area.withNumber(0, 5).filename()));
     CHECK(scrollAreaFileCount(dir) == 1);
 
-    // Gray termination (factor [0, 68), gap [68, 100), offset 20 -> frontier 80, trim 10) crops the staged
-    // 50 px strip in RAM to 40 px and drains the tail: the final set is contiguous and complete.
-    box.addScrollArea(factorThenGapFrame(68), 20);
+    // Gray termination: the run completes 11 rows into this background strip (staging 11, stack 161).
+    // crop = 141 + 2 = 143 -> trim 18: the staged rows peel and the 50 px strip crops in RAM to 43. The
+    // final set is contiguous and complete.
+    box.addScrollArea(gapFrame(), 20);
     CHECK(box.scrollAreaReady());
     CHECK(scrollAreaFileCount(dir) == 2);
     const cv::Mat frag0 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
     CHECK(frag0.rows == 100);
     const cv::Mat frag1 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(1, 5).filename());
-    CHECK(frag1.rows == 40);
+    CHECK(frag1.rows == 43);
 }
 
 TEST_CASE("delayed commit keeps committed indices contiguous when a staged strip is peeled") {
     HookRecorder recorder;
     const auto dir = freshTempDir("uma_delayed_peel_contiguous");
     scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
-    armFactorBox(box);                                                     // staged: 100 px
-    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 50);   // flushes 00000; staged: 50 px
-    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 6);    // staged: 50 + 6 px phantom
+    box.addScrollArea(structuredArmFrame(100));      // staged: 100 px, pure factor
+    box.addScrollArea(factorThenGapFrame(91), 50);   // flushes 00000; staged: 50 px, frontier 141, run 9 px
+    box.addScrollArea(gapFrame(), 6);                // lag strip: staged 50 + 6 px, run 15 px
 
-    // Gray termination with trim 10: the 6 px phantom is peeled entirely in RAM (never written), the 50 px
-    // strip is cropped to 46, and the flushed names have no gap for the stitcher's lexical enumeration.
-    box.addScrollArea(factorThenGapFrame(68), 20);
+    // The run completes 5 rows into this strip (staging 5, stack 161). crop = 143 -> trim 18: the staged
+    // rows and the 6 px lag strip peel entirely in RAM (never written), the 50 px strip crops to 43, and
+    // the flushed names have no gap for the stitcher's lexical enumeration.
+    box.addScrollArea(gapFrame(), 20);
     CHECK(scrollAreaFileCount(dir) == 2);
     CHECK_FALSE(std::filesystem::exists(dir / path_config.scroll_area.withNumber(2, 5).filename()));
     const cv::Mat frag1 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(1, 5).filename());
-    CHECK(frag1.rows == 46);
+    CHECK(frag1.rows == 43);
 }
 
 TEST_CASE("non-factor boxes write through immediately") {

--- a/native/test/chara_detail/test_scraping_box.cpp
+++ b/native/test/chara_detail/test_scraping_box.cpp
@@ -121,7 +121,7 @@ Frame greenBarFrame(int y0, int bar_height) {
 }
 
 // Consumes scan0 with a full gray frame, so current_scan is parked at the (never matched) scan1 and
-// image_count > 0 -- i.e. the probe is armed. Mutates the box in place (returning it by value would
+// fragmentCount() > 0 -- i.e. the probe is armed. Mutates the box in place (returning it by value would
 // leave current_scan, an iterator into the box's own vector, dangling into the moved-from source).
 void armBox(scraper_impl::PageScrapingBox &box) {
     box.addScrollArea(Frame::fixed(testutil::solid(100, kGray)));
@@ -135,7 +135,7 @@ TEST_CASE("detectGreenTerminator does not fire before scan0 is consumed (not arm
     scraper_impl::PageScrapingBox box(
         {kGrayScan0, kAbsentScan1}, freshTempDir("uma_probe_unarmed"), recorder.hooks(), kGreenTerminator);
 
-    // current_scan is still at begin() and image_count == 0: a green bar must not complete the tab.
+    // current_scan is still at begin() and fragmentCount() == 0: a green bar must not complete the tab.
     CHECK_FALSE(box.detectGreenTerminator(greenBarFrame(72, 10), kOffset));
     CHECK_FALSE(box.scrollAreaReady());
 }
@@ -350,6 +350,102 @@ TEST_CASE("gray-completion is a no-op when the last factor sits at the frontier 
     CHECK(frag0.rows == 100);
     const cv::Mat frag1 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(1, 5).filename());
     CHECK(frag1.rows == 10);
+}
+
+// --- delayed commit: the factor box stages its tail in RAM and flushes on terminal exits ----------------
+//
+// The factor box no longer writes each strip to disk as it is latched: strips are staged in a RAM tail so
+// the terminator-time trim never has to decode/re-save committed PNGs and phantom overscroll strips never
+// reach disk at all. The tail holdback is the worst-case trim depth: on a 100 px frame,
+// back().length (0.2) + the gray search span (0.16) -> 36 px. Strips older than that are flushed as they
+// can never be trimmed; every terminal exit (gray completion, green trim, setScrollArea) drains the tail.
+
+int scrollAreaFileCount(const std::filesystem::path &dir) {
+    int count = 0;
+    for (const auto &entry : std::filesystem::directory_iterator(dir)) {
+        if (entry.is_regular_file()
+            && stds::starts_with(entry.path().filename().string(), path_config.scroll_area.stem())) {
+            count++;
+        }
+    }
+    return count;
+}
+
+TEST_CASE("delayed commit stages the factor tail and flushes strips past the holdback") {
+    HookRecorder recorder;
+    const auto dir = freshTempDir("uma_delayed_stage");
+    scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
+
+    // The arm strip (100 px) is the whole tail: nothing on disk yet.
+    armFactorBox(box);
+    CHECK(scrollAreaFileCount(dir) == 0);
+
+    // A second 50 px strip pushes the arm strip past the 36 px holdback: it flushes as 00000, while the
+    // 50 px strip itself stays staged.
+    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 50);
+    CHECK(std::filesystem::exists(dir / path_config.scroll_area.withNumber(0, 5).filename()));
+    CHECK(scrollAreaFileCount(dir) == 1);
+
+    // Gray termination (factor [0, 68), gap [68, 100), offset 20 -> frontier 80, trim 10) crops the staged
+    // 50 px strip in RAM to 40 px and drains the tail: the final set is contiguous and complete.
+    box.addScrollArea(factorThenGapFrame(68), 20);
+    CHECK(box.scrollAreaReady());
+    CHECK(scrollAreaFileCount(dir) == 2);
+    const cv::Mat frag0 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(0, 5).filename());
+    CHECK(frag0.rows == 100);
+    const cv::Mat frag1 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(1, 5).filename());
+    CHECK(frag1.rows == 40);
+}
+
+TEST_CASE("delayed commit keeps committed indices contiguous when a staged strip is peeled") {
+    HookRecorder recorder;
+    const auto dir = freshTempDir("uma_delayed_peel_contiguous");
+    scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
+    armFactorBox(box);                                                     // staged: 100 px
+    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 50);   // flushes 00000; staged: 50 px
+    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)), 6);    // staged: 50 + 6 px phantom
+
+    // Gray termination with trim 10: the 6 px phantom is peeled entirely in RAM (never written), the 50 px
+    // strip is cropped to 46, and the flushed names have no gap for the stitcher's lexical enumeration.
+    box.addScrollArea(factorThenGapFrame(68), 20);
+    CHECK(scrollAreaFileCount(dir) == 2);
+    CHECK_FALSE(std::filesystem::exists(dir / path_config.scroll_area.withNumber(2, 5).filename()));
+    const cv::Mat frag1 = Frame::decodeBgr(dir / path_config.scroll_area.withNumber(1, 5).filename());
+    CHECK(frag1.rows == 46);
+}
+
+TEST_CASE("non-factor boxes write through immediately") {
+    HookRecorder recorder;
+    const auto dir = freshTempDir("uma_writethrough");
+    scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks());  // no end_green
+
+    box.addScrollArea(Frame::fixed(testutil::solid(100, kArmGray)));
+
+    CHECK(std::filesystem::exists(dir / path_config.scroll_area.withNumber(0, 5).filename()));
+}
+
+TEST_CASE("discarding the box abandons the staged tail without flushing") {
+    HookRecorder recorder;
+    const auto dir = freshTempDir("uma_delayed_abandon");
+    {
+        scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
+        armFactorBox(box);  // staged, not on disk
+        CHECK(scrollAreaFileCount(dir) == 0);
+    }
+    // Reset paths drop the box (recreate()/release() replace the shared_ptr) and rmdir the directory; a
+    // destructor flush would resurrect strips the reset meant to discard.
+    CHECK(scrollAreaFileCount(dir) == 0);
+}
+
+TEST_CASE("setScrollArea on a factor box commits its sole strip immediately") {
+    HookRecorder recorder;
+    const auto dir = freshTempDir("uma_delayed_set_scroll_area");
+    scraper_impl::PageScrapingBox box({kArmScan, kGapScan}, dir, recorder.hooks(), kGreenEnd);
+
+    box.setScrollArea(Frame::fixed(testutil::solid(100, kArmGray)));
+
+    CHECK(std::filesystem::exists(dir / path_config.scroll_area.withNumber(0, 5).filename()));
+    CHECK(box.scrollAreaReady());
 }
 
 }  // namespace

--- a/native/test/cv/test_ffv1_roundtrip.cpp
+++ b/native/test/cv/test_ffv1_roundtrip.cpp
@@ -1,0 +1,116 @@
+// Round-trip test for the FFV1 recorder/reader: encode a set of BGR frames to a lossless FFV1 .mkv and
+// decode them back, asserting the pixels are BIT-EXACT and the per-frame millisecond timestamps reproduce
+// the original inter-frame deltas (which is what the recognition debounce keys off). This target links
+// libav directly (unlike the opencv-only umacapture_tests), so it is built separately.
+
+#include <filesystem>
+#include <vector>
+
+#include <doctest/doctest.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+#include <opencv2/opencv.hpp>
+#pragma clang diagnostic pop
+
+#include "cv/ffv1_reader.h"
+#include "cv/ffv1_recorder.h"
+#include "cv/frame.h"
+#include "types/shape.h"
+#include "util/event_util.h"
+
+namespace uma {
+namespace {
+
+// A deterministic BGR pattern with per-channel gradients that span the full 0..255 range (the corners are
+// pinned to pure black and white), so a lossy colorspace conversion would corrupt at least one sample.
+cv::Mat makePattern(int width, int height, int seed) {
+    cv::Mat image(height, width, CV_8UC3);
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            const auto b = static_cast<uchar>((x * 7 + seed) % 256);
+            const auto g = static_cast<uchar>((y * 13 + seed * 3) % 256);
+            const auto r = static_cast<uchar>(((x + y) * 5 + seed * 7) % 256);
+            image.at<cv::Vec3b>(y, x) = cv::Vec3b(b, g, r);
+        }
+    }
+    image.at<cv::Vec3b>(0, 0) = cv::Vec3b(0, 0, 0);
+    image.at<cv::Vec3b>(height - 1, width - 1) = cv::Vec3b(255, 255, 255);
+    return image;
+}
+
+std::vector<Frame> roundTrip(const std::filesystem::path &path, const std::vector<Frame> &inputs) {
+    const auto size = inputs.front().size();
+    {
+        video::Ffv1Recorder recorder(path, size);
+        for (const auto &frame : inputs) {
+            recorder.push(frame);
+        }
+        recorder.close();
+    }
+
+    const auto connection = event_util::makeDirectConnection<Frame, Size<int>>();
+    std::vector<Frame> received;
+    connection->listen([&received](const Frame &frame, const Size<int> &) { received.push_back(frame.clone()); });
+
+    video::Ffv1Reader reader(path, connection);
+    reader.run();
+    return received;
+}
+
+bool bitExact(const cv::Mat &a, const cv::Mat &b) {
+    if (a.size() != b.size() || a.type() != b.type()) {
+        return false;
+    }
+    cv::Mat diff;
+    cv::absdiff(a, b, diff);
+    return cv::countNonZero(diff.reshape(1)) == 0;
+}
+
+TEST_CASE("FFV1 round-trip preserves pixels bit-exactly and reproduces timestamp deltas") {
+    const auto path = std::filesystem::temp_directory_path() / "uma_ffv1_roundtrip.mkv";
+    std::filesystem::remove(path);
+
+    // Odd dimensions on purpose: the bgr0 pixel format has no even-size requirement (unlike yuv420p), and
+    // this guards against any accidental subsampled pixel format slipping in.
+    const std::vector<uint64> timestamps = {1000, 1200, 2200};
+    std::vector<Frame> inputs;
+    inputs.reserve(timestamps.size());
+    for (size_t i = 0; i < timestamps.size(); ++i) {
+        inputs.emplace_back(makePattern(33, 17, static_cast<int>(i) * 40 + 1), timestamps[i]);
+    }
+
+    const auto received = roundTrip(path, inputs);
+
+    REQUIRE(received.size() == inputs.size());
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        CHECK(bitExact(received[i].data(), inputs[i].data()));
+    }
+
+    // The recorder rebases PTS to the first frame's timestamp, so absolute values start at 0 but the
+    // inter-frame deltas -- the only thing the pipeline consumes -- are preserved exactly.
+    CHECK(received[1].timestamp() - received[0].timestamp() == timestamps[1] - timestamps[0]);
+    CHECK(received[2].timestamp() - received[1].timestamp() == timestamps[2] - timestamps[1]);
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("FFV1 recorder writes through non-ASCII paths") {
+    const auto path = std::filesystem::temp_directory_path() / std::filesystem::u8path("uma_テスト_ffv1.mkv");
+    std::filesystem::remove(path);
+
+    std::vector<Frame> inputs;
+    inputs.emplace_back(makePattern(16, 16, 5), 500);
+    inputs.emplace_back(makePattern(16, 16, 9), 700);
+
+    const auto received = roundTrip(path, inputs);
+
+    REQUIRE(received.size() == inputs.size());
+    CHECK(bitExact(received[0].data(), inputs[0].data()));
+    CHECK(bitExact(received[1].data(), inputs[1].data()));
+
+    std::filesystem::remove(path);
+}
+
+}  // namespace
+}  // namespace uma

--- a/native/test/integration/cases.json
+++ b/native/test/integration/cases.json
@@ -1,8 +1,10 @@
 {
   "comment": [
     "Integration golden cases for native/test/integration/run.py.",
-    "Each case runs `umacapture_cli video` over `video` (resolved under --data-dir, default .notes)",
-    "and compares the recognized record.json set against `golden`.",
+    "Each case runs umacapture_cli over `video` (resolved under --data-dir, default .notes) and",
+    "compares the recognized record.json set against `golden`. The input extension picks the",
+    "subcommand: `.mp4` (or other plain clip) -> `video` (OpenCV decode); `.mkv` -> `replay`",
+    "(a lossless FFV1 recording replayed frame-for-frame).",
     "Videos live under .notes/ and are NOT committed; goldens ARE committed (regression baseline).",
     "A case whose video is absent is skipped, so this manifest may list more clips than any one",
     "machine has locally. Add a case here + regenerate its golden with run.py --update-golden."

--- a/native/test/integration/cases.json
+++ b/native/test/integration/cases.json
@@ -14,6 +14,9 @@
     { "name": "friend_inheritance", "video": "friend_inheritance.mp4", "golden": "golden/friend_inheritance.json" },
     { "name": "player_standard_scrollbar_change_1", "video": "player_standard_scrollbar_change_1.mp4", "golden": "golden/player_standard_scrollbar_change_1.json" },
     { "name": "player_standard_scrollbar_change_2", "video": "player_standard_scrollbar_change_2.mp4", "golden": "golden/player_standard_scrollbar_change_2.json" },
-    { "name": "player_standard_sequential", "video": "player_standard_sequential.mp4", "golden": "golden/player_standard_sequential.json" }
+    { "name": "player_standard_sequential", "video": "player_standard_sequential.mp4", "golden": "golden/player_standard_sequential.json" },
+    { "name": "player_standard_2", "video": "player_standard_2.mp4", "golden": "golden/player_standard_2.json" },
+    { "name": "player_standard_3", "video": "player_standard_3.mp4", "golden": "golden/player_standard_3.json" },
+    { "name": "player_standard_4", "video": "player_standard_4.mp4", "golden": "golden/player_standard_4.json" }
   ]
 }

--- a/native/test/integration/golden/friend_inheritance.json
+++ b/native/test/integration/golden/friend_inheritance.json
@@ -395,7 +395,7 @@
     "fans": 0,
     "metadata": {
       "format_version": "1.0.0",
-      "recognizer_version": "2026-06-29T11:00:00+0900",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
       "record_type": "FriendInheritance",
       "region": "JPN",
       "stage": "active",

--- a/native/test/integration/golden/friend_standard.json
+++ b/native/test/integration/golden/friend_standard.json
@@ -319,7 +319,7 @@
     "fans": 400022,
     "metadata": {
       "format_version": "1.0.0",
-      "recognizer_version": "2026-06-29T11:00:00+0900",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
       "record_type": "FriendStandard",
       "region": "JPN",
       "stage": "active",

--- a/native/test/integration/golden/player_inheritance.json
+++ b/native/test/integration/golden/player_inheritance.json
@@ -439,7 +439,7 @@
     "fans": 0,
     "metadata": {
       "format_version": "1.0.0",
-      "recognizer_version": "2026-06-29T11:00:00+0900",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
       "record_type": "InheritanceOnly",
       "region": "JPN",
       "stage": "active",

--- a/native/test/integration/golden/player_standard.json
+++ b/native/test/integration/golden/player_standard.json
@@ -415,7 +415,7 @@
     "fans": 240863,
     "metadata": {
       "format_version": "1.0.0",
-      "recognizer_version": "2026-06-29T11:00:00+0900",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
       "record_type": "Standard",
       "region": "JPN",
       "stage": "active",

--- a/native/test/integration/golden/player_standard_2.json
+++ b/native/test/integration/golden/player_standard_2.json
@@ -1,0 +1,765 @@
+[
+  {
+    "aptitudes": {
+      "distance": {
+        "long_range": 7,
+        "middle_range": 6,
+        "mile_range": 6,
+        "short_range": 0
+      },
+      "ground": {
+        "dirt": 0,
+        "turf": 6
+      },
+      "style": {
+        "late_charge": 2,
+        "lead_pace": 0,
+        "off_pace": 4,
+        "with_pace": 6
+      }
+    },
+    "evaluation_value": 55334,
+    "factors": {
+      "parent1": [
+        {
+          "id": 147,
+          "star": 2
+        },
+        {
+          "id": 142,
+          "star": 3
+        },
+        {
+          "id": 772,
+          "star": 2
+        },
+        {
+          "id": 95,
+          "star": 1
+        },
+        {
+          "id": 116,
+          "star": 2
+        },
+        {
+          "id": 263,
+          "star": 2
+        },
+        {
+          "id": 56,
+          "star": 2
+        },
+        {
+          "id": 273,
+          "star": 1
+        },
+        {
+          "id": 51,
+          "star": 1
+        },
+        {
+          "id": 292,
+          "star": 2
+        },
+        {
+          "id": 284,
+          "star": 2
+        },
+        {
+          "id": 275,
+          "star": 2
+        },
+        {
+          "id": 84,
+          "star": 1
+        },
+        {
+          "id": 62,
+          "star": 2
+        },
+        {
+          "id": 434,
+          "star": 2
+        },
+        {
+          "id": 450,
+          "star": 3
+        },
+        {
+          "id": 477,
+          "star": 2
+        },
+        {
+          "id": 591,
+          "star": 1
+        },
+        {
+          "id": 592,
+          "star": 2
+        },
+        {
+          "id": 722,
+          "star": 3
+        },
+        {
+          "id": 718,
+          "star": 1
+        },
+        {
+          "id": 760,
+          "star": 2
+        },
+        {
+          "id": 759,
+          "star": 2
+        },
+        {
+          "id": 758,
+          "star": 2
+        },
+        {
+          "id": 651,
+          "star": 2
+        },
+        {
+          "id": 657,
+          "star": 1
+        },
+        {
+          "id": 625,
+          "star": 3
+        },
+        {
+          "id": 626,
+          "star": 2
+        },
+        {
+          "id": 641,
+          "star": 2
+        }
+      ],
+      "parent2": [
+        {
+          "id": 8,
+          "star": 3
+        },
+        {
+          "id": 142,
+          "star": 3
+        },
+        {
+          "id": 587,
+          "star": 3
+        },
+        {
+          "id": 225,
+          "star": 2
+        },
+        {
+          "id": 108,
+          "star": 3
+        },
+        {
+          "id": 74,
+          "star": 2
+        },
+        {
+          "id": 56,
+          "star": 2
+        },
+        {
+          "id": 51,
+          "star": 1
+        },
+        {
+          "id": 239,
+          "star": 2
+        },
+        {
+          "id": 354,
+          "star": 2
+        },
+        {
+          "id": 234,
+          "star": 1
+        },
+        {
+          "id": 135,
+          "star": 1
+        },
+        {
+          "id": 132,
+          "star": 1
+        },
+        {
+          "id": 188,
+          "star": 2
+        },
+        {
+          "id": 162,
+          "star": 2
+        },
+        {
+          "id": 262,
+          "star": 2
+        },
+        {
+          "id": 170,
+          "star": 2
+        },
+        {
+          "id": 84,
+          "star": 2
+        },
+        {
+          "id": 477,
+          "star": 2
+        },
+        {
+          "id": 479,
+          "star": 2
+        },
+        {
+          "id": 555,
+          "star": 2
+        },
+        {
+          "id": 566,
+          "star": 2
+        },
+        {
+          "id": 563,
+          "star": 2
+        },
+        {
+          "id": 709,
+          "star": 1
+        },
+        {
+          "id": 708,
+          "star": 2
+        },
+        {
+          "id": 760,
+          "star": 2
+        },
+        {
+          "id": 375,
+          "star": 2
+        },
+        {
+          "id": 759,
+          "star": 2
+        },
+        {
+          "id": 758,
+          "star": 2
+        },
+        {
+          "id": 651,
+          "star": 2
+        },
+        {
+          "id": 670,
+          "star": 3
+        },
+        {
+          "id": 625,
+          "star": 2
+        },
+        {
+          "id": 661,
+          "star": 3
+        }
+      ],
+      "self": [
+        {
+          "id": 147,
+          "star": 2
+        },
+        {
+          "id": 142,
+          "star": 2
+        },
+        {
+          "id": 705,
+          "star": 2
+        },
+        {
+          "id": 70,
+          "star": 1
+        },
+        {
+          "id": 234,
+          "star": 2
+        },
+        {
+          "id": 135,
+          "star": 2
+        },
+        {
+          "id": 188,
+          "star": 2
+        },
+        {
+          "id": 183,
+          "star": 3
+        },
+        {
+          "id": 170,
+          "star": 2
+        },
+        {
+          "id": 84,
+          "star": 1
+        },
+        {
+          "id": 62,
+          "star": 2
+        },
+        {
+          "id": 387,
+          "star": 3
+        },
+        {
+          "id": 450,
+          "star": 2
+        },
+        {
+          "id": 475,
+          "star": 2
+        },
+        {
+          "id": 477,
+          "star": 2
+        },
+        {
+          "id": 573,
+          "star": 2
+        },
+        {
+          "id": 600,
+          "star": 3
+        },
+        {
+          "id": 704,
+          "star": 2
+        },
+        {
+          "id": 722,
+          "star": 3
+        },
+        {
+          "id": 760,
+          "star": 2
+        },
+        {
+          "id": 759,
+          "star": 1
+        },
+        {
+          "id": 758,
+          "star": 1
+        },
+        {
+          "id": 651,
+          "star": 3
+        },
+        {
+          "id": 679,
+          "star": 1
+        },
+        {
+          "id": 640,
+          "star": 1
+        },
+        {
+          "id": 657,
+          "star": 2
+        }
+      ]
+    },
+    "family": {
+      "parent1": {
+        "parent1": {
+          "card": 212,
+          "character": 114,
+          "icon": 466,
+          "rank": 74,
+          "record_type": "Standard"
+        },
+        "parent2": {
+          "card": 189,
+          "character": 83,
+          "icon": 419,
+          "rank": 43,
+          "record_type": "Standard"
+        },
+        "self": {
+          "card": 234,
+          "character": 7,
+          "icon": 510,
+          "rank": 68,
+          "record_type": "Standard"
+        }
+      },
+      "parent2": {
+        "parent1": {
+          "card": 210,
+          "character": 85,
+          "icon": 463,
+          "rank": 47,
+          "record_type": "Standard"
+        },
+        "parent2": {
+          "card": 86,
+          "character": 2,
+          "icon": 202,
+          "rank": 62,
+          "record_type": "Standard"
+        },
+        "rental": true,
+        "self": {
+          "card": 189,
+          "character": 83,
+          "icon": 419,
+          "rank": 43,
+          "record_type": "Standard"
+        }
+      }
+    },
+    "fans": 302959,
+    "metadata": {
+      "format_version": "1.0.0",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
+      "record_type": "Standard",
+      "region": "JPN",
+      "stage": "active",
+      "strategy": 1
+    },
+    "races": [
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 1,
+        "title": 242,
+        "turn": 73,
+        "variation": 5,
+        "weather": 10
+      },
+      {
+        "distance": 14,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 1,
+        "title": 265,
+        "turn": 73,
+        "variation": 2,
+        "weather": 5
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 1,
+        "title": 45,
+        "turn": 73,
+        "variation": 5,
+        "weather": 4
+      },
+      {
+        "distance": 15,
+        "ground": 0,
+        "place": 4,
+        "position": 1,
+        "strategy": 1,
+        "title": 212,
+        "turn": 71,
+        "variation": 5,
+        "weather": 10
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 7,
+        "position": 2,
+        "strategy": 1,
+        "title": 269,
+        "turn": 67,
+        "variation": 2,
+        "weather": 0
+      },
+      {
+        "distance": 12,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 1,
+        "title": 153,
+        "turn": 59,
+        "variation": 5,
+        "weather": 11
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 1,
+        "title": 270,
+        "turn": 53,
+        "variation": 5,
+        "weather": 0
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 1,
+        "title": 202,
+        "turn": 43,
+        "variation": 5,
+        "weather": 0
+      },
+      {
+        "distance": 14,
+        "ground": 0,
+        "place": 7,
+        "position": 2,
+        "strategy": 1,
+        "title": 5,
+        "turn": 33,
+        "variation": 2,
+        "weather": 1
+      },
+      {
+        "distance": 6,
+        "ground": 0,
+        "place": 2,
+        "position": 2,
+        "strategy": 1,
+        "title": 238,
+        "turn": 30,
+        "variation": 3,
+        "weather": 0
+      },
+      {
+        "distance": 6,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 1,
+        "title": 26,
+        "turn": 22,
+        "variation": 3,
+        "weather": 4
+      },
+      {
+        "distance": 8,
+        "ground": 0,
+        "place": 8,
+        "position": 1,
+        "strategy": 1,
+        "title": 273,
+        "turn": 11,
+        "variation": 1,
+        "weather": 11
+      }
+    ],
+    "scenario": {
+      "id": 11
+    },
+    "skills": [
+      {
+        "id": 1478,
+        "level": 6
+      },
+      {
+        "id": 1329
+      },
+      {
+        "id": 1473
+      },
+      {
+        "id": 1647
+      },
+      {
+        "id": 32
+      },
+      {
+        "id": 115
+      },
+      {
+        "id": 182
+      },
+      {
+        "id": 132
+      },
+      {
+        "id": 85
+      },
+      {
+        "id": 409
+      },
+      {
+        "id": 382
+      },
+      {
+        "id": 220
+      },
+      {
+        "id": 318
+      },
+      {
+        "id": 8
+      },
+      {
+        "id": 275
+      },
+      {
+        "id": 481
+      },
+      {
+        "id": 320
+      },
+      {
+        "id": 128
+      },
+      {
+        "id": 240
+      },
+      {
+        "id": 13
+      },
+      {
+        "id": 466
+      },
+      {
+        "id": 489
+      },
+      {
+        "id": 552
+      },
+      {
+        "id": 597
+      },
+      {
+        "id": 599
+      },
+      {
+        "id": 754
+      },
+      {
+        "id": 882
+      },
+      {
+        "id": 932
+      },
+      {
+        "id": 974
+      },
+      {
+        "id": 1306
+      },
+      {
+        "id": 1614
+      },
+      {
+        "id": 1095
+      },
+      {
+        "id": 1476
+      },
+      {
+        "id": 1239
+      },
+      {
+        "id": 1280
+      },
+      {
+        "id": 1302
+      },
+      {
+        "id": 1339
+      },
+      {
+        "id": 1338
+      },
+      {
+        "id": 1477
+      },
+      {
+        "id": 1408
+      },
+      {
+        "id": 1479
+      },
+      {
+        "id": 1525
+      },
+      {
+        "id": 1600
+      },
+      {
+        "id": 1610
+      },
+      {
+        "id": 1494
+      },
+      {
+        "id": 1613
+      }
+    ],
+    "status": {
+      "guts": 1331,
+      "intelligence": 1343,
+      "power": 1249,
+      "speed": 1959,
+      "stamina": 1814
+    },
+    "support_cards": [
+      {
+        "id": 416,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 496,
+        "level": 0,
+        "rank": 1
+      },
+      {
+        "id": 497,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 427,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 437,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 501,
+        "level": 0,
+        "rank": 5
+      }
+    ],
+    "trained_date": "2026/01/24",
+    "trainee": {
+      "card": 212,
+      "character": 114,
+      "icon": 466,
+      "rank": 78
+    }
+  }
+]

--- a/native/test/integration/golden/player_standard_3.json
+++ b/native/test/integration/golden/player_standard_3.json
@@ -1,0 +1,793 @@
+[
+  {
+    "aptitudes": {
+      "distance": {
+        "long_range": 7,
+        "middle_range": 6,
+        "mile_range": 3,
+        "short_range": 3
+      },
+      "ground": {
+        "dirt": 2,
+        "turf": 6
+      },
+      "style": {
+        "late_charge": 5,
+        "lead_pace": 6,
+        "off_pace": 5,
+        "with_pace": 6
+      }
+    },
+    "evaluation_value": 62346,
+    "factors": {
+      "parent1": [
+        {
+          "id": 147,
+          "star": 2
+        },
+        {
+          "id": 142,
+          "star": 3
+        },
+        {
+          "id": 772,
+          "star": 2
+        },
+        {
+          "id": 95,
+          "star": 1
+        },
+        {
+          "id": 116,
+          "star": 2
+        },
+        {
+          "id": 263,
+          "star": 2
+        },
+        {
+          "id": 56,
+          "star": 2
+        },
+        {
+          "id": 273,
+          "star": 1
+        },
+        {
+          "id": 51,
+          "star": 1
+        },
+        {
+          "id": 292,
+          "star": 2
+        },
+        {
+          "id": 284,
+          "star": 2
+        },
+        {
+          "id": 275,
+          "star": 2
+        },
+        {
+          "id": 84,
+          "star": 1
+        },
+        {
+          "id": 62,
+          "star": 2
+        },
+        {
+          "id": 434,
+          "star": 2
+        },
+        {
+          "id": 450,
+          "star": 3
+        },
+        {
+          "id": 477,
+          "star": 2
+        },
+        {
+          "id": 591,
+          "star": 1
+        },
+        {
+          "id": 592,
+          "star": 2
+        },
+        {
+          "id": 722,
+          "star": 3
+        },
+        {
+          "id": 718,
+          "star": 1
+        },
+        {
+          "id": 760,
+          "star": 2
+        },
+        {
+          "id": 759,
+          "star": 2
+        },
+        {
+          "id": 758,
+          "star": 2
+        },
+        {
+          "id": 651,
+          "star": 2
+        },
+        {
+          "id": 657,
+          "star": 1
+        },
+        {
+          "id": 625,
+          "star": 3
+        },
+        {
+          "id": 626,
+          "star": 2
+        },
+        {
+          "id": 641,
+          "star": 2
+        }
+      ],
+      "parent2": [
+        {
+          "id": 147,
+          "star": 3
+        },
+        {
+          "id": 142,
+          "star": 3
+        },
+        {
+          "id": 140,
+          "star": 3
+        },
+        {
+          "id": 108,
+          "star": 2
+        },
+        {
+          "id": 96,
+          "star": 2
+        },
+        {
+          "id": 282,
+          "star": 2
+        },
+        {
+          "id": 163,
+          "star": 2
+        },
+        {
+          "id": 3,
+          "star": 3
+        },
+        {
+          "id": 70,
+          "star": 2
+        },
+        {
+          "id": 57,
+          "star": 1
+        },
+        {
+          "id": 0,
+          "star": 3
+        },
+        {
+          "id": 23,
+          "star": 2
+        },
+        {
+          "id": 137,
+          "star": 2
+        },
+        {
+          "id": 491,
+          "star": 3
+        },
+        {
+          "id": 560,
+          "star": 2
+        },
+        {
+          "id": 573,
+          "star": 2
+        },
+        {
+          "id": 571,
+          "star": 3
+        },
+        {
+          "id": 621,
+          "star": 1
+        },
+        {
+          "id": 684,
+          "star": 2
+        },
+        {
+          "id": 709,
+          "star": 2
+        },
+        {
+          "id": 754,
+          "star": 1
+        },
+        {
+          "id": 760,
+          "star": 2
+        },
+        {
+          "id": 209,
+          "star": 3
+        },
+        {
+          "id": 375,
+          "star": 2
+        },
+        {
+          "id": 409,
+          "star": 2
+        },
+        {
+          "id": 759,
+          "star": 2
+        },
+        {
+          "id": 674,
+          "star": 2
+        },
+        {
+          "id": 658,
+          "star": 2
+        },
+        {
+          "id": 657,
+          "star": 2
+        },
+        {
+          "id": 628,
+          "star": 1
+        },
+        {
+          "id": 625,
+          "star": 2
+        },
+        {
+          "id": 666,
+          "star": 1
+        }
+      ],
+      "self": [
+        {
+          "id": 246,
+          "star": 2
+        },
+        {
+          "id": 142,
+          "star": 2
+        },
+        {
+          "id": 567,
+          "star": 2
+        },
+        {
+          "id": 96,
+          "star": 2
+        },
+        {
+          "id": 190,
+          "star": 2
+        },
+        {
+          "id": 0,
+          "star": 3
+        },
+        {
+          "id": 123,
+          "star": 1
+        },
+        {
+          "id": 117,
+          "star": 2
+        },
+        {
+          "id": 23,
+          "star": 1
+        },
+        {
+          "id": 174,
+          "star": 2
+        },
+        {
+          "id": 172,
+          "star": 2
+        },
+        {
+          "id": 170,
+          "star": 1
+        },
+        {
+          "id": 84,
+          "star": 2
+        },
+        {
+          "id": 477,
+          "star": 3
+        },
+        {
+          "id": 593,
+          "star": 2
+        },
+        {
+          "id": 651,
+          "star": 2
+        },
+        {
+          "id": 669,
+          "star": 2
+        }
+      ]
+    },
+    "family": {
+      "parent1": {
+        "parent1": {
+          "card": 212,
+          "character": 114,
+          "icon": 466,
+          "rank": 74,
+          "record_type": "Standard"
+        },
+        "parent2": {
+          "card": 189,
+          "character": 83,
+          "icon": 419,
+          "rank": 43,
+          "record_type": "Standard"
+        },
+        "self": {
+          "card": 234,
+          "character": 7,
+          "icon": 510,
+          "rank": 68,
+          "record_type": "Standard"
+        }
+      },
+      "parent2": {
+        "parent1": {
+          "card": 86,
+          "character": 2,
+          "icon": 202,
+          "rank": 62,
+          "record_type": "Standard"
+        },
+        "parent2": {
+          "card": 178,
+          "character": 68,
+          "icon": 396,
+          "rank": 56,
+          "record_type": "Standard"
+        },
+        "rental": true,
+        "self": {
+          "card": 37,
+          "character": 46,
+          "icon": 93,
+          "rank": 59,
+          "record_type": "Standard"
+        }
+      }
+    },
+    "fans": 473761,
+    "metadata": {
+      "format_version": "1.0.0",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
+      "record_type": "Standard",
+      "region": "JPN",
+      "stage": "active",
+      "strategy": 0
+    },
+    "races": [
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 0,
+        "title": 242,
+        "turn": 73,
+        "variation": 5,
+        "weather": 0
+      },
+      {
+        "distance": 12,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 0,
+        "title": 265,
+        "turn": 73,
+        "variation": 3,
+        "weather": 4
+      },
+      {
+        "distance": 12,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 0,
+        "title": 45,
+        "turn": 73,
+        "variation": 3,
+        "weather": 0
+      },
+      {
+        "distance": 15,
+        "ground": 0,
+        "place": 4,
+        "position": 1,
+        "strategy": 0,
+        "title": 212,
+        "turn": 71,
+        "variation": 5,
+        "weather": 0
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 0,
+        "title": 269,
+        "turn": 67,
+        "variation": 2,
+        "weather": 0
+      },
+      {
+        "distance": 14,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 0,
+        "title": 150,
+        "turn": 66,
+        "variation": 3,
+        "weather": 0
+      },
+      {
+        "distance": 12,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 0,
+        "title": 153,
+        "turn": 59,
+        "variation": 5,
+        "weather": 4
+      },
+      {
+        "distance": 18,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 0,
+        "title": 210,
+        "turn": 55,
+        "variation": 3,
+        "weather": 10
+      },
+      {
+        "distance": 17,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 0,
+        "title": 13,
+        "turn": 53,
+        "variation": 5,
+        "weather": 4
+      },
+      {
+        "distance": 15,
+        "ground": 0,
+        "place": 4,
+        "position": 1,
+        "strategy": 0,
+        "title": 212,
+        "turn": 47,
+        "variation": 5,
+        "weather": 4
+      },
+      {
+        "distance": 17,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 0,
+        "title": 144,
+        "turn": 43,
+        "variation": 3,
+        "weather": 0
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 4,
+        "position": 1,
+        "strategy": 0,
+        "title": 142,
+        "turn": 28,
+        "variation": 5,
+        "weather": 4
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 0,
+        "title": 273,
+        "turn": 11,
+        "variation": 5,
+        "weather": 0
+      }
+    ],
+    "scenario": {
+      "id": 13
+    },
+    "skills": [
+      {
+        "id": 1276,
+        "level": 6
+      },
+      {
+        "id": 319
+      },
+      {
+        "id": 1647
+      },
+      {
+        "id": 134
+      },
+      {
+        "id": 383
+      },
+      {
+        "id": 115
+      },
+      {
+        "id": 406
+      },
+      {
+        "id": 343
+      },
+      {
+        "id": 182
+      },
+      {
+        "id": 132
+      },
+      {
+        "id": 364
+      },
+      {
+        "id": 311
+      },
+      {
+        "id": 409
+      },
+      {
+        "id": 382
+      },
+      {
+        "id": 482
+      },
+      {
+        "id": 220
+      },
+      {
+        "id": 80
+      },
+      {
+        "id": 385
+      },
+      {
+        "id": 166
+      },
+      {
+        "id": 256
+      },
+      {
+        "id": 254
+      },
+      {
+        "id": 8
+      },
+      {
+        "id": 114
+      },
+      {
+        "id": 275
+      },
+      {
+        "id": 481
+      },
+      {
+        "id": 320
+      },
+      {
+        "id": 179
+      },
+      {
+        "id": 128
+      },
+      {
+        "id": 569
+      },
+      {
+        "id": 1812
+      },
+      {
+        "id": 253
+      },
+      {
+        "id": 70
+      },
+      {
+        "id": 243
+      },
+      {
+        "id": 489
+      },
+      {
+        "id": 754
+      },
+      {
+        "id": 882
+      },
+      {
+        "id": 928
+      },
+      {
+        "id": 974
+      },
+      {
+        "id": 1820
+      },
+      {
+        "id": 1028
+      },
+      {
+        "id": 1271
+      },
+      {
+        "id": 1240
+      },
+      {
+        "id": 1272
+      },
+      {
+        "id": 1269
+      },
+      {
+        "id": 1302
+      },
+      {
+        "id": 1290
+      },
+      {
+        "id": 1299
+      },
+      {
+        "id": 1338
+      },
+      {
+        "id": 1363
+      },
+      {
+        "id": 1408
+      },
+      {
+        "id": 1466
+      },
+      {
+        "id": 1479
+      },
+      {
+        "id": 1487
+      },
+      {
+        "id": 1571
+      },
+      {
+        "id": 1657
+      },
+      {
+        "id": 1662
+      },
+      {
+        "id": 1670
+      },
+      {
+        "id": 1718
+      },
+      {
+        "id": 1712
+      },
+      {
+        "id": 1809
+      },
+      {
+        "id": 1821
+      },
+      {
+        "id": 372
+      },
+      {
+        "id": 591
+      },
+      {
+        "id": 1617
+      },
+      {
+        "id": 1823
+      }
+    ],
+    "status": {
+      "guts": 1256,
+      "intelligence": 1287,
+      "power": 1270,
+      "speed": 2184,
+      "stamina": 1832
+    },
+    "support_cards": [
+      {
+        "id": 508,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 497,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 540,
+        "level": 0,
+        "rank": 3
+      },
+      {
+        "id": 416,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 522,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 539,
+        "level": 0,
+        "rank": 5
+      }
+    ],
+    "trained_date": "2026/06/30",
+    "trainee": {
+      "card": 183,
+      "character": 34,
+      "icon": 404,
+      "rank": 86
+    }
+  }
+]

--- a/native/test/integration/golden/player_standard_4.json
+++ b/native/test/integration/golden/player_standard_4.json
@@ -1,0 +1,833 @@
+[
+  {
+    "aptitudes": {
+      "distance": {
+        "long_range": 1,
+        "middle_range": 6,
+        "mile_range": 7,
+        "short_range": 0
+      },
+      "ground": {
+        "dirt": 0,
+        "turf": 6
+      },
+      "style": {
+        "late_charge": 3,
+        "lead_pace": 0,
+        "off_pace": 6,
+        "with_pace": 6
+      }
+    },
+    "evaluation_value": 61865,
+    "factors": {
+      "parent1": [
+        {
+          "id": 26,
+          "star": 3
+        },
+        {
+          "id": 27,
+          "star": 3
+        },
+        {
+          "id": 232,
+          "star": 3
+        },
+        {
+          "id": 56,
+          "star": 2
+        },
+        {
+          "id": 3,
+          "star": 2
+        },
+        {
+          "id": 152,
+          "star": 2
+        },
+        {
+          "id": 0,
+          "star": 2
+        },
+        {
+          "id": 284,
+          "star": 2
+        },
+        {
+          "id": 130,
+          "star": 1
+        },
+        {
+          "id": 268,
+          "star": 3
+        },
+        {
+          "id": 183,
+          "star": 2
+        },
+        {
+          "id": 275,
+          "star": 2
+        },
+        {
+          "id": 332,
+          "star": 2
+        },
+        {
+          "id": 407,
+          "star": 2
+        },
+        {
+          "id": 418,
+          "star": 2
+        },
+        {
+          "id": 433,
+          "star": 2
+        },
+        {
+          "id": 471,
+          "star": 2
+        },
+        {
+          "id": 540,
+          "star": 2
+        },
+        {
+          "id": 574,
+          "star": 2
+        },
+        {
+          "id": 600,
+          "star": 2
+        },
+        {
+          "id": 754,
+          "star": 2
+        },
+        {
+          "id": 777,
+          "star": 2
+        },
+        {
+          "id": 375,
+          "star": 2
+        },
+        {
+          "id": 802,
+          "star": 2
+        },
+        {
+          "id": 658,
+          "star": 2
+        }
+      ],
+      "parent2": [
+        {
+          "id": 246,
+          "star": 3
+        },
+        {
+          "id": 27,
+          "star": 3
+        },
+        {
+          "id": 775,
+          "star": 3
+        },
+        {
+          "id": 161,
+          "star": 1
+        },
+        {
+          "id": 74,
+          "star": 2
+        },
+        {
+          "id": 17,
+          "star": 1
+        },
+        {
+          "id": 273,
+          "star": 3
+        },
+        {
+          "id": 184,
+          "star": 2
+        },
+        {
+          "id": 354,
+          "star": 1
+        },
+        {
+          "id": 171,
+          "star": 2
+        },
+        {
+          "id": 151,
+          "star": 3
+        },
+        {
+          "id": 296,
+          "star": 3
+        },
+        {
+          "id": 94,
+          "star": 1
+        },
+        {
+          "id": 262,
+          "star": 1
+        },
+        {
+          "id": 275,
+          "star": 3
+        },
+        {
+          "id": 84,
+          "star": 2
+        },
+        {
+          "id": 280,
+          "star": 2
+        },
+        {
+          "id": 295,
+          "star": 2
+        },
+        {
+          "id": 231,
+          "star": 2
+        },
+        {
+          "id": 316,
+          "star": 2
+        },
+        {
+          "id": 433,
+          "star": 2
+        },
+        {
+          "id": 477,
+          "star": 2
+        },
+        {
+          "id": 522,
+          "star": 2
+        },
+        {
+          "id": 535,
+          "star": 2
+        },
+        {
+          "id": 621,
+          "star": 2
+        },
+        {
+          "id": 718,
+          "star": 1
+        },
+        {
+          "id": 727,
+          "star": 2
+        },
+        {
+          "id": 756,
+          "star": 3
+        },
+        {
+          "id": 375,
+          "star": 2
+        },
+        {
+          "id": 410,
+          "star": 1
+        },
+        {
+          "id": 658,
+          "star": 2
+        },
+        {
+          "id": 657,
+          "star": 1
+        },
+        {
+          "id": 626,
+          "star": 2
+        },
+        {
+          "id": 661,
+          "star": 3
+        },
+        {
+          "id": 618,
+          "star": 2
+        },
+        {
+          "id": 643,
+          "star": 2
+        }
+      ],
+      "self": [
+        {
+          "id": 147,
+          "star": 2
+        },
+        {
+          "id": 226,
+          "star": 2
+        },
+        {
+          "id": 800,
+          "star": 2
+        },
+        {
+          "id": 173,
+          "star": 1
+        },
+        {
+          "id": 67,
+          "star": 2
+        },
+        {
+          "id": 234,
+          "star": 2
+        },
+        {
+          "id": 135,
+          "star": 2
+        },
+        {
+          "id": 262,
+          "star": 1
+        },
+        {
+          "id": 316,
+          "star": 2
+        },
+        {
+          "id": 433,
+          "star": 2
+        },
+        {
+          "id": 471,
+          "star": 2
+        },
+        {
+          "id": 535,
+          "star": 2
+        },
+        {
+          "id": 637,
+          "star": 2
+        },
+        {
+          "id": 727,
+          "star": 2
+        },
+        {
+          "id": 760,
+          "star": 3
+        },
+        {
+          "id": 777,
+          "star": 2
+        },
+        {
+          "id": 765,
+          "star": 1
+        },
+        {
+          "id": 774,
+          "star": 2
+        },
+        {
+          "id": 375,
+          "star": 2
+        },
+        {
+          "id": 834,
+          "star": 3
+        },
+        {
+          "id": 835,
+          "star": 1
+        },
+        {
+          "id": 658,
+          "star": 2
+        },
+        {
+          "id": 669,
+          "star": 2
+        },
+        {
+          "id": 625,
+          "star": 3
+        }
+      ]
+    },
+    "family": {
+      "parent1": {
+        "parent1": {
+          "card": 162,
+          "character": 74,
+          "icon": 364,
+          "rank": 70,
+          "record_type": "Standard"
+        },
+        "parent2": {
+          "card": 215,
+          "character": 94,
+          "icon": 475,
+          "rank": 63,
+          "record_type": "Standard"
+        },
+        "self": {
+          "card": 8,
+          "character": 30,
+          "icon": 558,
+          "rank": 298,
+          "record_type": "InheritanceOnly"
+        }
+      },
+      "parent2": {
+        "parent1": {
+          "card": 157,
+          "character": 91,
+          "icon": 352,
+          "rank": 69,
+          "record_type": "Standard"
+        },
+        "parent2": {
+          "card": 25,
+          "character": 29,
+          "icon": 5,
+          "rank": 58,
+          "record_type": "Standard"
+        },
+        "rental": true,
+        "self": {
+          "card": 235,
+          "character": 121,
+          "icon": 513,
+          "rank": 70,
+          "record_type": "Standard"
+        }
+      }
+    },
+    "fans": 516405,
+    "metadata": {
+      "format_version": "1.0.0",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
+      "record_type": "Standard",
+      "region": "JPN",
+      "stage": "active",
+      "strategy": 1
+    },
+    "races": [
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 1,
+        "position": 1,
+        "strategy": 1,
+        "title": 242,
+        "turn": 73,
+        "variation": 2,
+        "weather": 4
+      },
+      {
+        "distance": 12,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 1,
+        "title": 265,
+        "turn": 73,
+        "variation": 5,
+        "weather": 10
+      },
+      {
+        "distance": 14,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 1,
+        "title": 45,
+        "turn": 73,
+        "variation": 3,
+        "weather": 0
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 1,
+        "title": 168,
+        "turn": 70,
+        "variation": 5,
+        "weather": 0
+      },
+      {
+        "distance": 14,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 1,
+        "title": 237,
+        "turn": 69,
+        "variation": 2,
+        "weather": 4
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 1,
+        "title": 269,
+        "turn": 67,
+        "variation": 2,
+        "weather": 0
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 6,
+        "position": 1,
+        "strategy": 1,
+        "title": 240,
+        "turn": 64,
+        "variation": 4,
+        "weather": 0
+      },
+      {
+        "distance": 6,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 1,
+        "title": 203,
+        "turn": 58,
+        "variation": 2,
+        "weather": 4
+      },
+      {
+        "distance": 6,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 1,
+        "title": 158,
+        "turn": 56,
+        "variation": 2,
+        "weather": 4
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 1,
+        "title": 270,
+        "turn": 53,
+        "variation": 5,
+        "weather": 4
+      },
+      {
+        "distance": 14,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 1,
+        "title": 237,
+        "turn": 45,
+        "variation": 2,
+        "weather": 0
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 1,
+        "title": 202,
+        "turn": 43,
+        "variation": 5,
+        "weather": 0
+      },
+      {
+        "distance": 14,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 1,
+        "title": 5,
+        "turn": 33,
+        "variation": 2,
+        "weather": 0
+      },
+      {
+        "distance": 6,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 1,
+        "title": 238,
+        "turn": 30,
+        "variation": 3,
+        "weather": 1
+      },
+      {
+        "distance": 6,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 1,
+        "title": 259,
+        "turn": 24,
+        "variation": 3,
+        "weather": 4
+      },
+      {
+        "distance": 6,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 1,
+        "title": 273,
+        "turn": 11,
+        "variation": 2,
+        "weather": 10
+      }
+    ],
+    "scenario": {
+      "id": 13
+    },
+    "skills": [
+      {
+        "id": 1729,
+        "level": 6
+      },
+      {
+        "id": 233
+      },
+      {
+        "id": 1509
+      },
+      {
+        "id": 1656
+      },
+      {
+        "id": 32
+      },
+      {
+        "id": 134
+      },
+      {
+        "id": 115
+      },
+      {
+        "id": 47
+      },
+      {
+        "id": 406
+      },
+      {
+        "id": 182
+      },
+      {
+        "id": 132
+      },
+      {
+        "id": 364
+      },
+      {
+        "id": 311
+      },
+      {
+        "id": 409
+      },
+      {
+        "id": 382
+      },
+      {
+        "id": 220
+      },
+      {
+        "id": 480
+      },
+      {
+        "id": 208
+      },
+      {
+        "id": 381
+      },
+      {
+        "id": 275
+      },
+      {
+        "id": 481
+      },
+      {
+        "id": 320
+      },
+      {
+        "id": 179
+      },
+      {
+        "id": 128
+      },
+      {
+        "id": 569
+      },
+      {
+        "id": 177
+      },
+      {
+        "id": 432
+      },
+      {
+        "id": 489
+      },
+      {
+        "id": 552
+      },
+      {
+        "id": 597
+      },
+      {
+        "id": 882
+      },
+      {
+        "id": 928
+      },
+      {
+        "id": 974
+      },
+      {
+        "id": 978
+      },
+      {
+        "id": 1007
+      },
+      {
+        "id": 1820
+      },
+      {
+        "id": 1183
+      },
+      {
+        "id": 1280
+      },
+      {
+        "id": 1302
+      },
+      {
+        "id": 1338
+      },
+      {
+        "id": 1408
+      },
+      {
+        "id": 1705
+      },
+      {
+        "id": 1518
+      },
+      {
+        "id": 1571
+      },
+      {
+        "id": 1600
+      },
+      {
+        "id": 1612
+      },
+      {
+        "id": 1625
+      },
+      {
+        "id": 1637
+      },
+      {
+        "id": 1648
+      },
+      {
+        "id": 1657
+      },
+      {
+        "id": 1662
+      },
+      {
+        "id": 1718
+      },
+      {
+        "id": 1714
+      },
+      {
+        "id": 591
+      },
+      {
+        "id": 584
+      },
+      {
+        "id": 712
+      },
+      {
+        "id": 1706
+      },
+      {
+        "id": 1823
+      }
+    ],
+    "status": {
+      "guts": 1294,
+      "intelligence": 1389,
+      "power": 1257,
+      "speed": 2236,
+      "stamina": 1800
+    },
+    "support_cards": [
+      {
+        "id": 508,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 497,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 540,
+        "level": 0,
+        "rank": 3
+      },
+      {
+        "id": 416,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 522,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 539,
+        "level": 0,
+        "rank": 5
+      }
+    ],
+    "trained_date": "2026/07/01",
+    "trainee": {
+      "card": 243,
+      "character": 124,
+      "icon": 531,
+      "rank": 86
+    }
+  }
+]

--- a/native/test/integration/golden/player_standard_scrollbar_change_1.json
+++ b/native/test/integration/golden/player_standard_scrollbar_change_1.json
@@ -351,7 +351,7 @@
     "fans": 263991,
     "metadata": {
       "format_version": "1.0.0",
-      "recognizer_version": "2026-06-29T11:00:00+0900",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
       "record_type": "Standard",
       "region": "JPN",
       "stage": "active",

--- a/native/test/integration/golden/player_standard_scrollbar_change_2.json
+++ b/native/test/integration/golden/player_standard_scrollbar_change_2.json
@@ -479,7 +479,7 @@
     "fans": 0,
     "metadata": {
       "format_version": "1.0.0",
-      "recognizer_version": "2026-06-29T11:00:00+0900",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
       "record_type": "InheritanceOnly",
       "region": "JPN",
       "stage": "active",

--- a/native/test/integration/golden/player_standard_sequential.json
+++ b/native/test/integration/golden/player_standard_sequential.json
@@ -395,7 +395,7 @@
     "fans": 231776,
     "metadata": {
       "format_version": "1.0.0",
-      "recognizer_version": "2026-06-29T11:00:00+0900",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
       "record_type": "Standard",
       "region": "JPN",
       "stage": "active",
@@ -1088,7 +1088,7 @@
     "fans": 240863,
     "metadata": {
       "format_version": "1.0.0",
-      "recognizer_version": "2026-06-29T11:00:00+0900",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
       "record_type": "Standard",
       "region": "JPN",
       "stage": "active",
@@ -1194,7 +1194,7 @@
         "id": 134
       },
       {
-        "id": 99
+        "id": 454
       },
       {
         "id": 383

--- a/native/test/integration/run.py
+++ b/native/test/integration/run.py
@@ -4,10 +4,13 @@
 # ///
 """Golden integration test for the native recognition pipeline.
 
-Drives the real ``umacapture_cli video`` over recorded clips and compares the
-recognized ``record.json`` set against committed golden files. This exercises the
-full ONNX/WinRT/FFmpeg pipeline end to end, so it depends on local-only assets
-(the ``.notes`` clips and the ``sandbox/modules`` ONNX models, neither committed).
+Drives the real ``umacapture_cli`` over recorded clips and compares the recognized
+``record.json`` set against committed golden files. Each case's input extension picks
+the subcommand: an ``.mp4`` (or other plain clip) goes through ``video`` (OpenCV
+decode), while an ``.mkv`` is treated as a lossless FFV1 recording and goes through
+``replay`` (the recorded frames drive the pipeline directly). This exercises the full
+ONNX/WinRT/FFmpeg pipeline end to end, so it depends on local-only assets (the
+``.notes`` clips and the ``sandbox/modules`` ONNX models, neither committed).
 
 A case whose input clip -- or the modules dir -- is absent is skipped, not failed,
 so a fresh checkout / CI can run this without the data present. If every case is
@@ -89,11 +92,17 @@ def run_case(case: dict, cli: Path, data_dir: Path, assets_dir: Path, modules_di
 
     with tempfile.TemporaryDirectory(prefix=f"uma_it_{case['name']}_") as tmp:
         output_dir = Path(tmp)
+        # An .mkv input is a lossless FFV1 recording (from `capture --record`): feed it through the
+        # `replay` subcommand, which reads the recorded frames straight into the pipeline. Anything
+        # else is a plain video clip decoded by OpenCV via the `video` subcommand. Both write the same
+        # storage/chara_detail/active/*/record.json set, so collection and comparison are identical.
+        if video.suffix.lower() == ".mkv":
+            input_args = ["replay", "--record", str(video)]
+        else:
+            input_args = ["video", "--video_path_list", str(video)]
         command = [
             str(cli),
-            "video",
-            "--video_path_list",
-            str(video),
+            *input_args,
             "--output_dir",
             str(output_dir),
             "--assets_dir",

--- a/tool/fetch_deps.py
+++ b/tool/fetch_deps.py
@@ -13,6 +13,12 @@ copied in by hand:
 * **ONNX Runtime 1.27.0** -> ``windows/onnxruntime`` (the official ``win-x64`` zip,
   plus two ``experimental_onnxruntime_cxx_*`` headers that live only in the source
   tree, not the release zip).
+* **FFmpeg n7.1.5 (BtbN LGPL, shared)** -> ``windows/ffmpeg`` (headers + import libs +
+  versioned DLLs). Only the CLI target links it, for the lossless FFV1 ``.mkv`` capture
+  recorder and its replay reader (``native/src/cv/ffv1_recorder.*`` / ``ffv1_reader.*``).
+  A dated BtbN autobuild tag is used so the pinned asset (git-hash in its name) is
+  immutable; ``lgpl`` (not ``gpl``) suffices because FFV1 and the matroska muxer are
+  native LGPL components.
 
 This script downloads each artifact from its official URL, verifies it against a
 pinned SHA-256, and extracts it into the exact layout CMake expects -- the same
@@ -39,9 +45,10 @@ source, no binaries) and is therefore not fetched here.
 Run it via ``uv run`` (this repo invokes Python through ``uv``, never bare
 ``python``); it uses only the standard library::
 
-    uv run tool/fetch_deps.py                 # both deps (skips ones already present)
+    uv run tool/fetch_deps.py                 # all deps (skips ones already present)
     uv run tool/fetch_deps.py --only opencv   # just OpenCV (what CI provisions)
     uv run tool/fetch_deps.py --only opencv --slim  # + prune unused OpenCV parts (CI)
+    uv run tool/fetch_deps.py --only ffmpeg --slim  # just FFmpeg, pruned (CLI FFV1 tests)
     uv run tool/fetch_deps.py --force         # re-fetch even if already present
 
 To bump a dependency version, change its ``*_URL`` and ``*_SHA256`` constants (and
@@ -68,6 +75,18 @@ OPENCV_SHA256 = "f0e98c302464d6860777a7015065e11b9b271b5394e6ba92663f0cf1fc303f2
 
 ONNX_URL = "https://github.com/microsoft/onnxruntime/releases/download/v1.27.0/onnxruntime-win-x64-1.27.0.zip"
 ONNX_SHA256 = "c5c81710938e68079ff1a192b04897faabe4b43830d48f39f27ecd4e16138bfc"
+
+# BtbN FFmpeg-Builds n7.1.5, win64, LGPL, shared. Pinned to a dated autobuild tag so the
+# asset (its name carries the git hash g7d0e842004) is immutable -- the SHA-256 below would
+# otherwise drift if it pointed at the mutable ``latest`` tag. The archive's single root
+# folder holds ``bin/ include/ lib/``. To bump: pick a newer autobuild tag's
+# ``ffmpeg-nX.Y.Z-...-win64-lgpl-shared-X.Y.zip`` asset, download it once, sha256sum it,
+# and update both constants (and the CMake DLL-version names if the major version changes).
+FFMPEG_URL = (
+    "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-10-13-44"
+    "/ffmpeg-n7.1.5-1-g7d0e842004-win64-lgpl-shared-7.1.zip"
+)
+FFMPEG_SHA256 = "d31de3f3c69b3f70fbe8babacea0cff8de2b51e259fc0bd0b37b3a5c0d114077"
 
 # The C++ recognizer uses ONNX Runtime's experimental C++ session wrapper, which
 # ships only in the source tree (tagged v1.27.0), not in the win-x64 release zip.
@@ -108,6 +127,21 @@ OPENCV_SLIM_PRUNE_GLOBS = (
 # The ONNX Runtime equivalent (paths relative to ``windows/onnxruntime``): its own debug
 # symbols, never symbolicated here, and ~384 MB -- dwarfing the 15 MB DLL they pair with.
 ONNX_SLIM_PRUNE_GLOBS = ("lib/*.pdb",)
+
+# FFmpeg parts the CLI never links or ships (paths relative to ``windows/ffmpeg``). We link
+# only avformat/avcodec/avutil and load their transitive DLLs (swresample, swscale); avdevice
+# and avfilter are unused, as are the ffmpeg/ffplay front-end exes. ``ffprobe.exe`` is kept for
+# the recorder's smoke-test assertions. A missing entry is skipped (see prune_tree), so a future
+# layout shift degrades to "kept" rather than erroring.
+FFMPEG_SLIM_PRUNE_DIRS = ("doc",)  # HTML manuals we never read
+FFMPEG_SLIM_PRUNE_GLOBS = (
+    "bin/ffmpeg.exe",
+    "bin/ffplay.exe",
+    "bin/avdevice-*.dll",
+    "bin/avfilter-*.dll",
+    "lib/avdevice.lib",
+    "lib/avfilter.lib",
+)
 
 
 def log(message: str) -> None:
@@ -252,11 +286,44 @@ def fetch_onnxruntime(force: bool, slim: bool) -> None:
     log(f"provisioned {target.relative_to(REPO_ROOT)}")
 
 
+def extract_ffmpeg(zip_path: Path, target: Path) -> None:
+    """Extract the BtbN FFmpeg zip so ``include/``, ``lib/`` and ``bin/`` land directly in ``target``.
+
+    The archive's single root folder (``ffmpeg-nX.Y.Z-...-shared/``) holds those three dirs, so this
+    mirrors ``extract_onnxruntime``: extract to a temp dir, then move the sole root folder's children
+    into ``windows/ffmpeg`` -- the exact ``FFMPEG_DIR`` layout ``native/CMakeLists.txt`` references.
+    """
+    import zipfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        with zipfile.ZipFile(zip_path) as archive:
+            archive.extractall(tmp_dir)
+        inner = _sole_child_dir(tmp_dir)
+        target.mkdir(parents=True)
+        for item in inner.iterdir():
+            shutil.move(str(item), str(target / item.name))
+
+
+def fetch_ffmpeg(force: bool, slim: bool) -> None:
+    """Provision windows/ffmpeg (BtbN LGPL shared build)."""
+    target = WINDOWS_DIR / "ffmpeg"
+    if not _prepare_target(target, force):
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        zip_path = Path(tmp) / "ffmpeg.zip"
+        download_verified(FFMPEG_URL, zip_path, FFMPEG_SHA256)
+        extract_ffmpeg(zip_path, target)
+    if slim:
+        prune_tree(target, FFMPEG_SLIM_PRUNE_DIRS, FFMPEG_SLIM_PRUNE_GLOBS)
+    log(f"provisioned {target.relative_to(REPO_ROOT)}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
         "--only",
-        choices=["opencv", "onnxruntime", "all"],
+        choices=["opencv", "onnxruntime", "ffmpeg", "all"],
         default="all",
         help="provision a single dependency instead of all (default: all)",
     )
@@ -276,6 +343,8 @@ def main() -> None:
         fetch_opencv(args.force, args.slim)
     if args.only in ("onnxruntime", "all"):
         fetch_onnxruntime(args.force, args.slim)
+    if args.only in ("ffmpeg", "all"):
+        fetch_ffmpeg(args.force, args.slim)
 
 
 if __name__ == "__main__":

--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -24,3 +24,4 @@ cmake-build-*/
 # clip is committed to the repo (pure MIT source, no binaries) and is not listed here.
 /opencv/
 /onnxruntime/
+/ffmpeg/


### PR DESCRIPTION
## Summary

Two related pieces of native capture/recognition work on one branch: a lossless
**FFV1 capture recorder + `replay`** path for reproducing failed captures, and a
**refactor of the factor(継承)-tab scroll termination**. Also bumps the golden
baseline and adds cases.

## What changed

### 1. Factor-tab termination refactor
- **Delayed strip commit** — factor strips are staged into a bounded RAM tail
  instead of being written eagerly.
- **Maintained frontier** — the factor-end live walk is replaced by a maintained
  scroll frontier.
- **Latch-above-bar fix** — on the terminating frame, latch the rows above the
  green 継承履歴 end-bar before the trim, so the last card is not clipped.

### 2. FFV1 lossless capture recorder + replay
- `capture --record <path>.mkv` records every captured frame plus its real
  timestamp into a single lossless FFV1 `.mkv`; `replay --record <path>.mkv`
  re-feeds those frames through the recognition pipeline deterministically. CLI
  only, libav linked directly. Includes review fixes for shutdown, I/O errors,
  and the close contract.
- The integration golden harness routes `.mkv` cases through `replay` and `.mp4`
  cases through `video` (extension-based), so recorded captures can be replayed as
  golden inputs.

### 3. Golden baseline / cases
- Golden baseline bumped to the 2026-07-10 recognizer models.
- Added `player_standard_2` / `_3` / `_4` golden cases.

## Known issue

Investigation during this work surfaced a **defect in scroll offset estimation**
(in the shared scroll-bar-guess + image-match path — *not* the termination code
changed here). On a bottom-clipped terminating frame — where the scroll-bar thumb
is pinned to the track bottom — the scroll-bar guess collapses far below the true
scroll, and the image match's guess-centered acceptance window then rejects the
true displacement, so the estimated offset undershoots. This can drop the **last
row of a scrolled tab** from the stitched image (observed on the factor tab: the
final factor row is misrecognized). The cause is root-caused and validated; the
fix is a larger offset-estimator change and will land on a **separate branch**. No
committed golden exercises this case, so it does not affect CI here.

## Testing

- Native unit tests (`umacapture_tests`), including the FFV1 round-trip test.
- Integration golden harness (`run.py`) over local clips; goldens regenerated
  against the 2026-07-10 models.
- CI (native ctest + Flutter, windows-2022) runs on push and is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
