### PR TITLE
chore(skills): refresh skill docs to match current toolchain and CLI

### DIFF
--- a/.claude/skills/native-cli-dev/SKILL.md
+++ b/.claude/skills/native-cli-dev/SKILL.md
@@ -4,12 +4,13 @@ description: >-
   Build, run, log, and debug the C++ capture/recognition backend in native/ as a
   standalone CLI (umacapture_cli) from the command line, without CLion. Sets up
   the MSVC toolchain via vcvars64, configures CMake with Ninja (Debug/Release),
-  runs the build / capture / video / stitch / recognize subcommands, explains the
-  spdlog output and which subcommands self-terminate vs. run a live event loop,
-  and steps through the binary with the cdb command-line debugger. Use when the user wants
-  to build, rebuild, run, inspect logs from, or debug the native CLI, regenerate
-  the assets/config/*.json scene definitions, or test capture/recognition logic
-  outside the Flutter app.
+  runs the build / capture / screenshot / video / replay / stitch / recognize
+  subcommands, explains the spdlog output and which subcommands self-terminate
+  vs. run a live event loop, and steps through the binary with the cdb
+  command-line debugger. Use when the user wants to build, rebuild, run, inspect
+  logs from, or debug the native CLI, regenerate the assets/config/*.json scene
+  definitions, record or replay FFV1 capture recordings, or test
+  capture/recognition logic outside the Flutter app.
 ---
 
 # Build, run, and debug the native C++ CLI (umacapture_cli)
@@ -39,16 +40,23 @@ and uses WinRT screen capture). Generator is **Ninja**, compiler is **MSVC
   `CMakeLists.txt` via `OpenCV_DIR`).
 - **ONNX Runtime 1.27.0** at `windows/onnxruntime` (headers in `include/`,
   `onnxruntime.lib`/`.dll` in `lib/`).
+- **FFmpeg n7.1.5 (BtbN LGPL shared)** at `windows/ffmpeg` (headers, import libs,
+  and versioned `av*`/`sw*` DLLs). The CLI links `avformat`/`avcodec`/`avutil`
+  directly for the FFV1 capture recorder and `replay` reader
+  (`src/cv/ffv1_*.{h,cpp}`); the separate `umacapture_ffv1_tests` target links it
+  too. The Flutter app target does **not** link it.
 
-These two dependency dirs are **gitignored** (`windows/.gitignore` excludes
-`/opencv/`, `/onnxruntime/`) because they are large prebuilt binaries. Provision
-them into the layout above by running `uv run tool/fetch_deps.py` (downloads the
-official prebuilts, hash-verified) -- see the **project-setup** skill for
-details. A fresh checkout must do this before the native build can configure
-(OpenCV is the hard requirement: `find_package(OpenCV REQUIRED)`; onnxruntime is
-only linked by the cli/app targets, not `umacapture_tests`). The third native
-dependency, `windows/clip`, is committed to the repo, so no fetch is needed. CI
-provisions OpenCV with the same script (see `.github/workflows/ci.yml`).
+These three dependency dirs are **gitignored** (`windows/.gitignore` excludes
+`/opencv/`, `/onnxruntime/`, `/ffmpeg/`) because they are large prebuilt
+binaries. Provision them into the layout above by running
+`uv run tool/fetch_deps.py` (downloads the official prebuilts, hash-verified) --
+see the **project-setup** skill for details. A fresh checkout must do this before
+the native build can configure (OpenCV is the hard requirement:
+`find_package(OpenCV REQUIRED)`; ffmpeg is required to link the CLI and
+`umacapture_ffv1_tests`; onnxruntime is only linked by the cli/app targets, not
+the test targets). The fourth native dependency, `windows/clip`, is committed to
+the repo, so no fetch is needed. CI provisions OpenCV and FFmpeg with the same
+script (see `.github/workflows/ci.yml`).
 
 ## Key fact: the MSVC environment is mandatory
 
@@ -106,9 +114,10 @@ Notes:
   longer matches the vcvars environment). Configure a new dir instead. (You can
   still *run* the pre-built exe that already sits in a CLion dir — see the
   `recognize`/`stitch` test-input note — just don't reconfigure/rebuild into it.)
-- A `POST_BUILD` step auto-copies the matching `opencv_world4130[d].dll` and
-  `onnxruntime.dll` next to the exe, so the exe runs from its own build dir
-  without PATH changes.
+- A `POST_BUILD` step auto-copies the matching `opencv_world4130[d].dll`,
+  `onnxruntime.dll`, the OpenCV videoio FFmpeg plugin, and the libav runtime
+  DLLs next to the exe, so the exe runs from its own build dir without PATH
+  changes (see the runtime-DLL note under **Running the CLI**).
 - Incremental rebuilds: re-run only `cmake --build <dir>` (still inside vcvars).
 - Cleanup gotcha: after a build, `mspdbsrv.exe` / `vctip.exe` linger and lock
   the build dir. Kill them (or just wait) before deleting a build directory.
@@ -122,13 +131,21 @@ those `../../` paths resolve to the repo root only from inside `native/<build-di
 
 Subcommands (see `src/core/cli.cpp`):
 
-| Subcommand  | Purpose | Example args |
-|-------------|---------|--------------|
-| `build`     | Regenerate the scene-definition JSONs from the C++ builders, round-trip-verifying each. | `build --assets_dir C:\Projects\umacapture\assets\config` |
-| `capture`   | Live capture from the game window on screen (WinRT recorder). | `capture` |
-| `video`     | Run capture against recorded video files. | `video --video_path_list "C:\Projects\umacapture\sandbox\inheritance_only_1.mp4"` |
-| `stitch`    | Stitch previously scraped images for one record id. | `stitch --id <uuid>` |
-| `recognize` | Run the recognizer over stitched images. | `recognize --id <uuid> [<uuid> ...]` |
+| Subcommand   | Purpose | Example args |
+|--------------|---------|--------------|
+| `build`      | Regenerate the scene-definition JSONs from the C++ builders, round-trip-verifying each. | `build --assets_dir C:\Projects\umacapture\assets\config` |
+| `capture`    | Live capture from the game window on screen (WinRT recorder). Optionally records every captured frame + timestamp to a lossless FFV1 `.mkv` for later `replay`. | `capture [--record out.mkv] [--duration 300] [--stop-file stop.flag]` |
+| `screenshot` | Capture a single screenshot from the game window. | `screenshot --output shot.png` |
+| `video`      | Run capture against recorded video files. | `video --video_path_list "C:\Projects\umacapture\sandbox\inheritance_only_1.mp4"` |
+| `replay`     | Re-feed a recorded FFV1 `.mkv` (from `capture --record`) through the recognition pipeline, preserving the original frame timestamps. | `replay --record "C:\...\run.mkv"` |
+| `stitch`     | Stitch previously scraped images for one record id. | `stitch --id <uuid>` |
+| `recognize`  | Run the recognizer over stitched images. | `recognize --id <uuid> [<uuid> ...]` |
+
+The one-shot pipeline subcommands (`video` / `replay` / `stitch` / `recognize`)
+also accept `--assets_dir`, `--modules_dir`, and `--output_dir`; the defaults
+reproduce the historical cwd-relative behavior (`../../assets/config`,
+`../../sandbox/modules`, `.`), so passing absolute paths makes a run independent
+of the working directory.
 
 Example (a harmless smoke test — `--help`, plus `build` into a throwaway dir):
 
@@ -143,16 +160,20 @@ umacapture_cli.exe build --assets_dir .\smoke_assets
 > place.** Only do that when you intend to regenerate them (see the `build`
 > section below); for a smoke test write to a throwaway dir as shown.
 
-### Self-termination: only `capture` runs forever; the rest exit on their own
+### Self-termination: only `capture` runs until stopped; the rest exit on their own
 
-`build` returns as soon as it finishes. `stitch` / `recognize` / `video` start
-`NativeApi`'s event loop, submit their work, then wait until the pipeline goes
-quiet — no notification for ~10s, an idle-grace window in `runUntilIdleThenJoin`
-(`src/core/cli.cpp`) — and then join the event loop and **exit on their own with
-code 0**. No need to watch for an artifact and kill them; just wait (a one-shot
-`recognize` typically exits ~10–13s after the work completes). Only `capture`
-(live screen capture) runs indefinitely and must be stopped with Ctrl-C /
-`Stop-Process -Name umacapture_cli -Force`.
+`build` and `screenshot` return as soon as they finish. `stitch` / `recognize` /
+`video` / `replay` start `NativeApi`'s event loop, submit their work, then wait
+until the pipeline goes quiet — no notification for ~10s, an idle-grace window in
+`runUntilIdleThenJoin` (`src/core/cli.cpp`) — and then join the event loop and
+**exit on their own with code 0**. No need to watch for an artifact and kill
+them; just wait (a one-shot `recognize` typically exits ~10–13s after the work
+completes). Only `capture` (live screen capture) runs indefinitely by default.
+Stop it with Ctrl-C, or — for scripted control — pass `--duration <seconds>`
+and/or `--stop-file <path>` (capture ends cleanly when the file appears). All
+three stop paths run full teardown, including finalizing an in-progress
+`--record` file; a hard `Stop-Process` kill instead leaves the `.mkv`
+un-finalized, so avoid it when recording.
 
 Because these now exit gracefully, they run full teardown — the event-loop join
 plus the `NativeApi` atexit destructor — a path that force-killing them never
@@ -172,12 +193,17 @@ commit them as the build artifact. (The round-trip `assert_` is only active in a
 Debug build — see Debugging.) With an absolute `--assets_dir`, `build` does not
 depend on the working directory, unlike the event-loop subcommands.
 
-### `video` subcommand needs the FFmpeg DLL
+### Runtime DLLs are auto-copied (including the video/FFmpeg ones)
 
-OpenCV decodes video via `opencv_videoio_ffmpeg4130_64.dll`, which the POST_BUILD
-step does **not** copy. For the `video` subcommand, copy it manually from
-`windows/opencv/build/x64/vc16/bin/opencv_videoio_ffmpeg4130_64.dll` into the
-build dir (alongside the exe). The other subcommands don't need it.
+A `POST_BUILD` step copies everything the exe needs next to it: the matching
+`opencv_world4130[d].dll`, `onnxruntime.dll`, OpenCV's video decoder plugin
+`opencv_videoio_ffmpeg4130_64.dll` (used by the `video` subcommand), and the
+libav runtime DLLs (`av*.dll` / `sw*.dll` from `windows/ffmpeg/bin`, used by
+`capture --record` / `replay`). No manual DLL copying is needed. One caveat: the
+copied videoio plugin is the release-named one; a **Debug** build's
+`opencv_world4130d.dll` looks for the `d`-suffixed plugin name, so if a Debug
+`video` run stops decoding early (progress stalls near 0), duplicate the DLL as
+`opencv_videoio_ffmpeg4130_64d.dll` in the build dir.
 
 ### `video` subcommand: automatic horizontal vs. vertical crop
 
@@ -213,8 +239,7 @@ The CLion run configs in `native/.idea/workspace.xml` recorded working inputs
 that still exist in the repo:
 
 - **`video`** — `sandbox/inheritance_only_1.mp4` (and many other `sandbox/*.mp4`
-  clips). Needs the FFmpeg DLL (see the `video` note above). Verified: it decodes
-  the clip and writes scraped scene dirs under
+  clips). Verified: it decodes the clip and writes scraped scene dirs under
   `<build-dir>/temp/chara_detail/<uuid>/`.
 - **`recognize`** / **`stitch`** — operate on record ids under
   `<build-dir>/storage/chara_detail/active/<uuid>/`. The committed CLion **debug**
@@ -253,11 +278,11 @@ what bites when you kill an event-loop subcommand. On Windows:
   (`set_level(trace)`) is already permissive, so the macro is the only gate.
 - **Buffering gotcha:** `flush_on(warn)` + `flush_every(5s)`. WARN and above
   flush immediately; DEBUG/INFO can sit in the buffer up to 5 seconds. This bites
-  the one subcommand you still kill, `capture`: **the last few seconds of buffered
-  DEBUG/INFO can be lost** when you `Stop-Process` it. `stitch` / `recognize` /
-  `video` now exit gracefully, so their final `spdlog::drop_all()` flushes the
-  tail. If you need the tail of a killed `capture`, log at WARN or wait for a
-  flush before killing.
+  a hard-killed `capture`: **the last few seconds of buffered DEBUG/INFO can be
+  lost** when you `Stop-Process` it. Every graceful exit (`stitch` / `recognize` /
+  `video` / `replay`, and `capture` via Ctrl-C / `--stop-file` / `--duration`)
+  runs the final `spdlog::drop_all()`, which flushes the tail. If you must
+  hard-kill and need the tail, log at WARN or wait for a flush first.
 
 ## Debugging
 
@@ -281,7 +306,8 @@ A Debug build differs from Release in three ways that matter:
   pipeline, **only fire in a Debug build**. A failed `assert_` calls `_wassert`,
   which pops the abort/retry/ignore dialog and breaks into an attached debugger.
 - POST_BUILD copies the debug OpenCV DLL (`opencv_world4130d.dll`) instead of the
-  release one. (FFmpeg DLL is still not copied — see the `video` note above.)
+  release one. (The videoio FFmpeg plugin and libav DLLs are copied too — see the
+  runtime-DLL note above for the Debug `d`-suffix caveat on the videoio plugin.)
 
 (The compile-time log level floor is independent of build type — see **Logs**.)
 

--- a/.claude/skills/project-setup/SKILL.md
+++ b/.claude/skills/project-setup/SKILL.md
@@ -54,7 +54,7 @@ From the repo root, in order (details for each below):
 fvm install                                      # 1. Flutter 3.44.4 -> .fvm/flutter_sdk
 git config core.hooksPath tool/hooks             # 2. pre-commit format/color hook
 git config blame.ignoreRevsFile .git-blame-ignore-revs   # 3. clean git blame
-uv run tool/fetch_deps.py                         # 4. native deps (OpenCV + ONNX Runtime)
+uv run tool/fetch_deps.py                         # 4. native deps (OpenCV + ONNX Runtime + FFmpeg)
 .fvm/flutter_sdk/bin/flutter pub get              # 5. Dart packages
 .fvm/flutter_sdk/bin/dart run build_runner build --force-jit   # 6. codegen
 ```
@@ -114,22 +114,30 @@ git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 Skips the one mechanical 120-col reformat commit so `git blame` shows real authors.
 
-### 4. Native dependencies (OpenCV / ONNX Runtime)
+### 4. Native dependencies (OpenCV / ONNX Runtime / FFmpeg)
 
 ```bash
-uv run tool/fetch_deps.py            # both; add --only opencv|onnxruntime, or --force
+uv run tool/fetch_deps.py            # all three; add --only opencv|onnxruntime|ffmpeg, or --force
 ```
 
 Downloads the official prebuilts, verifies them against pinned SHA-256 hashes, and
-extracts them into `windows/{opencv,onnxruntime}` (the gitignored layout CMake
-expects), including the two experimental ONNX C++ headers that ship only in the
-source tree. Nothing is pruned, so the result is byte-identical to a manual
+extracts them into `windows/{opencv,onnxruntime,ffmpeg}` (the gitignored layout
+CMake expects), including the two experimental ONNX C++ headers that ship only in
+the source tree. Nothing is pruned by default (`--slim`, used by CI, drops parts
+this project never links), so the result is byte-identical to a manual
 extraction. Provisioning OpenCV requires Windows (it's a self-extracting `.exe`).
 
 | Dependency | Version | Lands at |
 |---|---|---|
 | OpenCV | 4.13.0 (vc16) | `windows/opencv/build` |
 | ONNX Runtime | 1.27.0 | `windows/onnxruntime/{include,lib}` |
+| FFmpeg (BtbN LGPL shared) | n7.1.5 | `windows/ffmpeg/{include,lib,bin}` |
+
+FFmpeg (libav) is linked only by the native CLI's FFV1 capture recorder /
+`replay` reader and the `umacapture_ffv1_tests` target, so it is required to
+build anything under `native/` — but the Flutter app target never links it, so
+`flutter build windows` works without it. Provision it with the rest anyway; it
+is small when `--slim`med and the native CLI is the main debugging tool here.
 
 The third native dependency, `windows/clip`, is **committed** to the repo (pure MIT
 source, no binaries — see [`windows/clip/VENDORED.md`](../../../windows/clip/VENDORED.md)),
@@ -147,7 +155,10 @@ prebuilt encodes the version and MSVC toolset in its layout (`build/x64/vc16/bin
 - the `key:` of the **Cache OpenCV** step in [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml)
   — it pins the version, so a stale key would restore the old tree and break the build.
 
-CI provisions OpenCV with the same script.
+CI provisions OpenCV and FFmpeg with the same script (`--only opencv|ffmpeg
+--slim`, cached; ONNX Runtime is deliberately not provisioned there — the test
+targets never link it). When bumping the FFmpeg pin, also bump the
+`ffmpeg-…-slim` cache key in `ci.yml`.
 
 ### 5. Resolve Dart packages
 
@@ -192,7 +203,7 @@ For the standalone native C++ CLI / doctest suite (a separate CMake project unde
 
 - **Windows-only.** The native backend links `windowsapp.lib`/`dwmapi.lib` and uses
   WinRT capture; there is no macOS/Linux build path.
-- **`.fvm/` and `windows/{opencv,onnxruntime}` are gitignored** — FVM and
+- **`.fvm/` and `windows/{opencv,onnxruntime,ffmpeg}` are gitignored** — FVM and
   `fetch_deps.py` populate them; they are never committed. `windows/clip` is the
   exception (committed source).
 - **Keep `.fvmrc` and the CI Flutter version in sync** — CI hardcodes 3.44.4 because

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -2,26 +2,35 @@
 name: release
 description: >-
   Cut a new umacapture release end to end: bump the app version in pubspec.yaml,
-  regenerate the version/license assets via build_runner, commit and tag on
-  develop, then build and publish the Windows exe + zip to a GitHub release with
-  flutter_distributor. Covers the two phases (version bump + codegen, then
-  flutter_distributor deploy), the FVM/Inno Setup/GITHUB_TOKEN prerequisites, and
-  the known-broken global flutter_distributor activation under Dart 3.12. Use
-  when the user wants to release, ship, publish, or bump the app version and push
-  a new build to GitHub releases.
+  regenerate the version/license assets via build_runner, land the bump on the
+  protected develop branch via a release/v<version> PR, tag the merge commit,
+  then build and publish the Windows exe + zip to a GitHub release with
+  flutter_distributor. Covers the two phases (version bump + codegen + PR merge,
+  then tag + flutter_distributor deploy), the FVM/Inno Setup/GITHUB_TOKEN
+  prerequisites, and the known-broken global flutter_distributor activation
+  under Dart 3.12. Use when the user wants to release, ship, publish, or bump
+  the app version and push a new build to GitHub releases.
 ---
 
 # Release umacapture (version bump → codegen → flutter_distributor publish)
 
 A release has two phases:
 
-1. **Version bump + codegen + commit/push** — edit `pubspec.yaml` `version:`, run
-   `build_runner` (which regenerates `assets/version_info.json`, and
-   `assets/license_info.json` when dependencies changed), then commit and push to
-   `develop` to lock in the release commit before any build/publish work.
-2. **Tag + deploy** — tag the pushed commit, then `flutter_distributor` builds the
-   Windows installer (Inno Setup `exe`) and a `zip`, and publishes both as assets
-   on a GitHub release of `umasagashi/umacapture`.
+1. **Version bump + codegen + merge to develop** — edit `pubspec.yaml` `version:`,
+   run `build_runner` (which regenerates `assets/version_info.json`, and
+   `assets/license_info.json` when dependencies changed), then land the release
+   commit on `develop` **via a pull request** (see below) to lock it in before any
+   build/publish work.
+2. **Tag + deploy** — tag the merged `develop` commit, then `flutter_distributor`
+   builds the Windows installer (Inno Setup `exe`) and a `zip`, and publishes both
+   as assets on a GitHub release of `umasagashi/umacapture`.
+
+> **`develop` is a protected branch** (GitHub branch protection requires the two
+> CI status checks — `Flutter unit/widget tests` and `Native C++ tests (doctest)`
+> — to pass). A direct `git push origin develop` is **rejected by the remote**
+> regardless of local permission, so the version bump must go through a PR that is
+> merged once CI is green. Use a **merge commit** (`gh pr merge --merge`), not
+> squash, so the tagged commit is the exact commit that was reviewed.
 
 This skill runs the whole pipeline through the GitHub publish. Stop and ask the
 user if any preflight check fails.
@@ -54,14 +63,16 @@ user if any preflight check fails.
 ## Preflight (run these checks first)
 
 All commands use the FVM-pinned toolchain. The global `flutter` on PATH already
-resolves to the FVM default (3.44.0), but verify rather than assume.
+resolves to the FVM default, but verify rather than assume.
 
-1. **Flutter SDK is the pinned 3.44.0** — `flutter_distributor` shells out to
-   `flutter build windows`, so the PATH `flutter` must be the pinned one:
+1. **Flutter SDK is the pinned version** (`.fvmrc`, currently 3.44.4) —
+   `flutter_distributor` shells out to `flutter build windows`, so the PATH
+   `flutter` must be the pinned one:
    ```bash
-   flutter --version    # expect Flutter 3.44.0 / Dart 3.12.0
+   cat .fvmrc           # the pinned version
+   flutter --version    # must match it (currently Flutter 3.44.4 / Dart 3.12)
    ```
-   If it is not 3.44.0, prepend `.fvm/flutter_sdk/bin` to PATH for the session.
+   If it does not match, prepend `.fvm/flutter_sdk/bin` to PATH for the session.
 
 2. **Inno Setup `iscc` is available** (needed by the `exe` job):
    ```bash
@@ -103,7 +114,7 @@ resolves to the FVM default (3.44.0), but verify rather than assume.
    (`umasagashi` / `umacapture-release`); the token is passed via the
    `SENTRY_AUTH_TOKEN` env var, never on the command line.
 
-## Phase 1 — version bump + codegen + commit/push
+## Phase 1 — version bump + codegen + merge to develop
 
 1. Pick the new version with the user (semver, e.g. `0.0.11`; no leading `v`).
    The builder validates it with `Version.parse`, so it must be valid semver.
@@ -129,37 +140,66 @@ resolves to the FVM default (3.44.0), but verify rather than assume.
    `assets/license_info.json` and `assets/license/*.txt` change only when
    dependencies changed since the last release.
 
-Commit and push **at the end of Phase 1** to lock in the release commit before
-any build/publish work. The user-instructed version bump may be committed and
-pushed **directly to `develop`** (an explicit exception to the no-direct-push
-rule, granted for this release flow).
+Land the release commit on `develop` **at the end of Phase 1**, before any
+build/publish work. Because `develop` is protected (see the note at the top), this
+goes through a short-lived `release/v<version>` PR — a direct push is rejected by
+the remote.
 
-5. Commit on `develop` (title matches the project's history, "Bump app version"):
+5. Commit on a `release/v<version>` branch (title matches the project's history,
+   "Bump app version"). Stage `pubspec.yaml`, `assets/version_info.json`, and any
+   regenerated `assets/license_info.json` / `assets/license/*.txt`:
    ```bash
+   git switch -c release/v<version>
+   git add pubspec.yaml assets/version_info.json   # add license_info.json / license/*.txt if changed
    git commit -F - <<'EOF'
    Bump app version
 
-   Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+   Co-Authored-By: Claude <noreply@anthropic.com>
    EOF
    ```
-   Stage `pubspec.yaml`, `assets/version_info.json`, and any regenerated
-   `assets/license_info.json` / `assets/license/*.txt`.
-6. Push `develop`:
+   (Replace the `Co-Authored-By` line with the standard trailer for whichever
+   Claude model is running the release.)
+6. Push the branch and open a PR against `develop`:
    ```bash
-   git push origin develop
+   git push origin release/v<version>
+   gh pr create --base develop --head release/v<version> \
+     --title "chore: bump app version to <version>" --body-file - <<'EOF'
+   ## Summary
+
+   Bump the app version to `<version>` for the `v<version>` release.
+
+   ## Testing
+
+   Ran `dart run build_runner build --force-jit`; `assets/version_info.json`
+   reads `<version>`.
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   ```
+7. Wait for the two required checks to go green, then merge with a **merge
+   commit** (not squash — the tagged commit must be the reviewed one). Deleting
+   the branch keeps the ref namespace clean:
+   ```bash
+   gh pr checks <pr-number> --watch --interval 30
+   gh pr merge <pr-number> --merge --delete-branch
+   ```
+   Then sync local `develop` to the merge commit so the tag in Phase 2 points at
+   the right place:
+   ```bash
+   git switch develop && git pull --ff-only origin develop
    ```
 
 ## Phase 2 — tag + publish
 
-The Phase 1 commit is now fixed on the remote. Tag it and publish; the GitHub
+The Phase 1 merge commit is now on `develop`. Tag it and publish; the GitHub
 release the publisher creates attaches to the pushed `v<version>` tag.
 
-7. Create the annotated tag and push it:
+8. Create the annotated tag and push it:
    ```bash
    git tag -a "v<version>" -m "v<version>"
    git push origin "v<version>"
    ```
-8. Build and publish (packages both jobs and uploads to the GitHub release):
+9. Build and publish (packages both jobs and uploads to the GitHub release):
    ```bash
    .fvm/flutter_sdk/bin/dart pub global run flutter_distributor:main \
      release --name windows
@@ -169,10 +209,10 @@ release the publisher creates attaches to the pushed `v<version>` tag.
 
    flutter_distributor runs `flutter build windows --release` internally, so the
    fresh, matching PDBs are now sitting in `build/windows/x64/runner/Release/`.
-   Do step 8.5 **before** anything cleans `build/` — the debug-ids must match the
+   Do step 9.5 **before** anything cleans `build/` — the debug-ids must match the
    exe that was just packaged, and they cannot be regenerated later.
 
-8.5. Upload debug symbols so Sentry can symbolicate this build's native crashes.
+9.5. Upload debug symbols so Sentry can symbolicate this build's native crashes.
    Two files matter: `umacapture.pdb` (covers the runner **and** the native C++
    backend, which is linked straight into the exe) and the engine's
    `flutter_windows.dll.pdb` (already in the FVM SDK cache — no download). Third-
@@ -189,14 +229,14 @@ release the publisher creates attaches to the pushed `v<version>` tag.
    with `sentry-cli debug-files check build/windows/x64/runner/Release/umacapture.exe`
    — if the Debug ID is absent, the `/DEBUG` link flags in
    `windows/runner/CMakeLists.txt` regressed and symbols will never match.
-9. Attach `version_info.json` as a release asset. flutter_distributor only
+10. Attach `version_info.json` as a release asset. flutter_distributor only
    uploads the packaged exe/zip, so add this lightweight file separately (it lets
    a client read the published version without downloading a build). `--clobber`
    makes the step idempotent across re-runs:
    ```bash
    gh release upload "v<version>" assets/version_info.json --clobber
    ```
-10. Verify the release — all three assets present and `isPrerelease` true:
+11. Verify the release — all three assets present and `isPrerelease` true:
     ```bash
     gh release view "v<version>" --json tagName,isPrerelease,isDraft,assets \
       --jq '{tag:.tagName,prerelease:.isPrerelease,draft:.isDraft,assets:[.assets[].name]}'
@@ -204,11 +244,16 @@ release the publisher creates attaches to the pushed `v<version>` tag.
 
 ## Notes / gotchas
 
-- **flutter_distributor uses the PATH `flutter`**, not FVM directly. The pinned
-  3.44.0 must be first on PATH or the build uses the wrong SDK.
-- **Ordering matters.** The bump commit is pushed in Phase 1 and the `v<version>`
-  tag in Phase 2, both before `flutter_distributor` publishes; otherwise the
-  GitHub release the publisher creates can point at the wrong commit.
+- **flutter_distributor uses the PATH `flutter`**, not FVM directly. The
+  FVM-pinned SDK (`.fvmrc`) must be first on PATH or the build uses the wrong SDK.
+- **Ordering matters.** The bump commit is merged to `develop` via PR in Phase 1
+  and the `v<version>` tag is pushed in Phase 2, both before `flutter_distributor`
+  publishes; otherwise the GitHub release the publisher creates can point at the
+  wrong commit. Tag the merge commit on `develop`, not the pre-merge branch tip.
+- **`develop` is a protected branch.** Direct `git push origin develop` is rejected
+  by the remote (required checks: `Flutter unit/widget tests`,
+  `Native C++ tests (doctest)`), so the bump lands via a `release/v<version>` PR
+  merged with a merge commit once CI is green — no local permission overrides this.
 - **Releases publish as pre-releases** by default (`release-prerelease: "true"`
   in `distribute_options.yaml`). To cut a full (non-pre-release) release instead,
   drop that arg for the run, or promote afterwards with


### PR DESCRIPTION
## Summary

Bring the three stale Claude Code skills back in sync with the current repo state — the FFV1 recorder/replay work (PR #132), the OpenCV 4.13 / FFmpeg provisioning changes, and the protected-`develop` release flow (first exercised in PR #137).

## What changed

### 1. `native-cli-dev`

- **Subcommand table** now covers `screenshot` and `replay`, plus `capture`'s `--record` / `--duration` / `--stop-file` flags and the shared `--assets_dir` / `--modules_dir` / `--output_dir` options on the one-shot pipeline subcommands.
- **Prerequisites** add FFmpeg n7.1.5 (BtbN LGPL shared) at `windows/ffmpeg`, linked by the CLI and `umacapture_ffv1_tests`.
- **Runtime DLLs**: the "copy the videoio FFmpeg plugin manually" step is gone — the `POST_BUILD` step now copies the videoio plugin and the libav `av*`/`sw*` DLLs automatically. A caveat about the Debug `d`-suffixed plugin name remains.
- **Self-termination / logging** notes updated for `replay` and the clean `capture` stop paths (which finalize an in-progress recording, unlike a hard kill).

### 2. `project-setup`

- **Dependency table** adds the FFmpeg row; `tool/fetch_deps.py` provisions all three by default.
- **CI note** reflects that CI provisions OpenCV + FFmpeg via the same script with `--slim` (cached), and that the cache keys must be bumped with the pins.

### 3. `release`

- **Phase 1 rewritten for the protected branch**: the version bump lands via a short-lived `release/v<version>` PR merged with a merge commit once the two required checks pass — the old "direct push to develop" exception was false against the real remote.
- **Pinned Flutter version** now points at `.fvmrc` (currently 3.44.4) instead of the hardcoded 3.44.0.
- **Co-author trailer** in the example commit is no longer hardcoded to a specific model.

## Testing

Docs-only change. Every updated claim was verified against the current tree: `native/src/core/cli.cpp` (subcommands/options), `native/CMakeLists.txt` (ffmpeg linkage, POST_BUILD copies), `tool/fetch_deps.py` (default targets, `--slim`), `.github/workflows/ci.yml` (provisioning, cache keys, `umacapture_ffv1_tests`), and `.fvmrc` / `flutter --version` (3.44.4 / Dart 3.12.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
