### PR TITLE
fix(native): replace guess-windowed offset estimation with candidate+verify

### DIFF
--- a/assets/config/chara_detail/scene_scraper.json
+++ b/assets/config/chara_detail/scene_scraper.json
@@ -143,7 +143,6 @@
     "stationary_time_threshold": 200,
     "minimum_color_threshold": 18,
     "stationary_color_threshold": 100,
-    "viewport": 0.738,
     "cap_offset": 0.00126,
     "scroll_bar_margin_color": {
       "min": {
@@ -312,7 +311,6 @@
     "stationary_time_threshold": 200,
     "minimum_color_threshold": 18,
     "stationary_color_threshold": 100,
-    "viewport": 0.553,
     "cap_offset": 0.00126,
     "scroll_bar_margin_color": {
       "min": {

--- a/docs/native-recognition-backend.md
+++ b/docs/native-recognition-backend.md
@@ -69,10 +69,13 @@ in `native/src/chara_detail/chara_detail_record.h`.
   itself lives under `native/src/condition/`.
 - **Scraper** (`chara_detail_scene_scraper.h`) is the heart of "recording → tall
   image". Per tab it decides scrollable vs. non-scrollable by looking for a
-  scrollbar, then estimates scroll offset between frames with a **two-tier
-  estimator**: `ScrollBarOffsetEstimator` (coarse guess from scrollbar position)
-  refined by `ImageOffsetEstimator` (AKAZE feature match + homography, accepting
-  only vertical translation). Newly revealed strips are cut at color boundaries
+  scrollbar, then estimates scroll offset between frames with a **guess-free
+  candidate + verify estimator** (`ImageOffsetEstimator`): AKAZE keypoint matches
+  vote into a 1-px displacement histogram whose peaks become candidate offsets,
+  and a full-resolution pixel-overlap correlation selects among them. The
+  scrollbar (`ScrollBarOffsetEstimator`) is only used for progress reporting and
+  at-top detection, never to decide the offset — its geometry collapses exactly
+  on the terminating overscroll frame. Newly revealed strips are cut at color boundaries
   (`ScanParameter`) and saved as `scroll_area_NNNNN.png`. A `BaseFrameCatcher`
   grabs the static header/frame while ignoring snackbar (toast) interference.
   Output goes to `temp_dir/chara_detail/<record_id>/`.

--- a/native/src/chara_detail/chara_detail_config.h
+++ b/native/src/chara_detail/chara_detail_config.h
@@ -84,8 +84,8 @@ struct SceneScraperConfig {
     Rect<double> scroll_area_rect;
     // Full-width band the scrollbar is detected in, decoupled from scroll_area_rect (the content/stitch crop)
     // so the latter can move without shifting the scan geometry. It MUST stay full width (x IntersectStart ->
-    // IntersectPixelEnd): the scan line x, viewport and cap_offset are all normalized by the crop width, so a
-    // narrower band would silently mis-scale them. Only its y-range is meant to diverge from scroll_area_rect.
+    // IntersectPixelEnd): the scan line x and cap_offset are normalized by the crop width, so a narrower band
+    // would silently mis-scale them. Only its y-range is meant to diverge from scroll_area_rect.
     Rect<double> scroll_bar_rect;
     Rect<double> scroll_area_stationary_rect;
     Range<Color> scroll_bar_bg_color;
@@ -95,14 +95,11 @@ struct SceneScraperConfig {
     uint64 stationary_time_threshold;
     int minimum_color_threshold;
     uint64 stationary_color_threshold;
-    // Scrollbar physics, all width-normalized so they scale with the screen and never depend on the crop
-    // height (each layout carries its own values). `viewport` is the visible content height V used to turn
-    // thumb geometry into a content-pixel offset (abs = V * upper_gap / thumb_length); it is NOT the crop
-    // height. `cap_offset` is the thumb's rounded-cap depth c: the tip-to-tip length over-reads the logical
-    // thumb length by 2c, so the logical length is `tip - 2 * cap_offset`. `scroll_bar_margin_color` is the
+    // Scrollbar physics, width-normalized so they scale with the screen and never depend on the crop height.
+    // `cap_offset` is the thumb's rounded-cap depth c: the tip-to-tip length over-reads the logical thumb
+    // length by 2c, so the logical length is `tip - 2 * cap_offset`. `scroll_bar_margin_color` is the
     // near-white band flanking the placeholder track; isolating it locates the fixed track ends so the
     // position is measured against the true track, not the (slightly longer) config scan line.
-    double viewport;
     double cap_offset;
     Range<Color> scroll_bar_margin_color;
     // Sub-pixel thumb-centre probe geometry (self-centres the vertical scan on the thumb; see trackCenterX).
@@ -123,7 +120,6 @@ struct SceneScraperConfig {
         stationary_time_threshold,
         minimum_color_threshold,
         stationary_color_threshold,
-        viewport,
         cap_offset,
         scroll_bar_margin_color,
         scroll_bar_thumb_probe);

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -1,6 +1,6 @@
-#include <map>
-
 #include "chara_detail/chara_detail_scene_scraper.h"
+
+#include <map>
 
 namespace uma::chara_detail {
 

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -38,13 +38,11 @@ ScrollBarOffsetEstimator::ScrollBarOffsetEstimator(
     const Range<Color> &scroll_bar_bg_color_range,
     const Line<double> &scroll_bar_scan_line,
     const Range<Color> &scroll_bar_margin_color_range,
-    double viewport,
     double cap_offset,
     const scraper_config::ScrollBarThumbProbeConfig &thumb_probe)
     : scroll_bar_bg_color_range(scroll_bar_bg_color_range)
     , scroll_bar_scan_line(scroll_bar_scan_line)
     , scroll_bar_margin_color_range(scroll_bar_margin_color_range)
-    , viewport(viewport)
     , cap_offset(cap_offset)
     , thumb_probe(thumb_probe) {}
 
@@ -1033,7 +1031,6 @@ void SceneScraper::build(const Frame &frame) {
         config.scroll_bar_bg_color,
         config.scroll_bar_scan_line,
         config.scroll_bar_margin_color,
-        config.viewport,
         config.cap_offset,
         config.scroll_bar_thumb_probe);
     const auto &scroll_bar_offset_estimator = *scroll_bar_estimator;

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -1,3 +1,5 @@
+#include <map>
+
 #include "chara_detail/chara_detail_scene_scraper.h"
 
 namespace uma::chara_detail {
@@ -5,19 +7,6 @@ namespace uma::chara_detail {
 namespace scraper_impl {
 
 namespace {
-
-bool closeEnough(const std::vector<double> &a, const std::vector<double> &b, double threshold) {
-    if (a.size() != b.size()) {
-        return false;
-    }
-
-    for (size_t i = 0; i < a.size(); i++) {
-        if (std::abs(a[i] - b[i]) > threshold) {
-            return false;
-        }
-    }
-    return true;
-}
 
 // Bottom margin kept below the last factor when cropping the factor tab, as a fraction of the frame width
 // (the project's length unit). The background run that follows the last factor starts a few px below its
@@ -300,23 +289,68 @@ ImageOffsetEstimator::ImageOffsetEstimator(const ImageOffsetEstimatorConfig &con
           cv::makePtr<cv::FlannBasedMatcher>(
               cv::makePtr<cv::flann::LshIndexParams>(config.table_number, config.key_size, config.probe_level)))
     , trust_ratio(config.trust_ratio)
-    , horizontal_threshold(config.horizontal_threshold)
     , minimum_overlap_score(config.minimum_overlap_score)
-    , minimum_overlap_height(config.minimum_overlap_height)
-    , overlap_downscale(config.overlap_downscale)
-    , minimum_key_points(config.minimum_key_points)
-    , vertical_threshold(config.vertical_threshold) {}
+    , minimum_overlap_fraction(config.minimum_overlap_fraction)
+    , minimum_key_points(config.minimum_key_points) {}
 
 ImageOffsetEstimator::ImageOffsetEstimator()
     : ImageOffsetEstimator(ImageOffsetEstimatorConfig()) {}
 
-std::optional<double> ImageOffsetEstimator::estimate(FrameDescriptor &from, FrameDescriptor &to, double guess) const {
+std::vector<OffsetCandidate> detectOffsetCandidates(const std::vector<double> &displacements, size_t count_threshold) {
+    if (displacements.empty()) {
+        return {};
+    }
+
+    // 1-px bins keyed by the rounded displacement; std::map keeps them ordered for the local-maxima walk.
+    std::map<long, int> bins;
+    for (const double displacement : displacements) {
+        bins[std::lround(displacement)]++;
+    }
+    const auto countAt = [&bins](long bin) {
+        const auto it = bins.find(bin);
+        return it != bins.end() ? it->second : 0;
+    };
+
+    std::vector<OffsetCandidate> candidates;
+    for (const auto &[bin, count] : bins) {
+        // Local maximum with ties resolved to the leftmost bin, so a spike split evenly across a bin
+        // boundary yields one peak instead of two 1-px-apart twins.
+        if (count <= countAt(bin - 1) || count < countAt(bin + 1)) {
+            continue;
+        }
+
+        // Merge the +-1 px neighbours: genuine spikes are 1-2 px wide, and thresholding the merged count
+        // keeps a boundary-split spike above the threshold even when no single bin reaches it alone.
+        std::vector<double> members;
+        for (const double displacement : displacements) {
+            if (std::abs(std::lround(displacement) - bin) <= 1) {
+                members.push_back(displacement);
+            }
+        }
+        if (members.size() < count_threshold) {
+            continue;
+        }
+
+        const auto median_iterator = members.begin() + static_cast<long>(members.size() / 2);
+        std::nth_element(members.begin(), median_iterator, members.end());
+        candidates.push_back({*median_iterator, static_cast<int>(members.size())});
+    }
+    return candidates;
+}
+
+std::optional<double> ImageOffsetEstimator::estimate(FrameDescriptor &from, FrameDescriptor &to) const {
+    // A mid-scroll resolution change makes pixel offsets between the frames meaningless (and the overlap
+    // verification below would reject every candidate anyway). Bail up front.
+    if (!(from.frame.size() == to.frame.size())) {
+        return std::nullopt;
+    }
+
     detectKeyPoints(from);
     detectKeyPoints(to);
 
     // A near-uniform fragment yields zero AKAZE keypoints and an empty descriptor Mat; FLANN's knnMatch
     // can throw on empty/too-small train or query sets. k=2 needs at least two train rows. Bail early with
-    // the same "unreliable -> nullopt" semantics as the minimum_key_points guard below.
+    // the same "unreliable -> nullopt" semantics as an empty candidate list below.
     if (from.descriptors.empty() || to.descriptors.empty() || from.descriptors.rows < 2
         || to.descriptors.rows < 2) {
         return std::nullopt;
@@ -325,63 +359,45 @@ std::optional<double> ImageOffsetEstimator::estimate(FrameDescriptor &from, Fram
     std::vector<std::vector<cv::DMatch>> matches;
     matcher->knnMatch(from.descriptors, to.descriptors, matches, 2);
 
-    // vertical_threshold is a fraction of the frame width; scale it to pixels to match the keypoint coordinates.
-    const double vertical_margin = vertical_threshold * from.frame.width();
-    const Range<double> valid_range = {guess - vertical_margin, guess + vertical_margin};
-    std::vector<cv::Point2f> valid_key_points_of_from;
-    std::vector<cv::Point2f> valid_key_points_of_to;
+    // Collect every trusted match's vertical displacement, unwindowed. The scroll-bar guess deliberately
+    // plays no part here: on the terminating (bottom-clipped) frame the thumb's remaining travel collapses,
+    // the guess with it, and a window centred on it rejects the true offset -- the exact frame where offset
+    // accuracy decides whether the last row is captured.
+    std::vector<double> displacements;
     for (const auto &knn_match : matches) {
         // If the 2nd is closer to the 1st, the higher the probability that the 2nd is the correct one.
         if (knn_match.size() != 2 || knn_match[0].distance >= knn_match[1].distance * trust_ratio) {
             continue;
         }
-
         const auto &key_point_of_from = from.key_points[knn_match[0].queryIdx].pt;
         const auto &key_point_of_to = to.key_points[knn_match[0].trainIdx].pt;
+        displacements.push_back(key_point_of_from.y - key_point_of_to.y);
+    }
 
-        // The guess is not precise, but never wrong, matches that are far from it can be discarded.
-        if (!valid_range.contains(key_point_of_from.y - key_point_of_to.y)) {
-            continue;
+    const auto candidates = detectOffsetCandidates(displacements, static_cast<size_t>(minimum_key_points));
+    if (candidates.empty()) {
+        return std::nullopt;
+    }
+
+    // Let pixel evidence choose: the candidate with the strongest full-resolution overlap wins, regardless
+    // of how many keypoints voted for it. A keypoint majority is NOT trustworthy on this content -- factor
+    // rows repeat at a constant pitch, so an alias one row-pitch off can collect more matches than the true
+    // offset while overlaying visibly wrong pixels.
+    const cv::Mat &from_gray = grayFrame(from);
+    const cv::Mat &to_gray = grayFrame(to);
+    double best_offset = 0.0;
+    double best_score = -1.0;
+    for (const auto &candidate : candidates) {
+        const double score = overlapScore(from_gray, to_gray, std::lround(candidate.offset));
+        if (score > best_score) {
+            best_score = score;
+            best_offset = candidate.offset;
         }
-        valid_key_points_of_from.push_back(key_point_of_from);
-        valid_key_points_of_to.push_back(key_point_of_to);
     }
-
-    // If too many key points are discarded, the result is unreliable anyway.
-    if (valid_key_points_of_from.size() < minimum_key_points || valid_key_points_of_to.size() < minimum_key_points) {
+    if (best_score < minimum_overlap_score) {
         return std::nullopt;
     }
-
-    cv::Mat masks;
-    cv::Mat result = cv::findHomography(valid_key_points_of_to, valid_key_points_of_from, masks, cv::RANSAC, 3);
-    // findHomography returns an empty Mat when it cannot fit one (degenerate/insufficient inliers); reading
-    // matrix[2]/matrix[5] off an empty vector would be out of bounds. Treat a non-3x3 result as no match.
-    if (result.empty() || result.rows != 3 || result.cols != 3) {
-        return std::nullopt;
-    }
-    std::vector<double> matrix((double *) result.datastart, (double *) result.dataend);
-    const Point<double> offset = {matrix[2], matrix[5]};
-
-    // The result should only be a translation; a non-identity scale/rotation/shear means the match is wrong.
-    matrix[2] = 0.0;
-    matrix[5] = 0.0;
-    const std::vector<double> eye{1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
-    if (!closeEnough(matrix, eye, 0.1)) {
-        return std::nullopt;
-    }
-
-    // The scroll is vertical, so the horizontal translation should be ~0. A tiny value is sub-pixel matching noise
-    // and is accepted directly. A larger one (e.g. a fast scroll that leaves little frame overlap) is verified
-    // against pixel evidence instead of trusting the feature match, which can be self-consistent yet wrong:
-    // overlay the two frames using only the vertical offset and require a high overlap correlation. Rejecting these
-    // frames outright would freeze the reference descriptor and stall the page (the scroll-bar guess then grows
-    // unbounded), so this confirms the result the estimator actually returns before keeping it.
-    if (std::abs(offset.x()) > horizontal_threshold
-        && overlapScore(from.frame.data(), to.frame.data(), std::lround(offset.y())) < minimum_overlap_score) {
-        return std::nullopt;
-    }
-
-    return offset.y();
+    return best_offset;
 }
 
 void ImageOffsetEstimator::detectKeyPoints(FrameDescriptor &descriptor) const {
@@ -391,45 +407,58 @@ void ImageOffsetEstimator::detectKeyPoints(FrameDescriptor &descriptor) const {
     detector->detectAndCompute(descriptor.frame.data(), cv::noArray(), descriptor.key_points, descriptor.descriptors);
 }
 
-double ImageOffsetEstimator::overlapScore(const cv::Mat &from_frame, const cv::Mat &to_frame, long offset_pixels) const {
-    if (from_frame.size() != to_frame.size()) {
-        // Resolution changed mid-scroll. rowRange/matchTemplate below would throw on mismatched sizes and the
-        // runner would swallow it, stalling the tab. Report no overlap evidence (reject the offset) instead.
-        return 0.0;
-    }
-    const int height = from_frame.rows;
-    const long overlap_height = height - offset_pixels;
-    // overlap_height is a row count, but the threshold multiplies `cols` deliberately: minimum_overlap_height
-    // is a fraction of the frame WIDTH (the project's length unit -- see the config field doc), not of height.
-    // This is meaningful only while the scroll-area crop stays taller than minimum_overlap_height * cols, which
-    // holds for the configured crop (0.05 * width against a crop taller than that).
-    if (offset_pixels <= 0 || overlap_height < minimum_overlap_height * from_frame.cols) {
-        return 0.0;
-    }
-    const auto gray = [](const cv::Mat &frame) {
-        if (frame.channels() == 1) {
-            return frame;
+const cv::Mat &ImageOffsetEstimator::grayFrame(FrameDescriptor &descriptor) {
+    if (descriptor.gray.empty()) {
+        const cv::Mat &data = descriptor.frame.data();
+        if (data.channels() == 1) {
+            descriptor.gray = data;
+        } else {
+            cv::cvtColor(data, descriptor.gray, cv::COLOR_BGR2GRAY);
         }
-        cv::Mat result;
-        cv::cvtColor(frame, result, cv::COLOR_BGR2GRAY);
-        return result;
-    };
-    cv::Mat from_overlap = gray(from_frame).rowRange(static_cast<int>(offset_pixels), height);
-    cv::Mat to_overlap = gray(to_frame).rowRange(0, height - static_cast<int>(offset_pixels));
-    if (overlap_downscale > 1) {
-        const cv::Size size = {
-            std::max(1, from_overlap.cols / overlap_downscale),
-            std::max(1, from_overlap.rows / overlap_downscale),
-        };
-        cv::resize(from_overlap, from_overlap, size, 0, 0, cv::INTER_AREA);
-        cv::resize(to_overlap, to_overlap, size, 0, 0, cv::INTER_AREA);
     }
-    cv::Mat score;
-    cv::matchTemplate(from_overlap, to_overlap, score, cv::TM_CCOEFF_NORMED);
-    // TM_CCOEFF_NORMED is NaN when either band has zero variance (a near-uniform overlap, e.g. a long blank
-    // scroll gap). NaN must not slip through as a pass: `NaN < minimum_overlap_score` is false, which would
-    // skip the rejection and accept the suspect offset. Treat a non-finite score as no evidence (0.0).
-    const float result = score.at<float>(0, 0);
+    return descriptor.gray;
+}
+
+double ImageOffsetEstimator::overlapScore(const cv::Mat &from_gray, const cv::Mat &to_gray, long offset_pixels) const {
+    if (from_gray.size() != to_gray.size()) {
+        // rowRange/matchTemplate below would throw on mismatched sizes and the runner would swallow it,
+        // stalling the tab. Report no overlap evidence (reject the offset) instead.
+        return 0.0;
+    }
+    const int height = from_gray.rows;
+    const long overlap_height = height - std::labs(offset_pixels);
+    // Fraction of the crop HEIGHT (not the project's usual width unit): the guard bounds how much of the
+    // frames' shared content backs the correlation, which is inherently a height proportion. This also
+    // rejects |offset| >= height, so the rowRange arithmetic below cannot go out of bounds.
+    if (overlap_height < minimum_overlap_fraction * height) {
+        return 0.0;
+    }
+    const int shift = static_cast<int>(offset_pixels);
+    const cv::Mat from_overlap = shift >= 0 ? from_gray.rowRange(shift, height) : from_gray.rowRange(0, height + shift);
+    const cv::Mat to_overlap = shift >= 0 ? to_gray.rowRange(0, height - shift) : to_gray.rowRange(-shift, height);
+
+    // Zero-mean normalized cross-correlation (the TM_CCOEFF_NORMED value), computed directly:
+    // r = (sum(a*b) - N*mean_a*mean_b) / (N*sigma_a*sigma_b). matchTemplate is deliberately NOT used --
+    // for a template the size of the image (a single correlation point) it takes its DFT path, an order
+    // of magnitude slower than these three linear passes at full resolution (~8 ms vs <1 ms per verify).
+    // The double-precision accumulators are exact for this input (N*255^2 << 2^53).
+    cv::Scalar from_mean, from_stddev, to_mean, to_stddev;
+    cv::meanStdDev(from_overlap, from_mean, from_stddev);
+    cv::meanStdDev(to_overlap, to_mean, to_stddev);
+
+    // A (near-)zero-variance band -- a blank scroll gap -- carries no alignment evidence; without this
+    // guard the ~0/0 correlation could read as a perfect match (matchTemplate clamps that case to +-1)
+    // and a blank overlap would outscore every genuine candidate. 1e-3 on the 0-255 intensity scale only
+    // triggers on essentially flat pixels; any real content (text, card edges) has orders of magnitude
+    // more variance.
+    constexpr double zero_variance_epsilon = 1e-3;
+    if (from_stddev[0] <= zero_variance_epsilon || to_stddev[0] <= zero_variance_epsilon) {
+        return 0.0;
+    }
+
+    const double pixels = static_cast<double>(from_overlap.total());
+    const double result = (from_overlap.dot(to_overlap) - pixels * from_mean[0] * to_mean[0])
+                          / (pixels * from_stddev[0] * to_stddev[0]);
     return std::isfinite(result) ? result : 0.0;
 }
 
@@ -443,27 +472,7 @@ std::optional<double> ScrollAreaOffsetEstimator::position(const FrameDescriptor 
 }
 
 std::optional<double> ScrollAreaOffsetEstimator::estimate(FrameDescriptor &from, FrameDescriptor &to) const {
-    const auto guess = scroll_bar_offset_estimator.estimate(from.scroll_bar_frame, to.scroll_bar_frame);
-    if (!guess) {
-        return std::nullopt;
-    }
-    return image_offset_estimator.estimate(from, to, guess.value());
-}
-
-std::optional<double>
-ScrollAreaOffsetEstimator::estimateAcrossRescale(FrameDescriptor &from, FrameDescriptor &to) const {
-    // Fallback for when estimate()'s shared-length guess fails: match the two frames at a guess computed
-    // from each frame's OWN thumb length, which stays valid across a thumb-length change (the game lazily
-    // re-scales the factor thumb when it appends inheritance history). The image matcher validates the
-    // result, so a wrong guess (e.g. an unrelated content change) simply yields nullopt.
-    if (!(from.frame.size() == to.frame.size())) {
-        return std::nullopt;  // resolution change; estimate() already rejected it -- do not recover here.
-    }
-    const auto guess = scroll_bar_offset_estimator.scrollOffsetGuess(from.scroll_bar_frame, to.scroll_bar_frame);
-    if (!guess) {
-        return std::nullopt;
-    }
-    return image_offset_estimator.estimate(from, to, guess.value());
+    return image_offset_estimator.estimate(from, to);
 }
 
 PageScrapingBox::PageScrapingBox(
@@ -989,17 +998,10 @@ void ScrollableScrapingInterpreter::startScrolling(const FrameDescriptor &valid_
 
 void ScrollableScrapingInterpreter::updateScrolling(const Frame &frame) {
     FrameDescriptor current_fragment = {frame.copy(scroll_area_rect), frame.copy(scroll_bar_rect)};
-    auto offset = offset_estimator.estimate(previous_descriptor, current_fragment);
-    if (!offset.has_value()) {
-        // The shared-length scroll-bar guess in estimate() breaks when the game lazily re-scales the
-        // thumb (factor inheritance history appended mid-scroll): the two frames' thumb lengths disagree,
-        // the guess becomes inconsistent with the pixels, the image match rejects it, and the reference
-        // would freeze -- stalling the tab. Recover with a guess computed from each frame's OWN thumb
-        // length, which stays valid across the re-scale. If the frames still match we keep the true offset
-        // and capture the fragment normally (no skipped content); if they do not match this stays nullopt
-        // exactly as before.
-        offset = offset_estimator.estimateAcrossRescale(previous_descriptor, current_fragment);
-    }
+    // Guess-free: the offset comes from image evidence alone, so a scroll-bar thumb re-scale (inheritance
+    // history appended mid-scroll) or a clipped thumb cannot mislead it. On a genuine non-match the offset
+    // stays nullopt, the frame is skipped, and the reference descriptor freezes until a matching frame comes.
+    const auto offset = offset_estimator.estimate(previous_descriptor, current_fragment);
 
     // Check the green terminator every frame, anchored to the scroll frontier (height - offset), BEFORE
     // the minimum_scroll gate below. The bar can pop in in-place while the content is effectively

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -32,16 +32,6 @@ constexpr double kFactorEndGreenSearchSpan = 0.08;
 // still staged in RAM when the terminator fires.
 constexpr double kFactorEndGraySearchSpan = 0.16;
 
-// Thumb-bottom "clip" tolerance in pixels: at/below the true bottom the game pins the thumb bottom to the
-// track bottom (lower_gap ~= 0-1 px) and, if the user keeps dragging (overscroll), slides the thumb TOP down
-// so the MEASURED thumb length collapses while the logical length is unchanged. When lower_gap is within this
-// tolerance the frame is treated as clipped and the offset guess uses the reference frame's (unclipped)
-// logical thumb length instead of the shrunken measured one -- otherwise the shrinking divisor blows the
-// guess up (hundreds of px) and the image matcher's search window misses the true small offset. Expressed in
-// px via the anchor (mirroring factor_header.flush_tolerance_px = 1.5); a genuine mid-scroll history rescale
-// keeps content below the thumb so lower_gap stays well above this and the normal path is used.
-constexpr double kThumbBottomFlushPx = 2.0;
-
 }  // namespace
 
 ScrollBarOffsetEstimator::ScrollBarOffsetEstimator(
@@ -96,10 +86,6 @@ ScrollBarOffsetEstimator::geometryAt(const Frame &frame, const Line<double> &sca
     const double upper_gap = std::max(0., thumb_top - track_top);
     const double lower_gap = std::max(0., track_bottom - thumb_bottom);
     return TrackGeometry{upper_gap, lower_gap, track_span, thumb_logical};
-}
-
-bool ScrollBarOffsetEstimator::isBottomClipped(const Frame &frame, const TrackGeometry &geometry) const {
-    return frame.anchor().scaleToPixels(geometry.lower_gap) <= kThumbBottomFlushPx;
 }
 
 std::optional<double> ScrollBarOffsetEstimator::trackCenterX(const Frame &frame) const {
@@ -213,66 +199,6 @@ std::optional<double> ScrollBarOffsetEstimator::topMargin(const Frame &frame) co
         return std::nullopt;
     }
     return geometry->upper_gap / geometry->track_span;
-}
-
-std::optional<double> ScrollBarOffsetEstimator::estimate(const Frame &from, const Frame &to) const {
-    // A mid-scroll resolution change would mix from's pixel scale (viewport_px below) with a cross-scale
-    // averaged thumb length, so the delta is only valid at one scale. Bail. (!= is not auto-generated for
-    // value types here; use !(==).)
-    if (!(from.size() == to.size())) {
-        return std::nullopt;
-    }
-
-    const auto from_geometry = trackGeometry(from);
-    const auto to_geometry = trackGeometry(to);
-    if (!from_geometry || !to_geometry) {
-        return std::nullopt;
-    }
-
-    // Delta form over the calibrated track geometry: the fixed track top cancels in the upper_gap
-    // difference, so only one shared thumb length divides -- unlike scrollOffsetGuess()'s per-frame absolute
-    // difference, this cancels each frame's constant measurement bias and stays low-noise. When the game
-    // re-scales the thumb mid-scroll the two lengths disagree and this guess drifts; the image match then
-    // rejects it and estimateAcrossRescale() (each frame's OWN length) recovers -- see updateScrolling().
-    // On bottom overscroll the measured thumb collapses (top slides down, bottom pinned) while the logical
-    // length is constant (isBottomClipped(); see kThumbBottomFlushPx). On the clip, divide by the reference
-    // frame's logical length -- `from` is the last successful latch, frozen at the resting bottom (overscroll
-    // frames never latch), so its thumb length is the true unclipped one. Off the clip, keep the shared average.
-    const bool clipped = isBottomClipped(to, to_geometry.value());
-    const double thumb_logical = clipped
-        ? from_geometry->thumb_logical
-        : (from_geometry->thumb_logical + to_geometry->thumb_logical) / 2.0;
-    if (thumb_logical <= 0.0) {
-        return std::nullopt;
-    }
-    const double viewport_px = from.anchor().scaleToPixels(viewport);
-    return viewport_px * (to_geometry->upper_gap - from_geometry->upper_gap) / thumb_logical;
-}
-
-std::optional<double> ScrollBarOffsetEstimator::scrollOffsetGuess(const Frame &from, const Frame &to) const {
-    const auto from_geometry = trackGeometry(from);
-    const auto to_geometry = trackGeometry(to);
-    if (!from_geometry || !to_geometry) {
-        return std::nullopt;
-    }
-    // Absolute scroll offset (content px from the top) implied by one frame's scrollbar geometry, using THAT
-    // frame's own thumb length -- unlike estimate()'s shared-length delta, this stays correct across a
-    // thumb-length change. abs = V * upper_gap / thumb_logical, with V the true viewport (config, width-
-    // normalized -> px via scaleToPixels) rather than the crop height, and thumb_logical the cap-corrected
-    // thumb length. The fixed track top cancels in the delta below, but V and the -2c correction do not.
-    // Same clip guard as estimate(): when the thumb bottom is pinned (overscroll, or a history rescale that
-    // lands at the bottom), the `to` frame's measured length is corrupted, so divide BOTH absolute offsets by
-    // the reference (`from`) logical length. That cancels the constant bias exactly and keeps the delta sane;
-    // off the clip each frame keeps its own length so a genuine mid-scroll rescale is untouched.
-    const bool clipped = isBottomClipped(to, to_geometry.value());
-    const double reference_thumb = from_geometry->thumb_logical;
-    const auto absolute_offset =
-        [this, clipped, reference_thumb](const Frame &frame, const TrackGeometry &geometry) -> double {
-        const double viewport_px = frame.anchor().scaleToPixels(viewport);
-        const double thumb_logical = clipped ? reference_thumb : geometry.thumb_logical;
-        return viewport_px * geometry.upper_gap / thumb_logical;
-    };
-    return absolute_offset(to, to_geometry.value()) - absolute_offset(from, from_geometry.value());
 }
 
 ImageOffsetEstimator::ImageOffsetEstimator(const ImageOffsetEstimatorConfig &config)

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -59,7 +59,6 @@ public:
         const Range<Color> &scroll_bar_bg_color_range,
         const Line<double> &scroll_bar_scan_line,
         const Range<Color> &scroll_bar_margin_color_range,
-        double viewport,
         double cap_offset,
         const scraper_config::ScrollBarThumbProbeConfig &thumb_probe);
 
@@ -104,7 +103,6 @@ private:
     const Range<Color> scroll_bar_bg_color_range;
     const Line<double> scroll_bar_scan_line;
     const Range<Color> scroll_bar_margin_color_range;
-    const double viewport;
     const double cap_offset;
     const scraper_config::ScrollBarThumbProbeConfig thumb_probe;
 };

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -48,6 +48,7 @@ struct FrameDescriptor {
     Frame scroll_bar_frame;  // full-width scrollbar band: scrollbar geometry only
     std::vector<cv::KeyPoint> key_points;
     cv::Mat descriptors;
+    cv::Mat gray;  // grayscale of `frame`, lazily cached like key_points/descriptors (see grayFrame)
 
     [[nodiscard]] bool empty() const { return frame.empty(); }
 };
@@ -125,30 +126,43 @@ private:
     const scraper_config::ScrollBarThumbProbeConfig thumb_probe;
 };
 
+// One local maximum of the 1-px keypoint-displacement histogram: a plausible vertical scroll offset,
+// carrying the sub-pixel median of the displacements merged into the peak and how many matches support it.
+struct OffsetCandidate {
+    double offset;  // median of the peak's merged displacements (genuine peaks are ~1 px wide, so sub-pixel accurate)
+    int count;      // matches merged into the peak (the peak bin and its +-1 px neighbours)
+};
+
+// Extracts scroll-offset candidates from raw keypoint vertical displacements via a 1-px-bin histogram:
+// every local maximum whose merged count (peak bin + its +-1 px neighbours, absorbing spikes split across a
+// bin boundary) reaches count_threshold becomes a candidate. Genuine offsets show up as razor-sharp 1-2 px
+// spikes (sub-pixel keypoint localization noise is ~constant in pixels regardless of resolution), while
+// mismatch noise is wide but sparse -- a few counts per bin -- and never forms a qualifying peak. Local-maxima
+// detection is used instead of gap-based clustering deliberately: sparse noise bridging two nearby genuine
+// peaks would chain them into one merged cluster with a wrong median, but it cannot turn a valley into a
+// local maximum. The full range is considered, including zero and negative displacements, so a static frame
+// yields a candidate at ~0 instead of a false positive elsewhere. Candidates are returned in ascending
+// offset order; the caller decides between them on pixel evidence, not on count.
+[[nodiscard]] std::vector<OffsetCandidate> detectOffsetCandidates(
+    const std::vector<double> &displacements, size_t count_threshold);
+
 class ImageOffsetEstimator {
 public:
     struct ImageOffsetEstimatorConfig {
         double trust_ratio = 0.5;
-        // Scroll is purely vertical, so a tiny horizontal translation is accepted as matching noise. A larger one is
-        // verified by overlaying the frames (see estimate()) rather than trusted on the feature match alone.
-        double horizontal_threshold = 1.5;
-        // Half-width of the keypoint-acceptance window centred on the scroll-bar guess, as a fraction of the frame
-        // width (the project's length unit) so it is resolution-independent. The guess error scales with the frame's
-        // pixel size, so an absolute-pixel window would clip genuine matches on higher-resolution screens. Measured on
-        // 736px-wide footage the worst genuine keypoint sits 0.0586*width from the guess and the tightest periodic-row
-        // pitch is 0.0815*width, so 0.068 stays clear of both (it equals the previous 50px on that width).
-        double vertical_threshold = 0.068;
-        // When the horizontal translation exceeds horizontal_threshold, the vertical offset is confirmed by overlapping
-        // the two frames and requiring at least this normalized cross-correlation. Measured genuine scrolls score
-        // >=0.95 and wrong alignments <=0.56, so 0.8 separates them with margin.
+        // A candidate offset is accepted only when overlaying the two frames at it reaches this normalized
+        // cross-correlation. Measured genuine scrolls score >=0.91 and wrong alignments <=0.73 across all
+        // golden clips, so 0.8 separates them with margin.
         double minimum_overlap_score = 0.8;
-        // The overlap must be at least this tall (as a fraction of the frame width, the project's length unit) for the
-        // correlation to be meaningful. A thinner band -- only possible when the scroll is nearly a full frame -- is
-        // too little evidence to trust a large stitch on, and a near-uniform sliver could even correlate spuriously.
-        double minimum_overlap_height = 0.05;
-        // Downscale factor applied before the overlap correlation. The renderer is not pixel-exact (sub-pixel shifts),
-        // so averaging neighbours makes the score robust to that noise (and cheaper).
-        int overlap_downscale = 4;
+        // The overlap must be at least this fraction of the frame (crop) HEIGHT for the correlation to be
+        // meaningful. A thinner band -- only possible when the scroll is nearly a full frame -- is too little
+        // evidence to trust a large stitch on, and a near-uniform sliver can even correlate spuriously high
+        // (measured: a 37 px sliver scoring 0.989 on a wrong offset).
+        double minimum_overlap_fraction = 0.10;
+        // Minimum merged match count for a displacement-histogram peak to become a candidate. This is a count,
+        // and keypoint counts scale with resolution/content: measured on ~736 px-wide footage genuine peaks
+        // carry 35-600 matches and noise bins <=9, but do not raise this on that evidence alone. Keep it low --
+        // a spurious extra candidate is rejected by the overlap gate, while a missed genuine peak loses the frame.
         int minimum_key_points = 10;
         int descriptor_channels = 3;
         float descriptor_threshold = 0.001f;
@@ -163,26 +177,36 @@ public:
 
     ImageOffsetEstimator();
 
-    [[nodiscard]] std::optional<double> estimate(FrameDescriptor &from, FrameDescriptor &to, double guess) const;
+    // Vertical content scroll between the frames, guess-free: keypoint matching proposes a short list of
+    // displacement-histogram candidates (detectOffsetCandidates) and dense pixel overlap selects among them
+    // (overlapScore). Neither side decides alone -- a keypoint majority can lock onto a periodic-row alias
+    // (factor rows repeat every ~0.09 of the width), and a dense scan alone can spike on a thin sliver; each
+    // covers the other's failure. Returns the winning candidate's sub-pixel offset, or nullopt when the
+    // frames differ in size, yield too few features, or no candidate passes the overlap gate.
+    [[nodiscard]] std::optional<double> estimate(FrameDescriptor &from, FrameDescriptor &to) const;
+
+    // Overlays the two (grayscale, full-resolution) frames shifted by the vertical offset and returns the
+    // normalized cross-correlation of their shared region. Symmetric in the shift sign: a point at row y in
+    // `to` lands at row y + offset_pixels in `from`, so a negative offset (backward scroll) reverses the row
+    // ranges, and zero compares the full frames -- a static frame therefore verifies at ~1 instead of needing
+    // a special case. Returns 0 when the overlap is thinner than minimum_overlap_fraction of the height or
+    // the sizes mismatch, which the caller treats as no evidence. Public for direct unit testing; production
+    // callers go through estimate().
+    [[nodiscard]] double overlapScore(const cv::Mat &from_gray, const cv::Mat &to_gray, long offset_pixels) const;
 
 private:
     void detectKeyPoints(FrameDescriptor &descriptor) const;
 
-    // Overlays the two frames shifted by the vertical offset and returns the normalized cross-correlation of their
-    // shared region. A point at row y in `to` lands at row y + offset_pixels in `from`, so those row ranges hold the
-    // overlapping content. Returns 0 when the overlap is too thin to verify (a non-positive scroll, or a band shorter
-    // than minimum_overlap_height of the frame width), which the caller treats as a failed match.
-    [[nodiscard]] double overlapScore(const cv::Mat &from_frame, const cv::Mat &to_frame, long offset_pixels) const;
+    // Grayscale of the descriptor's content crop, computed once and cached on the descriptor (same lazy
+    // pattern as detectKeyPoints), so per-candidate verification and the next frame's `from` role reuse it.
+    static const cv::Mat &grayFrame(FrameDescriptor &descriptor);
 
     const cv::Ptr<cv::Feature2D> detector;
     const cv::Ptr<cv::FlannBasedMatcher> matcher;
     const double trust_ratio;
-    const double horizontal_threshold;
     const double minimum_overlap_score;
-    const double minimum_overlap_height;
-    const int overlap_downscale;
+    const double minimum_overlap_fraction;
     const int minimum_key_points;
-    const double vertical_threshold;
 };
 
 class ScrollAreaOffsetEstimator {
@@ -192,12 +216,11 @@ public:
 
     [[nodiscard]] std::optional<double> position(const FrameDescriptor &descriptor) const;
 
+    // Content scroll offset between the frames, decided purely by the image estimator. The scroll bar is NOT
+    // consulted: its guess is wrong exactly when it matters most (the thumb pins to the track bottom on the
+    // terminating frame, collapsing the measured travel), and a keypoint window built on a wrong guess
+    // rejects the true offset. The scroll-bar estimator remains only for position()/topMargin().
     [[nodiscard]] std::optional<double> estimate(FrameDescriptor &from, FrameDescriptor &to) const;
-
-    // Recovery estimate for when estimate() fails because the thumb re-scaled (factor inheritance
-    // history appended mid-scroll): matches the two frames at scrollOffsetGuess, a guess valid across a
-    // thumb-length change. Returns the image-verified offset, or nullopt if the frames do not match.
-    [[nodiscard]] std::optional<double> estimateAcrossRescale(FrameDescriptor &from, FrameDescriptor &to) const;
 
 private:
     const ScrollBarOffsetEstimator scroll_bar_offset_estimator;

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -76,18 +76,6 @@ public:
     // completed tab snapping back to the top after a character switch.
     [[nodiscard]] std::optional<double> topMargin(const Frame &frame) const;
 
-    // Content-pixel scroll offset between two frames: the placeholder-track upper_gap difference over a
-    // shared (cap-corrected) thumb length, scaled by the true viewport. The fixed track top cancels in the
-    // difference, so this delta form keeps low per-frame noise. The primary guess that seeds the image
-    // matcher for stitching. nullopt when either frame has no scrollbar or on a mid-scroll resolution change.
-    [[nodiscard]] std::optional<double> estimate(const Frame &from, const Frame &to) const;
-
-    // Content-pixel scroll offset between two frames, computed from each frame's OWN thumb length, so it
-    // stays correct across a thumb-length change (unlike estimate()'s shared-length delta). Used as the
-    // recovery guess when estimate() fails because the game lazily re-scaled the thumb (factor
-    // inheritance history appended mid-scroll). nullopt when either frame has no scrollbar.
-    [[nodiscard]] std::optional<double> scrollOffsetGuess(const Frame &from, const Frame &to) const;
-
 private:
     // Placeholder-track geometry from one frame, all width-normalized. The thumb and track ends come from
     // colour runs along the scan line: the background run reaches the (dark) thumb, the margin run reaches
@@ -112,11 +100,6 @@ private:
     // (~10x more stable than a hard threshold; tolerates layout/resolution drift). nullopt when the thumb is
     // not found or the cap contrast is too low, so trackGeometry() falls back to the config column.
     [[nodiscard]] std::optional<double> trackCenterX(const Frame &frame) const;
-
-    // True when the thumb bottom is pinned to the track bottom (bottom rest / overscroll): the measured thumb
-    // length is corrupted (top slides down, bottom pinned), so the offset guess must divide by the reference
-    // frame's logical length instead. See kThumbBottomFlushPx.
-    [[nodiscard]] bool isBottomClipped(const Frame &frame, const TrackGeometry &geometry) const;
 
     const Range<Color> scroll_bar_bg_color_range;
     const Line<double> scroll_bar_scan_line;

--- a/native/src/core/native_api.cpp
+++ b/native/src/core/native_api.cpp
@@ -61,16 +61,26 @@ void NativeApi::startPipeline(const std::string &native_config) {
 
     const auto queue_limit_mode = video_mode ? event_util::QueueLimitMode::Block : event_util::QueueLimitMode::Discard;
 
+    // Frame-path queue depth (recorder -> distributor -> scraper). Deeper than the default so live
+    // (Discard) capture rides out transient per-frame spikes -- the scraper's offset estimation sits
+    // near the 33 ms frame budget at p95, and occasional AKAZE/scheduling spikes would otherwise drop
+    // frames a depth-3 queue cannot absorb. Sustained overload still degrades to frame thinning (by
+    // design); the costs of the extra depth are bounded staleness (8 frames ~ 270 ms at 30 fps) and a
+    // few refcounted frames of RAM. Video (Block) mode is unaffected in outcome: depth only changes
+    // read-ahead.
+    constexpr size_t frame_queue_limit_size = 8;
+
     assert_(event_runners == nullptr);
     event_runners = event_util::makeRunnerController();
 
     const auto distributor_runner =
-        event_util::makeSingleThreadRunner(queue_limit_mode, detach_callback, "distributor");
+        event_util::makeSingleThreadRunner(queue_limit_mode, detach_callback, "distributor", frame_queue_limit_size);
     event_runners->add(distributor_runner);
     const auto frame_captured_connection = distributor_runner->makeConnection<Frame>();
     on_frame_captured = frame_captured_connection;
 
-    const auto scraper_runner = event_util::makeSingleThreadRunner(queue_limit_mode, detach_callback, "scraper");
+    const auto scraper_runner =
+        event_util::makeSingleThreadRunner(queue_limit_mode, detach_callback, "scraper", frame_queue_limit_size);
     event_runners->add(scraper_runner);
 
     const auto chara_detail_updated_connection = scraper_runner->makeConnection<Frame, chara_detail::SceneState>();

--- a/native/src/util/event_util.h
+++ b/native/src/util/event_util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <stdexcept>
 #include <thread>
 #include <utility>
@@ -18,6 +19,14 @@ enum QueueLimitMode {
     Discard,
     Block,
 };
+
+// Default depth of a Discard/Block-mode connection's queue. In Discard mode the depth is a burst
+// absorber, not a throughput fix: a consumer that is slow for a few events keeps them queued instead
+// of dropping, but a consumer that is slower than the producer on average eventually drops no matter
+// the depth. Deeper queues trade memory (queued args stay alive) and worst-case staleness
+// (depth x production interval) for burst tolerance; pass a per-connection size where that trade
+// matters (see the frame-path runners in native_api.cpp).
+inline constexpr size_t kDefaultQueueLimitSize = 3;
 
 namespace event_util_impl {
 
@@ -100,13 +109,19 @@ private:
 template<typename... Args>
 class QueuedConnectionImpl : public ConnectionInterface<Args...>, public EventProcessorInterface {
 public:
-    explicit QueuedConnectionImpl(QueueLimitMode queue_limit_mode)
+    explicit QueuedConnectionImpl(QueueLimitMode queue_limit_mode, size_t queue_limit_size = kDefaultQueueLimitSize)
         : queue_limit_mode(queue_limit_mode)
+        , queue_limit_size(queue_limit_size)
         , notifier(nullptr)
         , id(0) {}
 
-    QueuedConnectionImpl(QueueLimitMode queue_limit_mode, const std::shared_ptr<SenderBase<int>> &notifier, int id)
+    QueuedConnectionImpl(
+        QueueLimitMode queue_limit_mode,
+        size_t queue_limit_size,
+        const std::shared_ptr<SenderBase<int>> &notifier,
+        int id)
         : queue_limit_mode(queue_limit_mode)
+        , queue_limit_size(queue_limit_size)
         , notifier(notifier)
         , id(id) {}
 
@@ -166,7 +181,7 @@ private:
     }
 
     const QueueLimitMode queue_limit_mode;
-    const size_t queue_limit_size = 3;
+    const size_t queue_limit_size;
 
     eventpp::EventQueue<int, void(Args...)> connection;
     const std::shared_ptr<SenderBase<int>> notifier;
@@ -228,11 +243,15 @@ public:
 class SingleThreadMultiEventRunnerImpl : public EventRunnerInterface {
 public:
     SingleThreadMultiEventRunnerImpl(
-        QueueLimitMode queue_limit_mode, const std::function<void()> &finalizer, const std::string &name)
+        QueueLimitMode queue_limit_mode,
+        const std::function<void()> &finalizer,
+        const std::string &name,
+        size_t queue_limit_size = kDefaultQueueLimitSize)
         : notifier(std::make_shared<QueuedConnectionImpl<int>>(QueueLimitMode::NoLimit))
         , finalizer(finalizer)
         , name(name)
-        , queue_limit_mode(queue_limit_mode) {
+        , queue_limit_mode(queue_limit_mode)
+        , queue_limit_size(queue_limit_size) {
         notifier->listen([this](const int &index) {
             assert_(isRunning());
             processors[index]->processOne();
@@ -249,7 +268,7 @@ public:
             throw std::logic_error("SingleThreadMultiEventRunner::makeConnection called after start()");
         }
         auto connection = std::make_shared<QueuedConnectionImpl<Args...>>(
-            queue_limit_mode, notifier, static_cast<int>(processors.size()));
+            queue_limit_mode, queue_limit_size, notifier, static_cast<int>(processors.size()));
         processors.emplace_back(connection);
         return connection;
     }
@@ -299,6 +318,7 @@ private:
     const std::function<void(void)> finalizer;
     const std::string name;
     const QueueLimitMode queue_limit_mode;
+    const size_t queue_limit_size;
 
     std::vector<std::shared_ptr<EventProcessorInterface>> processors;
     std::shared_ptr<EventRunnerThread> runner;
@@ -393,8 +413,9 @@ template<typename... Args, typename Listener>
 }
 
 template<typename... Args>
-[[maybe_unused]] inline QueuedConnection<Args...> makeQueuedConnection(QueueLimitMode queue_limit_mode) {
-    return std::make_shared<event_util_impl::QueuedConnectionImpl<Args...>>(queue_limit_mode);
+[[maybe_unused]] inline QueuedConnection<Args...> makeQueuedConnection(
+    QueueLimitMode queue_limit_mode, size_t queue_limit_size = kDefaultQueueLimitSize) {
+    return std::make_shared<event_util_impl::QueuedConnectionImpl<Args...>>(queue_limit_mode, queue_limit_size);
 }
 
 using EventProcessor = std::shared_ptr<event_util_impl::EventProcessorInterface>;
@@ -403,8 +424,12 @@ using SingleThreadMultiEventRunner = std::shared_ptr<event_util_impl::SingleThre
 using EventRunnerController = std::shared_ptr<event_util_impl::EventRunnerControllerImpl>;
 
 inline SingleThreadMultiEventRunner makeSingleThreadRunner(
-    QueueLimitMode queue_limit_mode, const std::function<void()> &finalizer, const std::string &name) {
-    return std::make_shared<event_util_impl::SingleThreadMultiEventRunnerImpl>(queue_limit_mode, finalizer, name);
+    QueueLimitMode queue_limit_mode,
+    const std::function<void()> &finalizer,
+    const std::string &name,
+    size_t queue_limit_size = kDefaultQueueLimitSize) {
+    return std::make_shared<event_util_impl::SingleThreadMultiEventRunnerImpl>(
+        queue_limit_mode, finalizer, name, queue_limit_size);
 }
 
 inline EventRunnerController makeRunnerController() {

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -2,13 +2,17 @@
 // chara_detail_scene_scraper.cpp.
 //
 // These are the geometric heart of scroll capture: the scroll-bar estimator turns a rendered scroll
-// track into a normalized position/offset, the scroll-area estimator layers image matching on top of it,
-// and the stationary-frame catcher latches a frame once its watched region stops changing. They are
-// driven here with hand-built CV_8UC3 mats through Frame::fixed(), whose anchor normalizes BOTH axes by
-// the frame width, so on a square frame a pixel (px, py) is addressed at normalized (px/w, py/w).
+// track into a normalized position (UI progress / at-top detection), the image estimator decides the
+// content scroll offset from keypoint-displacement candidates verified by pixel overlap, and the
+// stationary-frame catcher latches a frame once its watched region stops changing. They are driven here
+// with hand-built CV_8UC3 mats through Frame::fixed(), whose anchor normalizes BOTH axes by the frame
+// width, so on a square frame a pixel (px, py) is addressed at normalized (px/w, py/w).
 //
 // The image estimator's full AKAZE/FLANN match on synthetic frames is not asserted (it is brittle on
-// feature-poor test images); only its "no features -> nullopt" guard, which is deterministic, is pinned.
+// feature-poor test images); its deterministic pieces are pinned instead: the "no features -> nullopt"
+// guard, the candidate extraction (detectOffsetCandidates on hand-built displacement sets), and the
+// symmetric overlap verification (overlapScore on hand-built grayscale mats). The end-to-end match is
+// arbitrated by the integration golden harness on real footage.
 
 #include <doctest/doctest.h>
 
@@ -21,6 +25,7 @@
 namespace uma::chara_detail {
 namespace {
 
+using scraper_impl::detectOffsetCandidates;
 using scraper_impl::FrameDescriptor;
 using scraper_impl::ImageOffsetEstimator;
 using scraper_impl::ScrollAreaOffsetEstimator;
@@ -146,7 +151,7 @@ TEST_CASE("ScrollBarOffsetEstimator rejects a size change between frames") {
     CHECK_FALSE(estimator.estimate(from, to).has_value());
 }
 
-TEST_CASE("ScrollAreaOffsetEstimator delegates position and short-circuits without a scrollbar") {
+TEST_CASE("ScrollAreaOffsetEstimator delegates position and rejects featureless frames") {
     const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const ImageOffsetEstimator image;  // default config
     const ScrollAreaOffsetEstimator estimator(scroll_bar, image);
@@ -157,8 +162,8 @@ TEST_CASE("ScrollAreaOffsetEstimator delegates position and short-circuits witho
     const FrameDescriptor with_bar{bar, bar};
     CHECK(estimator.position(with_bar).has_value());
 
-    // Two uniform frames have no scroll bar, so the scroll-bar guess is nullopt and estimate() returns
-    // before ever reaching the image matcher.
+    // The offset is decided by the image estimator alone (the scroll bar is not consulted); two uniform
+    // frames yield no keypoints, so the estimate is nullopt.
     const Frame uniform = Frame::fixed(testutil::solid(100, kTrack));
     FrameDescriptor from{uniform, uniform};
     FrameDescriptor to{uniform, uniform};
@@ -190,7 +195,121 @@ TEST_CASE("ImageOffsetEstimator returns nullopt when a frame yields no keypoints
 
     // A uniform frame produces zero AKAZE features and an empty descriptor matrix; the guard rejects it
     // rather than letting FLANN throw on the empty set.
-    CHECK_FALSE(estimator.estimate(from, to, 10.0).has_value());
+    CHECK_FALSE(estimator.estimate(from, to).has_value());
+}
+
+TEST_CASE("detectOffsetCandidates extracts sharp peaks with sub-pixel medians, in ascending order") {
+    std::vector<double> displacements;
+    displacements.insert(displacements.end(), 20, 84.2);  // spurious cluster
+    displacements.insert(displacements.end(), 40, 204.7);  // genuine offset
+    displacements.insert(displacements.end(), 3, 150.0);  // noise below the threshold
+
+    const auto candidates = detectOffsetCandidates(displacements, 10);
+    REQUIRE(candidates.size() == 2);
+    CHECK(candidates[0].offset == doctest::Approx(84.2));
+    CHECK(candidates[0].count == 20);
+    CHECK(candidates[1].offset == doctest::Approx(204.7));
+    CHECK(candidates[1].count == 40);
+}
+
+TEST_CASE("detectOffsetCandidates keeps two nearby peaks separate despite bridge noise") {
+    // The chaining flaw of gap-based clustering: sparse noise bridging two real peaks merges them into one
+    // cluster with a median between them. Local-maxima detection must keep both peaks as candidates.
+    std::vector<double> displacements;
+    displacements.insert(displacements.end(), 200, 100.0);
+    displacements.insert(displacements.end(), 60, 110.0);
+    for (const double bridge : {104.0, 105.0, 105.5, 106.0, 107.0, 107.5, 108.0}) {
+        displacements.push_back(bridge);
+    }
+
+    const auto candidates = detectOffsetCandidates(displacements, 10);
+    REQUIRE(candidates.size() == 2);
+    CHECK(candidates[0].offset == doctest::Approx(100.0));
+    CHECK(candidates[1].offset == doctest::Approx(110.0));
+}
+
+TEST_CASE("detectOffsetCandidates ignores wide but sparse mismatch noise") {
+    // One match every few pixels across a wide range: every bin is a trivial local maximum, but no merged
+    // count comes near the threshold, so nothing qualifies.
+    std::vector<double> displacements;
+    for (int i = 0; i < 30; i++) {
+        displacements.push_back(i * 7.0 - 100.0);
+    }
+
+    CHECK(detectOffsetCandidates(displacements, 10).empty());
+    CHECK(detectOffsetCandidates({}, 10).empty());
+}
+
+TEST_CASE("detectOffsetCandidates covers zero and negative displacements") {
+    // A static frame clusters at ~0 and backward matches go negative; both must surface as candidates
+    // (the historical dense-scan false positives came from excluding exactly these shifts).
+    std::vector<double> displacements;
+    displacements.insert(displacements.end(), 25, 0.02);
+    displacements.insert(displacements.end(), 15, -37.4);
+
+    const auto candidates = detectOffsetCandidates(displacements, 10);
+    REQUIRE(candidates.size() == 2);
+    CHECK(candidates[0].offset == doctest::Approx(-37.4));
+    CHECK(candidates[1].offset == doctest::Approx(0.02));
+}
+
+TEST_CASE("detectOffsetCandidates absorbs a spike split across a bin boundary") {
+    // 6 + 6 matches straddling the 204/205 boundary: neither bin alone reaches the threshold of 10, but the
+    // merged +-1 px peak does, so the (sub-pixel) offset is still found as a single candidate.
+    std::vector<double> displacements;
+    displacements.insert(displacements.end(), 6, 204.4);
+    displacements.insert(displacements.end(), 6, 204.6);
+
+    const auto candidates = detectOffsetCandidates(displacements, 10);
+    REQUIRE(candidates.size() == 1);
+    CHECK(candidates[0].count == 12);
+    CHECK(candidates[0].offset == doctest::Approx(204.6));  // upper median of the 12 merged members
+}
+
+// A tall deterministic noise texture (cv::RNG is a fixed-algorithm LCG, so a fixed seed reproduces
+// everywhere); two windows d rows apart simulate a genuine scroll of d content pixels, and white noise
+// makes any wrong alignment correlate near zero.
+cv::Mat texturedColumn(int height, int width) {
+    cv::Mat mat(height, width, CV_8UC1);
+    cv::RNG rng(12345);
+    rng.fill(mat, cv::RNG::UNIFORM, 0, 256);
+    return mat;
+}
+
+TEST_CASE("ImageOffsetEstimator::overlapScore verifies genuine shifts of either sign and rejects wrong ones") {
+    const ImageOffsetEstimator estimator;  // default config
+    const cv::Mat column = texturedColumn(160, 40);
+    const cv::Mat from = column.rowRange(0, 100);
+    const cv::Mat to = column.rowRange(30, 130);  // `to` shows content 30 px further down
+
+    // A point at row y in `to` is at row y + 30 in `from`, so +30 aligns perfectly.
+    CHECK(estimator.overlapScore(from, to, 30) == doctest::Approx(1.0));
+    // Swapping the roles reverses the sign: the same evidence, negative shift.
+    CHECK(estimator.overlapScore(to, from, -30) == doctest::Approx(1.0));
+    // Identical frames align at zero (the static case needs no special handling).
+    CHECK(estimator.overlapScore(from, from, 0) == doctest::Approx(1.0));
+    // A misaligned shift correlates poorly.
+    CHECK(estimator.overlapScore(from, to, 45) < 0.8);
+}
+
+TEST_CASE("ImageOffsetEstimator::overlapScore returns no evidence on degenerate inputs") {
+    const ImageOffsetEstimator estimator;  // default config
+    const cv::Mat column = texturedColumn(160, 40);
+    const cv::Mat frame = column.rowRange(0, 100);
+
+    // Thinner overlap than minimum_overlap_fraction (0.10 * 100 rows): too little evidence, either sign.
+    CHECK(estimator.overlapScore(frame, frame, 95) == 0.0);
+    CHECK(estimator.overlapScore(frame, frame, -95) == 0.0);
+    // |shift| at/beyond the frame height cannot overlap at all (and must not read out of bounds).
+    CHECK(estimator.overlapScore(frame, frame, 100) == 0.0);
+    CHECK(estimator.overlapScore(frame, frame, 250) == 0.0);
+    // Size mismatch: resolution changed mid-scroll.
+    CHECK(estimator.overlapScore(frame, column.rowRange(0, 50), 10) == 0.0);
+    // A zero-variance (blank) overlap carries no alignment evidence. OpenCV clamps the degenerate
+    // TM_CCOEFF_NORMED to a perfect score rather than NaN, so the estimator must reject it explicitly --
+    // otherwise a blank band would outscore every genuine candidate.
+    const cv::Mat uniform(100, 40, CV_8UC1, cv::Scalar(128));
+    CHECK(estimator.overlapScore(uniform, uniform, 10) == 0.0);
 }
 
 TEST_CASE("StationaryFrameCatcher latches once its region holds still for the threshold") {

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -38,9 +38,9 @@ const Color kThumb{60, 60, 60};  // the scroll thumb
 const Range<Color> kTrackRange{Color(200, 200, 200), Color(255, 255, 255)};  // thumb vs. background
 const Range<Color> kMarginRange{Color(228, 228, 228), Color(255, 255, 255)};  // near-white margin vs. track
 
-// Estimator physics for the tests: a unit viewport keeps scrollOffsetGuess in frame-height pixels, and a
-// zero cap offset makes the logical thumb length exactly the measured tip-to-tip span, so the geometric
-// expectations below stay clean. The real cap correction is validated end-to-end (video harness), not here.
+// Estimator physics for the tests: a unit viewport, and a zero cap offset so the logical thumb length is
+// exactly the measured tip-to-tip span and the geometric expectations below stay clean. The real cap
+// correction is validated end-to-end (video harness), not here.
 constexpr double kViewport = 1.0;
 constexpr double kCapOffset = 0.0;
 
@@ -92,63 +92,6 @@ TEST_CASE("ScrollBarOffsetEstimator reports no scrollbar on a uniform frame") {
     CHECK_FALSE(estimator.hasScrollbar(frame));
     CHECK_FALSE(estimator.position(frame).has_value());
     CHECK_FALSE(estimator.topMargin(frame).has_value());
-}
-
-TEST_CASE("ScrollBarOffsetEstimator estimates a nonzero pixel offset between two thumb positions") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
-    const Frame from = scrollbarFrame(100, 40, 60);
-    const Frame to = scrollbarFrame(100, 50, 70);  // scrolled down: the thumb moved lower
-
-    const auto offset = estimator.estimate(from, to);
-    REQUIRE(offset.has_value());
-    CHECK(*offset > 0.0);  // scrolled down => positive content offset
-
-    // Unified geometry: estimate() (shared-length delta) and scrollOffsetGuess() (per-frame absolute
-    // difference) now read the same trackGeometry, so for a constant thumb length they agree.
-    const auto guess = estimator.scrollOffsetGuess(from, to);
-    REQUIRE(guess.has_value());
-    CHECK(*offset == doctest::Approx(*guess));
-}
-
-TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess is zero for identical frames and positive scrolling down") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
-    const Frame a = scrollbarFrame(100, 40, 60);
-    const Frame b = scrollbarFrame(100, 55, 75);  // thumb lower (scrolled down), same length
-
-    const auto same = estimator.scrollOffsetGuess(a, a);
-    REQUIRE(same.has_value());
-    CHECK(*same == doctest::Approx(0.0));
-
-    const auto down = estimator.scrollOffsetGuess(a, b);
-    REQUIRE(down.has_value());
-    CHECK(*down > 0.0);  // scrolling down => positive content offset
-}
-
-TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess works across a thumb-length change") {
-    // The point of this guess: unlike estimate()'s shared-length delta, it stays valid when the thumb
-    // re-scales (content lazily appended), because each frame contributes its OWN thumb length.
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
-    const Frame before = scrollbarFrame(100, 60, 90);  // long thumb near the bottom (small content)
-    const Frame after = scrollbarFrame(100, 40, 55);  // shorter thumb, lifted up (content grew)
-
-    CHECK(estimator.scrollOffsetGuess(before, after).has_value());  // does not choke on differing lengths
-}
-
-TEST_CASE("ScrollBarOffsetEstimator::scrollOffsetGuess returns nullopt without a scrollbar") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
-    const Frame bar = scrollbarFrame(100, 40, 60);
-    const Frame uniform = Frame::fixed(testutil::solid(100, kTrack));
-
-    CHECK_FALSE(estimator.scrollOffsetGuess(bar, uniform).has_value());
-    CHECK_FALSE(estimator.scrollOffsetGuess(uniform, bar).has_value());
-}
-
-TEST_CASE("ScrollBarOffsetEstimator rejects a size change between frames") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
-    const Frame from = scrollbarFrame(100, 40, 60);
-    const Frame to = scrollbarFrame(80, 32, 48);
-
-    CHECK_FALSE(estimator.estimate(from, to).has_value());
 }
 
 TEST_CASE("ScrollAreaOffsetEstimator delegates position and rejects featureless frames") {

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -38,10 +38,9 @@ const Color kThumb{60, 60, 60};  // the scroll thumb
 const Range<Color> kTrackRange{Color(200, 200, 200), Color(255, 255, 255)};  // thumb vs. background
 const Range<Color> kMarginRange{Color(228, 228, 228), Color(255, 255, 255)};  // near-white margin vs. track
 
-// Estimator physics for the tests: a unit viewport, and a zero cap offset so the logical thumb length is
-// exactly the measured tip-to-tip span and the geometric expectations below stay clean. The real cap
-// correction is validated end-to-end (video harness), not here.
-constexpr double kViewport = 1.0;
+// Estimator physics for the tests: a zero cap offset so the logical thumb length is exactly the measured
+// tip-to-tip span and the geometric expectations below stay clean. The real cap correction is validated
+// end-to-end (video harness), not here.
 constexpr double kCapOffset = 0.0;
 
 // Thumb-centre probe geometry. These tests render a full-width thumb, so trackCenterX finds no pill contrast
@@ -68,7 +67,7 @@ Frame scrollbarFrame(int size, int thumb_top, int thumb_bottom) {
 const Line<double> kScanLine{Point<double>(0.5, 0.0), Point<double>(0.5, 0.99)};
 
 TEST_CASE("ScrollBarOffsetEstimator reads the thumb margins from a rendered track") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kCapOffset, kThumbProbe);
     const Frame frame = scrollbarFrame(100, 40, 60);
 
     CHECK(estimator.hasScrollbar(frame));
@@ -86,7 +85,7 @@ TEST_CASE("ScrollBarOffsetEstimator reads the thumb margins from a rendered trac
 }
 
 TEST_CASE("ScrollBarOffsetEstimator reports no scrollbar on a uniform frame") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kCapOffset, kThumbProbe);
     const Frame frame = Frame::fixed(testutil::solid(100, kTrack));
 
     CHECK_FALSE(estimator.hasScrollbar(frame));
@@ -95,7 +94,7 @@ TEST_CASE("ScrollBarOffsetEstimator reports no scrollbar on a uniform frame") {
 }
 
 TEST_CASE("ScrollAreaOffsetEstimator delegates position and rejects featureless frames") {
-    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kCapOffset, kThumbProbe);
     const ImageOffsetEstimator image;  // default config
     const ScrollAreaOffsetEstimator estimator(scroll_bar, image);
 
@@ -116,7 +115,7 @@ TEST_CASE("ScrollAreaOffsetEstimator delegates position and rejects featureless 
 TEST_CASE("ScrollAreaOffsetEstimator reads scrollbar geometry from scroll_bar_frame, not frame") {
     // Guards the scroll-area / scroll-bar decoupling: geometry must come from the dedicated band, so that the
     // content crop (frame) can change without disturbing detection.
-    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kCapOffset, kThumbProbe);
     const ImageOffsetEstimator image;  // default config
     const ScrollAreaOffsetEstimator estimator(scroll_bar, image);
 

--- a/native/test/integration/cases.json
+++ b/native/test/integration/cases.json
@@ -19,6 +19,7 @@
     { "name": "player_standard_sequential", "video": "player_standard_sequential.mp4", "golden": "golden/player_standard_sequential.json" },
     { "name": "player_standard_2", "video": "player_standard_2.mp4", "golden": "golden/player_standard_2.json" },
     { "name": "player_standard_3", "video": "player_standard_3.mp4", "golden": "golden/player_standard_3.json" },
-    { "name": "player_standard_4", "video": "player_standard_4.mp4", "golden": "golden/player_standard_4.json" }
+    { "name": "player_standard_4", "video": "player_standard_4.mp4", "golden": "golden/player_standard_4.json" },
+    { "name": "player_standard_5", "video": "player_standard_5.mkv", "golden": "golden/player_standard_5.json" }
   ]
 }

--- a/native/test/integration/golden/player_standard_5.json
+++ b/native/test/integration/golden/player_standard_5.json
@@ -1,0 +1,756 @@
+[
+  {
+    "aptitudes": {
+      "distance": {
+        "long_range": 0,
+        "middle_range": 7,
+        "mile_range": 6,
+        "short_range": 1
+      },
+      "ground": {
+        "dirt": 6,
+        "turf": 6
+      },
+      "style": {
+        "late_charge": 5,
+        "lead_pace": 0,
+        "off_pace": 6,
+        "with_pace": 6
+      }
+    },
+    "evaluation_value": 54729,
+    "factors": {
+      "parent1": [
+        {
+          "id": 147,
+          "star": 3
+        },
+        {
+          "id": 73,
+          "star": 3
+        },
+        {
+          "id": 705,
+          "star": 2
+        },
+        {
+          "id": 116,
+          "star": 2
+        },
+        {
+          "id": 282,
+          "star": 2
+        },
+        {
+          "id": 70,
+          "star": 1
+        },
+        {
+          "id": 179,
+          "star": 2
+        },
+        {
+          "id": 67,
+          "star": 1
+        },
+        {
+          "id": 107,
+          "star": 2
+        },
+        {
+          "id": 135,
+          "star": 2
+        },
+        {
+          "id": 296,
+          "star": 2
+        },
+        {
+          "id": 117,
+          "star": 2
+        },
+        {
+          "id": 183,
+          "star": 2
+        },
+        {
+          "id": 199,
+          "star": 3
+        },
+        {
+          "id": 280,
+          "star": 1
+        },
+        {
+          "id": 347,
+          "star": 2
+        },
+        {
+          "id": 445,
+          "star": 2
+        },
+        {
+          "id": 455,
+          "star": 2
+        },
+        {
+          "id": 476,
+          "star": 1
+        },
+        {
+          "id": 555,
+          "star": 1
+        },
+        {
+          "id": 593,
+          "star": 3
+        },
+        {
+          "id": 603,
+          "star": 2
+        },
+        {
+          "id": 737,
+          "star": 2
+        },
+        {
+          "id": 727,
+          "star": 2
+        },
+        {
+          "id": 760,
+          "star": 2
+        },
+        {
+          "id": 773,
+          "star": 2
+        },
+        {
+          "id": 779,
+          "star": 2
+        },
+        {
+          "id": 797,
+          "star": 2
+        },
+        {
+          "id": 623,
+          "star": 3
+        }
+      ],
+      "parent2": [
+        {
+          "id": 8,
+          "star": 3
+        },
+        {
+          "id": 73,
+          "star": 3
+        },
+        {
+          "id": 587,
+          "star": 3
+        },
+        {
+          "id": 225,
+          "star": 2
+        },
+        {
+          "id": 161,
+          "star": 2
+        },
+        {
+          "id": 17,
+          "star": 2
+        },
+        {
+          "id": 63,
+          "star": 2
+        },
+        {
+          "id": 282,
+          "star": 3
+        },
+        {
+          "id": 163,
+          "star": 2
+        },
+        {
+          "id": 211,
+          "star": 2
+        },
+        {
+          "id": 243,
+          "star": 2
+        },
+        {
+          "id": 158,
+          "star": 2
+        },
+        {
+          "id": 57,
+          "star": 3
+        },
+        {
+          "id": 135,
+          "star": 3
+        },
+        {
+          "id": 109,
+          "star": 2
+        },
+        {
+          "id": 174,
+          "star": 2
+        },
+        {
+          "id": 216,
+          "star": 2
+        },
+        {
+          "id": 177,
+          "star": 2
+        },
+        {
+          "id": 433,
+          "star": 2
+        },
+        {
+          "id": 476,
+          "star": 2
+        },
+        {
+          "id": 475,
+          "star": 1
+        },
+        {
+          "id": 477,
+          "star": 3
+        },
+        {
+          "id": 479,
+          "star": 2
+        },
+        {
+          "id": 535,
+          "star": 2
+        },
+        {
+          "id": 593,
+          "star": 2
+        },
+        {
+          "id": 603,
+          "star": 2
+        },
+        {
+          "id": 600,
+          "star": 2
+        },
+        {
+          "id": 701,
+          "star": 2
+        },
+        {
+          "id": 727,
+          "star": 1
+        },
+        {
+          "id": 754,
+          "star": 2
+        },
+        {
+          "id": 760,
+          "star": 2
+        },
+        {
+          "id": 777,
+          "star": 2
+        },
+        {
+          "id": 773,
+          "star": 3
+        },
+        {
+          "id": 410,
+          "star": 2
+        },
+        {
+          "id": 759,
+          "star": 2
+        },
+        {
+          "id": 758,
+          "star": 2
+        },
+        {
+          "id": 623,
+          "star": 2
+        },
+        {
+          "id": 679,
+          "star": 2
+        },
+        {
+          "id": 615,
+          "star": 2
+        },
+        {
+          "id": 626,
+          "star": 1
+        },
+        {
+          "id": 661,
+          "star": 2
+        },
+        {
+          "id": 655,
+          "star": 1
+        }
+      ],
+      "self": [
+        {
+          "id": 26,
+          "star": 2
+        },
+        {
+          "id": 182,
+          "star": 2
+        },
+        {
+          "id": 71,
+          "star": 2
+        },
+        {
+          "id": 273,
+          "star": 2
+        },
+        {
+          "id": 51,
+          "star": 2
+        },
+        {
+          "id": 3,
+          "star": 2
+        },
+        {
+          "id": 179,
+          "star": 1
+        },
+        {
+          "id": 0,
+          "star": 3
+        },
+        {
+          "id": 188,
+          "star": 3
+        },
+        {
+          "id": 183,
+          "star": 2
+        },
+        {
+          "id": 170,
+          "star": 2
+        },
+        {
+          "id": 177,
+          "star": 2
+        },
+        {
+          "id": 254,
+          "star": 2
+        },
+        {
+          "id": 418,
+          "star": 2
+        },
+        {
+          "id": 433,
+          "star": 2
+        },
+        {
+          "id": 477,
+          "star": 2
+        },
+        {
+          "id": 489,
+          "star": 2
+        },
+        {
+          "id": 573,
+          "star": 2
+        },
+        {
+          "id": 593,
+          "star": 2
+        },
+        {
+          "id": 760,
+          "star": 2
+        },
+        {
+          "id": 835,
+          "star": 2
+        },
+        {
+          "id": 623,
+          "star": 3
+        },
+        {
+          "id": 667,
+          "star": 2
+        }
+      ]
+    },
+    "family": {
+      "parent1": {
+        "parent1": {
+          "card": 234,
+          "character": 7,
+          "icon": 578,
+          "rank": 298,
+          "record_type": "InheritanceOnly"
+        },
+        "parent2": {
+          "card": 215,
+          "character": 94,
+          "icon": 475,
+          "rank": 68,
+          "record_type": "Standard"
+        },
+        "self": {
+          "card": 212,
+          "character": 114,
+          "icon": 662,
+          "rank": 298,
+          "record_type": "InheritanceOnly"
+        }
+      },
+      "parent2": {
+        "parent1": {
+          "card": 22,
+          "character": 15,
+          "icon": 128,
+          "rank": 72,
+          "record_type": "Standard"
+        },
+        "parent2": {
+          "card": 183,
+          "character": 34,
+          "icon": 404,
+          "rank": 62,
+          "record_type": "Standard"
+        },
+        "rental": true,
+        "self": {
+          "card": 189,
+          "character": 83,
+          "icon": 419,
+          "rank": 81,
+          "record_type": "Standard"
+        }
+      }
+    },
+    "fans": 267133,
+    "metadata": {
+      "format_version": "1.0.0",
+      "recognizer_version": "2026-07-10T11:00:00+0900",
+      "record_type": "Standard",
+      "region": "JPN",
+      "stage": "active",
+      "strategy": 2
+    },
+    "races": [
+      {
+        "distance": 6,
+        "ground": 0,
+        "place": 2,
+        "position": 1,
+        "strategy": 2,
+        "title": 242,
+        "turn": 73,
+        "variation": 3,
+        "weather": 0
+      },
+      {
+        "distance": 8,
+        "ground": 0,
+        "place": 4,
+        "position": 1,
+        "strategy": 2,
+        "title": 265,
+        "turn": 73,
+        "variation": 5,
+        "weather": 0
+      },
+      {
+        "distance": 8,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 2,
+        "title": 45,
+        "turn": 73,
+        "variation": 3,
+        "weather": 0
+      },
+      {
+        "distance": 10,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 2,
+        "title": 269,
+        "turn": 67,
+        "variation": 2,
+        "weather": 0
+      },
+      {
+        "distance": 6,
+        "ground": 0,
+        "place": 10,
+        "position": 1,
+        "strategy": 2,
+        "title": 201,
+        "turn": 45,
+        "variation": 3,
+        "weather": 0
+      },
+      {
+        "distance": 10,
+        "ground": 1,
+        "place": 3,
+        "position": 1,
+        "strategy": 2,
+        "title": 183,
+        "turn": 36,
+        "variation": 1,
+        "weather": 11
+      },
+      {
+        "distance": 6,
+        "ground": 0,
+        "place": 7,
+        "position": 1,
+        "strategy": 2,
+        "title": 59,
+        "turn": 32,
+        "variation": 2,
+        "weather": 0
+      },
+      {
+        "distance": 6,
+        "ground": 1,
+        "place": 7,
+        "position": 1,
+        "strategy": 2,
+        "title": 260,
+        "turn": 27,
+        "variation": 2,
+        "weather": 4
+      },
+      {
+        "distance": 6,
+        "ground": 1,
+        "place": 7,
+        "position": 1,
+        "strategy": 2,
+        "title": 273,
+        "turn": 11,
+        "variation": 2,
+        "weather": 4
+      }
+    ],
+    "scenario": {
+      "id": 13
+    },
+    "skills": [
+      {
+        "id": 42,
+        "level": 5
+      },
+      {
+        "id": 1478
+      },
+      {
+        "id": 1329
+      },
+      {
+        "id": 1647
+      },
+      {
+        "id": 383
+      },
+      {
+        "id": 115
+      },
+      {
+        "id": 230
+      },
+      {
+        "id": 47
+      },
+      {
+        "id": 343
+      },
+      {
+        "id": 182
+      },
+      {
+        "id": 132
+      },
+      {
+        "id": 364
+      },
+      {
+        "id": 456
+      },
+      {
+        "id": 311
+      },
+      {
+        "id": 409
+      },
+      {
+        "id": 382
+      },
+      {
+        "id": 220
+      },
+      {
+        "id": 166
+      },
+      {
+        "id": 256
+      },
+      {
+        "id": 275
+      },
+      {
+        "id": 481
+      },
+      {
+        "id": 791
+      },
+      {
+        "id": 179
+      },
+      {
+        "id": 128
+      },
+      {
+        "id": 240
+      },
+      {
+        "id": 1812
+      },
+      {
+        "id": 260
+      },
+      {
+        "id": 835
+      },
+      {
+        "id": 432
+      },
+      {
+        "id": 489
+      },
+      {
+        "id": 552
+      },
+      {
+        "id": 597
+      },
+      {
+        "id": 882
+      },
+      {
+        "id": 928
+      },
+      {
+        "id": 962
+      },
+      {
+        "id": 974
+      },
+      {
+        "id": 981
+      },
+      {
+        "id": 1820
+      },
+      {
+        "id": 1066
+      },
+      {
+        "id": 1302
+      },
+      {
+        "id": 1338
+      },
+      {
+        "id": 1408
+      },
+      {
+        "id": 1612
+      },
+      {
+        "id": 1728
+      },
+      {
+        "id": 1494
+      },
+      {
+        "id": 1823
+      }
+    ],
+    "status": {
+      "guts": 1164,
+      "intelligence": 1483,
+      "power": 1367,
+      "speed": 2157,
+      "stamina": 1502
+    },
+    "support_cards": [
+      {
+        "id": 508,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 497,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 540,
+        "level": 0,
+        "rank": 3
+      },
+      {
+        "id": 416,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 522,
+        "level": 0,
+        "rank": 5
+      },
+      {
+        "id": 539,
+        "level": 0,
+        "rank": 5
+      }
+    ],
+    "trained_date": "2026/07/05",
+    "trainee": {
+      "card": 79,
+      "character": 13,
+      "icon": 98,
+      "rank": 77
+    }
+  }
+]

--- a/native/test/util/test_event_util.cpp
+++ b/native/test/util/test_event_util.cpp
@@ -79,7 +79,7 @@ TEST_CASE("a NoLimit queued connection keeps every enqueued event") {
 }
 
 TEST_CASE("a Discard queued connection drops sends past its depth limit") {
-    // The limit is 3 (queue_limit_size); the 4th and 5th sends find the queue full and are dropped.
+    // The limit is 3 (kDefaultQueueLimitSize); the 4th and 5th sends find the queue full and are dropped.
     const auto connection = makeQueuedConnection<int>(Discard);
     std::vector<int> received;
     connection->listen([&](int value) { received.push_back(value); });
@@ -90,6 +90,21 @@ TEST_CASE("a Discard queued connection drops sends past its depth limit") {
     drainQueued(connection);
 
     CHECK(received == std::vector<int>{0, 1, 2});
+}
+
+TEST_CASE("a Discard queued connection honors a per-connection depth limit") {
+    // The frame-path runners pass a deeper limit than the default (see native_api.cpp); the depth must
+    // be per-connection, not the compiled-in default.
+    const auto connection = makeQueuedConnection<int>(Discard, 5);
+    std::vector<int> received;
+    connection->listen([&](int value) { received.push_back(value); });
+
+    for (int i = 0; i < 8; i++) {
+        connection->send(i);
+    }
+    drainQueued(connection);
+
+    CHECK(received == std::vector<int>{0, 1, 2, 3, 4});
 }
 
 TEST_CASE("a Block queued connection back-pressures the producer without dropping") {

--- a/native/tool/builder/chara_detail_scene_scraper_builder.h
+++ b/native/tool/builder/chara_detail_scene_scraper_builder.h
@@ -57,10 +57,9 @@ private:
             200,
             18,
             100,
-            // Viewport V and cap offset c fit across player_standard/player_inheritance/friend_inheritance
-            // (common layout): tip_len = 2c + V*slope, R^2 = 1.0 -> V = 543 px, c = 0.94 px at 736 px width.
-            // Stored width-normalized: 543/736 = 0.738, 0.94/736 = 0.00126. c is a widget constant (shared).
-            0.738,
+            // Cap offset c fit across player_standard/player_inheritance/friend_inheritance (common layout):
+            // tip_len = 2c + V*slope, R^2 = 1.0 -> c = 0.94 px at 736 px width, stored width-normalized
+            // (0.94/736 = 0.00126). c is a widget constant, shared by both layouts.
             0.00126,
             // Placeholder track is faintly coloured (satisfies R < 228 or G < 228); the near-white scroll-area
             // margin flanking it is all channels >= 228. This box catches that margin and excludes the track,
@@ -101,10 +100,6 @@ private:
         config.tab_button_rect = {{0.0222, 0.7259 + shift, IS}, {0.9759, 0.8037 + shift, IS}};
         config.scroll_area_rect = {{0.0000, 0.8093 + shift, IS}, {0.0000, -0.2426, {IPE, ILE}}};
         config.scroll_bar_rect = {{0.0000, 0.8093 + shift, IS}, {0.0000, -0.2426, {IPE, ILE}}};
-        // The shorter friend scroll area has a smaller viewport: fit across friend_standard /
-        // friend_standard_many_rental gives V = 407 px (0.553 width-normalized), R^2 = 1.0. cap_offset and
-        // the margin colour are widget constants, unchanged from common().
-        config.viewport = 0.553;
         return config;
     }
 


### PR DESCRIPTION
## Summary

Replaces the scroll-offset estimation's "scrollbar guess + keypoint window" scheme with a guess-free candidate + verify design: AKAZE match displacements vote into a 1-px histogram whose local maxima become candidate offsets, and a full-resolution pixel-overlap correlation selects among them. This fixes the last-row loss on the factor tab's terminating overscroll frame, where the collapsing thumb geometry blew up the guess and the window rejected the true offset.

## What changed

### 1. Candidate + verify offset estimation

- **`detectOffsetCandidates`**: every local maximum of the 1-px displacement histogram (peak bin + its ±1 px neighbours merged, absorbing boundary-split spikes) that reaches `minimum_key_points` becomes a candidate carrying the sub-pixel median. Local-maxima detection is used instead of gap-based clustering so bridge noise cannot chain two genuine peaks into one wrong median. Zero and negative displacements are covered, so a static frame yields a ~0 candidate instead of a false positive.
- **`overlapScore`**: zero-mean NCC of the full-resolution grayscale overlap, computed directly via `dot` + `meanStdDev` (equal-size `matchTemplate` takes its ~10x slower DFT path). Symmetric in shift sign, guarded against thin slivers (fraction of crop height) and zero-variance bands (OpenCV clamps the degenerate case to a perfect score rather than NaN).
- **`ImageOffsetEstimator::estimate`**: pixel evidence arbitrates between candidates regardless of vote count — a keypoint majority can lock onto a periodic-row alias (factor rows repeat at constant pitch), and a dense scan alone can spike on a sliver; each side covers the other's failure. Grayscale frames are lazily cached on the descriptor.

### 2. Dead code removal

- **Scrollbar offset estimation deleted**: `ScrollBarOffsetEstimator::estimate` / `scrollOffsetGuess` / `isBottomClipped` and `ScrollAreaOffsetEstimator::estimateAcrossRescale` are gone; the scrollbar estimator now serves only `position()` / `topMargin()` (UI progress, at-top detection).
- **`viewport` config removed** end to end (config struct, serialization, `scene_scraper.json`, builder) — it existed only to convert thumb geometry into a content offset.

### 3. Frame-path queue depth

- `event_util` queue depth is now per-connection (`kDefaultQueueLimitSize = 3` preserved as the default), and the frame-path runners (distributor, scraper) pass a depth of 8 so live Discard-mode capture rides out transient per-frame estimation spikes instead of dropping frames.

### 4. Tests

- New unit tests pin the deterministic pieces: candidate extraction (sharp peaks, bridge noise, sparse noise, negative/zero shifts, boundary-split spikes) and symmetric overlap verification (both signs, thin/out-of-bounds/size-mismatch/zero-variance rejection).
- New golden case `player_standard_5` (FFV1 recording via the `replay` path) covers the terminating-overscroll footage that motivated the fix.

## Testing

- Native unit suite (ctest): all passing, including the new candidate/overlap cases.
- Integration golden harness: all 10 pre-existing goldens unchanged; the new `player_standard_5` golden captures the previously-lost trailing rows.
- Verified on 11 recorded clips: genuine scrolls score NCC >= 0.91, wrong alignments <= 0.73, so the 0.8 gate separates them with margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
