### PR TITLE
feat(core): clear temp directory contents on startup

### DIFF
--- a/lib/src/core/path_entity.dart
+++ b/lib/src/core/path_entity.dart
@@ -250,6 +250,28 @@ class DirectoryPath extends PathEntity {
     }
   }
 
+  /// Deletes every entry inside this directory, leaving the (now empty)
+  /// directory itself in place.
+  ///
+  /// Used to reclaim scratch space (e.g. the `temp` tree the native pipeline
+  /// leaves scraping fragments in after an incomplete capture) without removing
+  /// the directory the app expects to exist. Each child is removed recursively
+  /// via [PathEntity.deleteSync], inheriting its file-lock retry. A missing
+  /// directory is a no-op when [emptyOk]; individual entries that fail to delete
+  /// are skipped so a single locked file does not abort the rest.
+  void clearSync({bool emptyOk = true}) {
+    if (emptyOk && !existsSync()) {
+      return;
+    }
+    for (final entry in listSync(recursive: false, followLinks: false)) {
+      try {
+        entry.deleteSync(recursive: true, emptyOk: true);
+      } catch (error, stackTrace) {
+        logger.e("Failed to delete temp entry: ${entry.path}", error, stackTrace);
+      }
+    }
+  }
+
   void deleteSyncSafeWithCheck() {
     try {
       listSync(recursive: false, followLinks: false).forEach((e) => e.deleteSync(recursive: false));

--- a/lib/src/gui/app_widget.dart
+++ b/lib/src/gui/app_widget.dart
@@ -239,6 +239,21 @@ class ApplicationWidget extends ConsumerStatefulWidget {
 }
 
 class ApplicationWidgetState extends ConsumerState<ApplicationWidget> {
+  @override
+  void initState() {
+    super.initState();
+    // Reclaim scratch space left over from a previous run. The native pipeline
+    // can leave scraping fragments in the temp tree when a capture is interrupted
+    // (or the app is killed), so empty it once at startup -- keeping the temp
+    // directory itself -- rather than on exit, which never runs after a crash.
+    ref.read(pathInfoLoader.future).then((info) => info.tempDir.clearSync()).catchError((
+      Object error,
+      StackTrace stackTrace,
+    ) {
+      logger.e("Failed to clear temp directory on startup.", error, stackTrace);
+    });
+  }
+
   TextStyle? modifyFontWeight(TextStyle? base, int offset) {
     // FontWeight.index was deprecated in favor of the numeric `value` (100-900).
     // Reproduce the old index (value ~/ 100 - 1, clamped to 0..8) and step by `offset`,


### PR DESCRIPTION
## Summary

The native pipeline leaves scraping fragments in the `temp` tree when a capture is interrupted or the app is killed, and nothing reclaimed them. Empty the `temp` directory once at launch — keeping the directory itself — so stale scratch files no longer accumulate across runs. Doing this on **startup** rather than on exit deliberately covers the crash case, where an exit-time cleanup would never run.

## What changed

- **`DirectoryPath.clearSync()`** (`lib/src/core/path_entity.dart`): new helper that removes every entry inside a directory while leaving the directory in place. Each child is deleted recursively via the existing `PathEntity.deleteSync` file-lock retry; a single locked entry is logged and skipped instead of aborting the rest. A missing directory is a no-op when `emptyOk`.
- **Startup hook** (`lib/src/gui/app_widget.dart`): `ApplicationWidgetState.initState` calls `pathInfo.tempDir.clearSync()` once `pathInfoLoader` resolves. Failures are logged, not surfaced.

## Testing

- `dart analyze` on both files — no issues.
- `dart format` — clean (no churn).
- Clean release build (`rm -rf build/windows` + `flutter build windows --release`) succeeded; launched the fresh `umacapture.exe` and confirmed it runs. The `temp` directory is preserved and its contents are empty after startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
