### PR TITLE
feat(capture): turn frame-rate chip green at 25 fps and above

### DIFF
--- a/lib/src/gui/capture.dart
+++ b/lib/src/gui/capture.dart
@@ -487,7 +487,7 @@ class _CapturingPlatformInfoWidget extends ConsumerWidget {
     if (fps == null) {
       return const Text("-");
     }
-    final requirement = fps > 30 ? _Requirement.good : (fps > 15 ? _Requirement.unsure : _Requirement.insufficient);
+    final requirement = fps >= 25 ? _Requirement.good : (fps > 15 ? _Requirement.unsure : _Requirement.insufficient);
     return chip(
       theme: theme,
       label: fps.round().toString(),


### PR DESCRIPTION
## Summary

Lower the frame-rate indicator's green threshold on the capture screen so **25 fps and above** is shown as green, addressing a user request that 25+ fps be treated as sufficient.

## What changed

- **`fpsWidget` threshold** in `lib/src/gui/capture.dart`: the `good` (green / `success`) band changes from `fps > 30` to `fps >= 25`.
- The `unsure` (yellow / `warning`) band now covers `15 < fps < 25`; the `insufficient` (red / `danger`) band is unchanged at `fps <= 15`.
- Tooltip strings in `assets/translations/ja.json` carry no numeric thresholds, so no translation change was needed.

## Testing

- `dart format` verified clean via the pre-commit hook (0 files changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
