### PR TITLE
feat(chara-detail): veto image offsets that stray from the scroll-bar guess

### DIFF
--- a/assets/config/chara_detail/scene_scraper.json
+++ b/assets/config/chara_detail/scene_scraper.json
@@ -143,6 +143,7 @@
     "stationary_time_threshold": 200,
     "minimum_color_threshold": 18,
     "stationary_color_threshold": 100,
+    "viewport": 0.738,
     "cap_offset": 0.00126,
     "scroll_bar_margin_color": {
       "min": {
@@ -165,7 +166,8 @@
       "max_sampled_rows": 32,
       "minimum_contrast": 20.0,
       "minimum_coverage": 3.0
-    }
+    },
+    "guess_window_margin": 0.1
   },
   "friend_common": {
     "base_image_stationary_rect": {
@@ -311,6 +313,7 @@
     "stationary_time_threshold": 200,
     "minimum_color_threshold": 18,
     "stationary_color_threshold": 100,
+    "viewport": 0.553,
     "cap_offset": 0.00126,
     "scroll_bar_margin_color": {
       "min": {
@@ -333,7 +336,8 @@
       "max_sampled_rows": 32,
       "minimum_contrast": 20.0,
       "minimum_coverage": 3.0
-    }
+    },
+    "guess_window_margin": 0.1
   },
   "skill_scans": [
     {

--- a/native/src/chara_detail/chara_detail_config.h
+++ b/native/src/chara_detail/chara_detail_config.h
@@ -84,8 +84,8 @@ struct SceneScraperConfig {
     Rect<double> scroll_area_rect;
     // Full-width band the scrollbar is detected in, decoupled from scroll_area_rect (the content/stitch crop)
     // so the latter can move without shifting the scan geometry. It MUST stay full width (x IntersectStart ->
-    // IntersectPixelEnd): the scan line x and cap_offset are normalized by the crop width, so a narrower band
-    // would silently mis-scale them. Only its y-range is meant to diverge from scroll_area_rect.
+    // IntersectPixelEnd): the scan line x, viewport and cap_offset are all normalized by the crop width, so a
+    // narrower band would silently mis-scale them. Only its y-range is meant to diverge from scroll_area_rect.
     Rect<double> scroll_bar_rect;
     Rect<double> scroll_area_stationary_rect;
     Range<Color> scroll_bar_bg_color;
@@ -95,15 +95,24 @@ struct SceneScraperConfig {
     uint64 stationary_time_threshold;
     int minimum_color_threshold;
     uint64 stationary_color_threshold;
-    // Scrollbar physics, width-normalized so they scale with the screen and never depend on the crop height.
-    // `cap_offset` is the thumb's rounded-cap depth c: the tip-to-tip length over-reads the logical thumb
-    // length by 2c, so the logical length is `tip - 2 * cap_offset`. `scroll_bar_margin_color` is the
-    // near-white band flanking the placeholder track; isolating it locates the fixed track ends so the
-    // position is measured against the true track, not the (slightly longer) config scan line.
+    // Scrollbar physics, all width-normalized so they scale with the screen and never depend on the crop
+    // height (each layout carries its own values). `viewport` is the visible content height V used to turn a
+    // per-step thumb-travel delta into a content-pixel scroll guess (guess = V * delta_upper_gap /
+    // thumb_length); it is NOT the crop height. `cap_offset` is the thumb's rounded-cap depth c: the tip-to-tip
+    // length over-reads the logical thumb length by 2c, so the logical length is `tip - 2 * cap_offset`.
+    // `scroll_bar_margin_color` is the near-white band flanking the placeholder track; isolating it locates the
+    // fixed track ends so the position is measured against the true track, not the (slightly longer) config
+    // scan line.
+    double viewport;
     double cap_offset;
     Range<Color> scroll_bar_margin_color;
     // Sub-pixel thumb-centre probe geometry (self-centres the vertical scan on the thumb; see trackCenterX).
     ScrollBarThumbProbeConfig scroll_bar_thumb_probe;
+    // Half-width (width-normalized) of the scroll-guess safeguard window: the image estimator's chosen offset
+    // is vetoed when it lands farther than this from the scroll-bar guess (see ScrollAreaOffsetEstimator::
+    // estimate). Sized well above the worst measured true-offset guess error yet far below the periodicity
+    // alias distance, so it rejects far aliases without ever rejecting a genuine offset.
+    double guess_window_margin;
 
     EXTENDED_JSON_TYPE_NDC(
         SceneScraperConfig,
@@ -120,9 +129,11 @@ struct SceneScraperConfig {
         stationary_time_threshold,
         minimum_color_threshold,
         stationary_color_threshold,
+        viewport,
         cap_offset,
         scroll_bar_margin_color,
-        scroll_bar_thumb_probe);
+        scroll_bar_thumb_probe,
+        guess_window_margin);
 };
 
 struct ScanParameter {

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -45,8 +45,8 @@ constexpr double kThumbBottomFlushPx = 2.0;
 // cleanly. Above this the two frames' thumb lengths genuinely differ and the guess divides each upper_gap by
 // its own frame's length; at or below it the difference is only measurement jitter and the reference length is
 // shared to cancel it. The change is compared in EXACT pixels (thumb_logical * unit): the tips feeding it are
-// sub-pixel-refined on the veto path (scrollGuess refine=true), so there is no per-operand lround rounding to
-// wobble the difference.
+// sub-pixel-refined by default (scrollGuess refine=true, the calibrated path the veto uses), so there is no
+// per-operand lround rounding to wobble the difference.
 //
 // 2.0 sits in a wide empty band between the two populations, measured over all 11 golden clips (3879 frame
 // pairs) with the sub-pixel-refined tips the veto path actually uses: steady-scroll jitter tops out at ~1.2 px
@@ -339,6 +339,12 @@ std::optional<double> ScrollBarOffsetEstimator::scrollGuess(const Frame &from, c
     // thumb-length change. The gate uses only the change MAGNITUDE, never the thumb direction: V1 is correct
     // for any genuine re-scale regardless of whether the thumb net moved up or down, so a re-scale followed by
     // scrolling that nets the thumb downward is still caught (|Δtl| ~5px > 2.0 -> V1) with no per-frame state.
+    // The clip check outranking the re-scale gate can never mis-route a genuine re-scale into the shared form:
+    // a re-scale IS content appended at the END of the scroll area, and the append detaches the thumb bottom
+    // from the track bottom by exactly the appended fraction -- so a post-re-scale `to` is never bottom-clipped
+    // (cases 1 and 2 are mutually exclusive). The lone counterexample -- being overscrolled by at least the
+    // appended amount when the append lands -- does not occur in practice, and motion that fast defeats the
+    // image overlap anyway, so it is deliberately unsupported.
     const double viewport_px = from.anchor().scaleToPixels(viewport);
     const bool to_bottom_clipped = to.anchor().scaleToPixels(gt->lower_gap) <= kThumbBottomFlushPx;
     const double thumb_change_px =
@@ -560,12 +566,12 @@ std::optional<double> ScrollAreaOffsetEstimator::estimate(FrameDescriptor &from,
     // hundreds of px from the guess while a true offset lands within a fraction of a row pitch, so the window
     // rejects the alias and never a true offset. When the guess is unavailable (no scrollbar / mid-scroll
     // resolution change) no veto is applied and the pure candidate+verify result stands.
-    // Sub-pixel thumb-tip refinement (refine=true): on a short thumb one integer tip pixel is worth tens of
-    // content pixels (viewport / thumb_length ~= 27 px per tip pixel on the tiny friend rental thumb), so the
-    // colour-run's whole-pixel tips quantize the guess into coarse steps -- measured to halve the guess error
-    // on real scrolls and to cut the tiny-thumb worst case from ~44 px to ~17 px. The tighter guess only
+    // Sub-pixel thumb-tip refinement (scrollGuess's default): on a short thumb one integer tip pixel is worth
+    // tens of content pixels (viewport / thumb_length ~= 27 px per tip pixel on the tiny friend rental thumb),
+    // so the colour-run's whole-pixel tips quantize the guess into coarse steps -- measured to halve the guess
+    // error on real scrolls and to cut the tiny-thumb worst case from ~44 px to ~17 px. The tighter guess only
     // sharpens this outlier veto; the offset itself still comes from the image estimator.
-    if (const auto guess = scroll_bar_offset_estimator.scrollGuess(from.scroll_bar_frame, to.scroll_bar_frame, true)) {
+    if (const auto guess = scroll_bar_offset_estimator.scrollGuess(from.scroll_bar_frame, to.scroll_bar_frame)) {
         const double margin = from.scroll_bar_frame.anchor().scaleToPixels(guess_window_margin);
         if (std::abs(offset.value() - guess.value()) > margin) {
             return std::nullopt;

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -40,18 +40,23 @@ constexpr double kThumbBottomFlushPx = 2.0;
 
 // Minimum thumb-length CHANGE, in pixels, between two frames that counts as a genuine mid-scroll re-scale (the
 // game re-scaling the factor thumb when it appends 継承履歴). A percentage tolerance conflates jitter and
-// re-scale on a tiny thumb: on a ~15 px thumb (friend max-rental) the ±2 px endpoint-quantization jitter is
-// ~5.7%, indistinguishable from a genuine re-scale step (~5.7%). In ABSOLUTE pixels the two separate cleanly --
-// jitter stays ~2 px regardless of thumb size, while a real re-scale moves the thumb ~5 px. Above this the two
-// frames' thumb lengths genuinely differ and the guess divides each upper_gap by its own frame's length; at or
-// below it the difference is only measurement jitter and the reference length is shared to cancel it. 2.5 sits
-// between the two populations: safely above the worst jitter (two lengthIn grid steps, each slightly OVER 1 px
-// -- the sample grid is scan_length/(samples-1) -- so a 2.0 cut would let plain quantization jitter trip) and
-// safely below the ~5 px re-scale. The change is compared in EXACT pixels (thumb_logical * unit), never through
-// per-operand lround: rounding each length first wobbles the difference by ±1 px, enough to push 2 px jitter
-// over the cut (a false re-scale -> the jitter-amplifying own-length form -> a spurious veto) or a true 3 px
-// change under it.
-constexpr double kRescaleThumbChangePx = 2.5;
+// re-scale on a tiny thumb: on a ~15 px thumb (friend max-rental) the endpoint-measurement jitter is a large
+// fraction of the length, indistinguishable from a genuine re-scale step. In ABSOLUTE pixels the two separate
+// cleanly. Above this the two frames' thumb lengths genuinely differ and the guess divides each upper_gap by
+// its own frame's length; at or below it the difference is only measurement jitter and the reference length is
+// shared to cancel it. The change is compared in EXACT pixels (thumb_logical * unit): the tips feeding it are
+// sub-pixel-refined on the veto path (scrollGuess refine=true), so there is no per-operand lround rounding to
+// wobble the difference.
+//
+// 2.0 sits in a wide empty band between the two populations, measured over all 11 golden clips (3879 frame
+// pairs) with the sub-pixel-refined tips the veto path actually uses: steady-scroll jitter tops out at ~1.2 px
+// (max 1.23, p99.9 1.15; even the tiny ~30 px friend-inheritance thumb stays at ~1.0), while the sole genuine
+// re-scale in the corpus moves the thumb ~5 px (5.14). Nothing lands in (1.5, 5.0]. 2.0 clears the worst
+// observed jitter by ~0.8 px yet stays well below the re-scale, so it neither trips on jitter (a false
+// re-scale -> the jitter-amplifying own-length form -> a spurious veto) nor misses a real re-scale. Sub-pixel
+// refinement is what shrank the jitter here: without it the whole-pixel tips quantize the change into ±1 px
+// steps, which is why the historical gate needed the extra headroom.
+constexpr double kRescaleThumbChangePx = 2.0;
 
 }  // namespace
 

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -1,5 +1,6 @@
 #include "chara_detail/chara_detail_scene_scraper.h"
 
+#include <array>
 #include <map>
 
 namespace uma::chara_detail {
@@ -32,17 +33,35 @@ constexpr double kFactorEndGreenSearchSpan = 0.08;
 // still staged in RAM when the terminator fires.
 constexpr double kFactorEndGraySearchSpan = 0.16;
 
+// Thumb-bottom "pinned" tolerance in pixels for the scroll-bar guess: at/below this lower_gap the thumb
+// bottom is treated as at the track bottom (bottom rest / overscroll), where the frame's own measured thumb
+// length is unreliable, so the guess divides by the reference (from) length instead. Mirrors the historical
+// kThumbBottomFlushPx / factor_header.flush_tolerance_px = 1.5, rounded to 2 px.
+constexpr double kThumbBottomFlushPx = 2.0;
+
+// Minimum thumb-length CHANGE, in pixels, between two frames that counts as a genuine mid-scroll re-scale (the
+// game re-scaling the factor thumb when it appends 継承履歴). A percentage tolerance conflates jitter and
+// re-scale on a tiny thumb: on a ~15 px thumb (friend max-rental) the ±2 px endpoint-quantization jitter is
+// ~5.7%, indistinguishable from a genuine re-scale step (~5.7%). In ABSOLUTE pixels the two separate cleanly --
+// jitter stays ~2 px regardless of thumb size, while a real re-scale moves the thumb ~5 px. Above this the two
+// frames' thumb lengths genuinely differ and the guess divides each upper_gap by its own frame's length; at or
+// below it the difference is only measurement jitter and the reference length is shared to cancel it. The
+// comparison is strict (>), so the observed ±2.0 px jitter does not trip it (2.0 > 2.0 is false).
+constexpr double kRescaleThumbChangePx = 2.0;
+
 }  // namespace
 
 ScrollBarOffsetEstimator::ScrollBarOffsetEstimator(
     const Range<Color> &scroll_bar_bg_color_range,
     const Line<double> &scroll_bar_scan_line,
     const Range<Color> &scroll_bar_margin_color_range,
+    double viewport,
     double cap_offset,
     const scraper_config::ScrollBarThumbProbeConfig &thumb_probe)
     : scroll_bar_bg_color_range(scroll_bar_bg_color_range)
     , scroll_bar_scan_line(scroll_bar_scan_line)
     , scroll_bar_margin_color_range(scroll_bar_margin_color_range)
+    , viewport(viewport)
     , cap_offset(cap_offset)
     , thumb_probe(thumb_probe) {}
 
@@ -197,6 +216,46 @@ std::optional<double> ScrollBarOffsetEstimator::topMargin(const Frame &frame) co
         return std::nullopt;
     }
     return geometry->upper_gap / geometry->track_span;
+}
+
+std::optional<double> ScrollBarOffsetEstimator::scrollGuess(const Frame &from, const Frame &to) const {
+    // A mid-scroll resolution change would mix from's pixel scale (viewport_px below) with a cross-scale thumb
+    // length, so the guess is only valid at one scale. Bail. (!= is not auto-generated for these value types;
+    // use !(==).)
+    if (!(from.size() == to.size())) {
+        return std::nullopt;
+    }
+    const auto gf = trackGeometry(from);
+    const auto gt = trackGeometry(to);
+    if (!gf || !gt) {
+        return std::nullopt;
+    }
+    // The scroll offset is viewport * (S_to - S_from) with each frame's absolute scroll fraction S = upper_gap
+    // / thumb_length. The total content length C cancels out of S per frame, so the guess is exact even when C
+    // changes mid-scroll -- PROVIDED each upper_gap is divided by ITS OWN frame's thumb length. Two effects
+    // force a choice of divisor:
+    //   1. Mid-scroll re-scale (inheritance history appended): the thumb length genuinely changes between the
+    //      frames. Only the per-frame-own-length form is correct; dividing to's upper_gap by from's stale
+    //      length reads a post-re-scale position on a pre-re-scale ruler and yields a large phantom offset.
+    //   2. Bottom overscroll: to's thumb collapses (top slides down, bottom pinned), so to's own length is
+    //      corrupted -- there the reference (from) length must be used instead.
+    //   3. Steady scrolling: the true length is unchanged, but the ~1px thumb-length MEASUREMENT jitter, when
+    //      each frame divides its large absolute upper_gap by its own noisy length, amplifies into a large step
+    //      error. Sharing the single reference length cancels that jitter (and the absolute position with it).
+    // So: use per-frame own length ONLY when the thumb genuinely re-scaled AND to is not bottom-clipped;
+    // otherwise share from's length (which both cancels jitter and freezes across the bottom clip). Detection
+    // is by to's lower_gap (bottom clip pins the thumb bottom to the track bottom) and the absolute-pixel
+    // thumb-length change. The gate uses only the change MAGNITUDE, never the thumb direction: V1 is correct
+    // for any genuine re-scale regardless of whether the thumb net moved up or down, so a re-scale followed by
+    // scrolling that nets the thumb downward is still caught (|Δtl| ~5px > 2.0 -> V1) with no per-frame state.
+    const double viewport_px = from.anchor().scaleToPixels(viewport);
+    const bool to_bottom_clipped = to.anchor().scaleToPixels(gt->lower_gap) <= kThumbBottomFlushPx;
+    const double thumb_change_px =
+        std::abs(to.anchor().scaleToPixels(gt->thumb_logical) - from.anchor().scaleToPixels(gf->thumb_logical));
+    if (!to_bottom_clipped && thumb_change_px > kRescaleThumbChangePx) {
+        return viewport_px * (gt->upper_gap / gt->thumb_logical - gf->upper_gap / gf->thumb_logical);
+    }
+    return viewport_px * (gt->upper_gap - gf->upper_gap) / gf->thumb_logical;
 }
 
 ImageOffsetEstimator::ImageOffsetEstimator(const ImageOffsetEstimatorConfig &config)
@@ -387,16 +446,37 @@ double ImageOffsetEstimator::overlapScore(const cv::Mat &from_gray, const cv::Ma
 }
 
 ScrollAreaOffsetEstimator::ScrollAreaOffsetEstimator(
-    const ScrollBarOffsetEstimator &scroll_bar_offset_estimator, const ImageOffsetEstimator &image_offset_estimator)
+    const ScrollBarOffsetEstimator &scroll_bar_offset_estimator,
+    const ImageOffsetEstimator &image_offset_estimator,
+    double guess_window_margin)
     : scroll_bar_offset_estimator(scroll_bar_offset_estimator)
-    , image_offset_estimator(image_offset_estimator) {}
+    , image_offset_estimator(image_offset_estimator)
+    , guess_window_margin(guess_window_margin) {}
 
 std::optional<double> ScrollAreaOffsetEstimator::position(const FrameDescriptor &descriptor) const {
     return scroll_bar_offset_estimator.position(descriptor.scroll_bar_frame);
 }
 
 std::optional<double> ScrollAreaOffsetEstimator::estimate(FrameDescriptor &from, FrameDescriptor &to) const {
-    return image_offset_estimator.estimate(from, to);
+    const auto offset = image_offset_estimator.estimate(from, to);
+    if (!offset) {
+        return std::nullopt;
+    }
+    // --- guess-window safeguard (independent; delete this block + scrollGuess + config to remove) ---
+    // Veto an image-estimator offset that sits far from the scroll-bar guess. The candidate+verify estimator is
+    // correct whenever a genuine overlap exists, but the periodic factor/list rows let a far-apart, non-
+    // overlapping pair alias onto a wrong offset that still clears the overlap gate; such an alias lands
+    // hundreds of px from the guess while a true offset lands within a fraction of a row pitch, so the window
+    // rejects the alias and never a true offset. When the guess is unavailable (no scrollbar / mid-scroll
+    // resolution change) no veto is applied and the pure candidate+verify result stands.
+    if (const auto guess = scroll_bar_offset_estimator.scrollGuess(from.scroll_bar_frame, to.scroll_bar_frame)) {
+        const double margin = from.scroll_bar_frame.anchor().scaleToPixels(guess_window_margin);
+        if (std::abs(offset.value() - guess.value()) > margin) {
+            return std::nullopt;
+        }
+    }
+    // --- end safeguard ---
+    return offset;
 }
 
 PageScrapingBox::PageScrapingBox(
@@ -1031,6 +1111,7 @@ void SceneScraper::build(const Frame &frame) {
         config.scroll_bar_bg_color,
         config.scroll_bar_scan_line,
         config.scroll_bar_margin_color,
+        config.viewport,
         config.cap_offset,
         config.scroll_bar_thumb_probe);
     const auto &scroll_bar_offset_estimator = *scroll_bar_estimator;
@@ -1044,7 +1125,7 @@ void SceneScraper::build(const Frame &frame) {
     if (scroll_bar_offset_estimator.hasScrollbar(scroll_bar_frame)) {
         scroll_area_scraper = std::make_unique<ScrollableScrapingInterpreter>(
             scraping_box,
-            ScrollAreaOffsetEstimator(scroll_bar_offset_estimator, ImageOffsetEstimator()),
+            ScrollAreaOffsetEstimator(scroll_bar_offset_estimator, ImageOffsetEstimator(), config.guess_window_margin),
             stationary_catcher,
             config.scroll_area_rect,
             config.scroll_bar_rect,

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -44,9 +44,14 @@ constexpr double kThumbBottomFlushPx = 2.0;
 // ~5.7%, indistinguishable from a genuine re-scale step (~5.7%). In ABSOLUTE pixels the two separate cleanly --
 // jitter stays ~2 px regardless of thumb size, while a real re-scale moves the thumb ~5 px. Above this the two
 // frames' thumb lengths genuinely differ and the guess divides each upper_gap by its own frame's length; at or
-// below it the difference is only measurement jitter and the reference length is shared to cancel it. The
-// comparison is strict (>), so the observed ±2.0 px jitter does not trip it (2.0 > 2.0 is false).
-constexpr double kRescaleThumbChangePx = 2.0;
+// below it the difference is only measurement jitter and the reference length is shared to cancel it. 2.5 sits
+// between the two populations: safely above the worst jitter (two lengthIn grid steps, each slightly OVER 1 px
+// -- the sample grid is scan_length/(samples-1) -- so a 2.0 cut would let plain quantization jitter trip) and
+// safely below the ~5 px re-scale. The change is compared in EXACT pixels (thumb_logical * unit), never through
+// per-operand lround: rounding each length first wobbles the difference by ±1 px, enough to push 2 px jitter
+// over the cut (a false re-scale -> the jitter-amplifying own-length form -> a spurious veto) or a true 3 px
+// change under it.
+constexpr double kRescaleThumbChangePx = 2.5;
 
 }  // namespace
 
@@ -332,7 +337,7 @@ std::optional<double> ScrollBarOffsetEstimator::scrollGuess(const Frame &from, c
     const double viewport_px = from.anchor().scaleToPixels(viewport);
     const bool to_bottom_clipped = to.anchor().scaleToPixels(gt->lower_gap) <= kThumbBottomFlushPx;
     const double thumb_change_px =
-        std::abs(to.anchor().scaleToPixels(gt->thumb_logical) - from.anchor().scaleToPixels(gf->thumb_logical));
+        std::abs(gt->thumb_logical - gf->thumb_logical) * from.anchor().scaleToPixels(1.0);
     if (!to_bottom_clipped && thumb_change_px > kRescaleThumbChangePx) {
         return viewport_px * (gt->upper_gap / gt->thumb_logical - gf->upper_gap / gf->thumb_logical);
     }

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -1,6 +1,5 @@
 #include "chara_detail/chara_detail_scene_scraper.h"
 
-#include <array>
 #include <map>
 
 namespace uma::chara_detail {
@@ -242,11 +241,14 @@ std::optional<std::pair<double, double>> ScrollBarOffsetEstimator::refineThumbEd
         if (lo - kPlateau < 0 || hi + kPlateau >= image.rows) {
             return std::nullopt;
         }
-        // Plateaus sampled a couple of pixels clear of the transition on each side.
-        const int bright_row = bg_above ? lo - 1 : hi + 1;
-        const int dark_row = bg_above ? hi + 1 : lo - 1;
-        const double bright = median3(lum(bright_row), lum(bright_row + (bg_above ? -1 : 1)), lum(bright_row));
-        const double dark = median3(lum(dark_row), lum(dark_row + (bg_above ? 1 : -1)), lum(dark_row));
+        // Plateaus: three rows per side, starting at the window edge and walking outward, so the deepest row
+        // is exactly what the bounds check above reserves (lo - kPlateau / hi + kPlateau). The edge rows sit
+        // clear of the ~1-2 px tip ramp, and the median drops one stray (or ramp-tinted) pixel among them.
+        const auto plateau = [&](int edge_row, int outward) {
+            return median3(lum(edge_row), lum(edge_row + outward), lum(edge_row + 2 * outward));
+        };
+        const double bright = bg_above ? plateau(lo, -1) : plateau(hi, 1);
+        const double dark = bg_above ? plateau(hi, 1) : plateau(lo, -1);
         if (bright - dark < kMinEdgeContrast) {
             return std::nullopt;
         }
@@ -1086,9 +1088,11 @@ void ScrollableScrapingInterpreter::startScrolling(const FrameDescriptor &valid_
 
 void ScrollableScrapingInterpreter::updateScrolling(const Frame &frame) {
     FrameDescriptor current_fragment = {frame.copy(scroll_area_rect), frame.copy(scroll_bar_rect)};
-    // Guess-free: the offset comes from image evidence alone, so a scroll-bar thumb re-scale (inheritance
-    // history appended mid-scroll) or a clipped thumb cannot mislead it. On a genuine non-match the offset
-    // stays nullopt, the frame is skipped, and the reference descriptor freezes until a matching frame comes.
+    // The offset is decided by image evidence (candidate + overlap verify); the scroll-bar guess is applied
+    // only as a far-outlier veto on that result, with a window sized so a thumb re-scale (inheritance history
+    // appended mid-scroll) or a clipped thumb cannot reject a genuine offset (see ScrollAreaOffsetEstimator::
+    // estimate). On a genuine non-match -- or a veto -- the offset stays nullopt, the frame is skipped, and
+    // the reference descriptor freezes until a matching frame comes.
     const auto offset = offset_estimator.estimate(previous_descriptor, current_fragment);
 
     // Check the green terminator every frame, anchored to the scroll frontier (height - offset), BEFORE

--- a/native/src/chara_detail/chara_detail_scene_scraper.cpp
+++ b/native/src/chara_detail/chara_detail_scene_scraper.cpp
@@ -70,7 +70,7 @@ bool ScrollBarOffsetEstimator::hasScrollbar(const Frame &frame) const {
 }
 
 std::optional<ScrollBarOffsetEstimator::TrackGeometry>
-ScrollBarOffsetEstimator::geometryAt(const Frame &frame, const Line<double> &scan_line) const {
+ScrollBarOffsetEstimator::geometryAt(const Frame &frame, const Line<double> &scan_line, bool refine) const {
     // Background run from each end reaches the thumb (dark, out of the light bg range). == 1. means the whole
     // line is background: no thumb, so no scrollbar.
     const auto upper = frame.lengthIn(scroll_bar_bg_color_range, scan_line);
@@ -88,10 +88,17 @@ ScrollBarOffsetEstimator::geometryAt(const Frame &frame, const Line<double> &sca
     const double m_lo = (margin_lower && margin_lower.value() < 1.) ? margin_lower.value() : 0.0;
 
     const auto scan = frame.anchor().absolute(scan_line).vertical();
-    const double thumb_top = scan.pointAt(upper.value());
-    const double thumb_bottom = scan.pointAt(1. - lower.value());
+    double thumb_top = scan.pointAt(upper.value());
+    double thumb_bottom = scan.pointAt(1. - lower.value());
     const double track_top = scan.pointAt(m_up);
     const double track_bottom = scan.pointAt(1. - m_lo);
+
+    if (refine) {
+        if (const auto refined = refineThumbEdges(frame, scan_line, thumb_top, thumb_bottom)) {
+            thumb_top = refined->first;
+            thumb_bottom = refined->second;
+        }
+    }
 
     const double thumb_logical = (thumb_bottom - thumb_top) - 2. * cap_offset;
     const double track_span = track_bottom - track_top;
@@ -187,15 +194,87 @@ std::optional<double> ScrollBarOffsetEstimator::trackCenterX(const Frame &frame)
 }
 
 std::optional<ScrollBarOffsetEstimator::TrackGeometry>
-ScrollBarOffsetEstimator::trackGeometry(const Frame &frame) const {
+ScrollBarOffsetEstimator::trackGeometry(const Frame &frame, bool refine) const {
     const auto center_x = trackCenterX(frame);
     if (!center_x) {
-        return geometryAt(frame, scroll_bar_scan_line);  // Fall back to the fixed config column.
+        return geometryAt(frame, scroll_bar_scan_line, refine);  // Fall back to the fixed config column.
     }
     const auto &p1 = scroll_bar_scan_line.p1();
     const auto &p2 = scroll_bar_scan_line.p2();
     const Line<double> centered_line{{center_x.value(), p1.y(), p1.anchor()}, {center_x.value(), p2.y(), p2.anchor()}};
-    return geometryAt(frame, centered_line);
+    return geometryAt(frame, centered_line, refine);
+}
+
+std::optional<std::pair<double, double>> ScrollBarOffsetEstimator::refineThumbEdges(
+    const Frame &frame, const Line<double> &scan_line, double thumb_top_norm, double thumb_bottom_norm) const {
+    const auto &anchor = frame.anchor();
+    const cv::Mat &image = frame.data();
+    const int unit = anchor.scaleToPixels(1.0);
+    // Scan column x in raw Mat pixels. Same fixed-anchor invariant as trackCenterX (intersection.left() == 0),
+    // so absolute()'s x-offset is a no-op and is skipped.
+    const int x = anchor.scaleToPixels(scan_line.p1().x());
+    const int top_row = anchor.scaleToPixels(thumb_top_norm);     // last background pixel above the thumb tip
+    const int bottom_row = anchor.scaleToPixels(thumb_bottom_norm);  // last background pixel below the thumb tip
+    if (unit <= 0 || x < 0 || x >= image.cols) {
+        return std::nullopt;
+    }
+    const auto lum = [&image, x](int y) {
+        const auto &p = image.at<cv::Vec3b>(y, x);
+        return (static_cast<double>(p[0]) + static_cast<double>(p[1]) + static_cast<double>(p[2])) / 3.;
+    };
+
+    // Search half-window and plateau sampling depth (whole pixels; the tip ramp is ~1-2 px wide).
+    constexpr int kWin = 3;
+    constexpr int kPlateau = 2;
+    constexpr double kMinEdgeContrast = 20.;  // bright(track ~200) vs dark(thumb ~60) is ~140; 20 rejects noise.
+
+    // Median of three samples, robust to a stray pixel.
+    const auto median3 = [](double a, double b, double c) {
+        return std::max(std::min(a, b), std::min(std::max(a, b), c));
+    };
+
+    // Refine one tip to the bright->dark mid-point crossing. `bg_above` marks the bright (background) side as
+    // the smaller-y side (the top tip); otherwise the bright side is below (the bottom tip). `anchor_row` is the
+    // last-background integer row, so the ramp lies just on the thumb side of it.
+    const auto refine = [&](int anchor_row, bool bg_above) -> std::optional<double> {
+        const int lo = anchor_row - kWin;
+        const int hi = anchor_row + kWin;
+        if (lo - kPlateau < 0 || hi + kPlateau >= image.rows) {
+            return std::nullopt;
+        }
+        // Plateaus sampled a couple of pixels clear of the transition on each side.
+        const int bright_row = bg_above ? lo - 1 : hi + 1;
+        const int dark_row = bg_above ? hi + 1 : lo - 1;
+        const double bright = median3(lum(bright_row), lum(bright_row + (bg_above ? -1 : 1)), lum(bright_row));
+        const double dark = median3(lum(dark_row), lum(dark_row + (bg_above ? 1 : -1)), lum(dark_row));
+        if (bright - dark < kMinEdgeContrast) {
+            return std::nullopt;
+        }
+        const double mid = (bright + dark) / 2.;
+        for (int y = lo; y < hi; y++) {
+            const double a = lum(y);
+            const double b = lum(y + 1);
+            if (bg_above) {
+                // Going downward: bright -> dark, so luminance falls through mid between y and y+1.
+                if (a >= mid && b < mid && a > b) {
+                    return static_cast<double>(y) + (a - mid) / (a - b);
+                }
+            } else {
+                // Going downward: dark -> bright, so luminance rises through mid between y and y+1.
+                if (a < mid && b >= mid && b > a) {
+                    return static_cast<double>(y) + (mid - a) / (b - a);
+                }
+            }
+        }
+        return std::nullopt;
+    };
+
+    const auto top = refine(top_row, /*bg_above=*/true);
+    const auto bottom = refine(bottom_row, /*bg_above=*/false);
+    if (!top || !bottom) {
+        return std::nullopt;
+    }
+    return std::make_pair(top.value() / unit, bottom.value() / unit);
 }
 
 std::optional<double> ScrollBarOffsetEstimator::position(const Frame &frame) const {
@@ -218,15 +297,15 @@ std::optional<double> ScrollBarOffsetEstimator::topMargin(const Frame &frame) co
     return geometry->upper_gap / geometry->track_span;
 }
 
-std::optional<double> ScrollBarOffsetEstimator::scrollGuess(const Frame &from, const Frame &to) const {
+std::optional<double> ScrollBarOffsetEstimator::scrollGuess(const Frame &from, const Frame &to, bool refine) const {
     // A mid-scroll resolution change would mix from's pixel scale (viewport_px below) with a cross-scale thumb
     // length, so the guess is only valid at one scale. Bail. (!= is not auto-generated for these value types;
     // use !(==).)
     if (!(from.size() == to.size())) {
         return std::nullopt;
     }
-    const auto gf = trackGeometry(from);
-    const auto gt = trackGeometry(to);
+    const auto gf = trackGeometry(from, refine);
+    const auto gt = trackGeometry(to, refine);
     if (!gf || !gt) {
         return std::nullopt;
     }
@@ -469,7 +548,12 @@ std::optional<double> ScrollAreaOffsetEstimator::estimate(FrameDescriptor &from,
     // hundreds of px from the guess while a true offset lands within a fraction of a row pitch, so the window
     // rejects the alias and never a true offset. When the guess is unavailable (no scrollbar / mid-scroll
     // resolution change) no veto is applied and the pure candidate+verify result stands.
-    if (const auto guess = scroll_bar_offset_estimator.scrollGuess(from.scroll_bar_frame, to.scroll_bar_frame)) {
+    // Sub-pixel thumb-tip refinement (refine=true): on a short thumb one integer tip pixel is worth tens of
+    // content pixels (viewport / thumb_length ~= 27 px per tip pixel on the tiny friend rental thumb), so the
+    // colour-run's whole-pixel tips quantize the guess into coarse steps -- measured to halve the guess error
+    // on real scrolls and to cut the tiny-thumb worst case from ~44 px to ~17 px. The tighter guess only
+    // sharpens this outlier veto; the offset itself still comes from the image estimator.
+    if (const auto guess = scroll_bar_offset_estimator.scrollGuess(from.scroll_bar_frame, to.scroll_bar_frame, true)) {
         const double margin = from.scroll_bar_frame.anchor().scaleToPixels(guess_window_margin);
         if (std::abs(offset.value() - guess.value()) > margin) {
             return std::nullopt;

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -86,8 +86,11 @@ public:
     // change. Coarse by design -- used only as a far-outlier veto on the image estimate, never to decide the
     // offset. nullopt when either frame has no scrollbar or on a mid-scroll resolution change. `refine` snaps
     // both thumbs to sub-pixel tips (see refineThumbEdges), which is what removes the coarse per-tip-pixel
-    // quantization that otherwise dominates the guess on a short thumb; the veto path passes it.
-    [[nodiscard]] std::optional<double> scrollGuess(const Frame &from, const Frame &to, bool refine = false) const;
+    // quantization that otherwise dominates the guess on a short thumb. It defaults to true because that is
+    // the calibrated production path: the re-scale gate (kRescaleThumbChangePx) is sized on refined-tip
+    // jitter, so the integer-tip path runs the gate outside its calibration. Pass false only to measure or
+    // diagnose against the integer-tip baseline, never from production code.
+    [[nodiscard]] std::optional<double> scrollGuess(const Frame &from, const Frame &to, bool refine = true) const;
 
 private:
     // Placeholder-track geometry from one frame, all width-normalized. The thumb and track ends come from

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -59,6 +59,7 @@ public:
         const Range<Color> &scroll_bar_bg_color_range,
         const Line<double> &scroll_bar_scan_line,
         const Range<Color> &scroll_bar_margin_color_range,
+        double viewport,
         double cap_offset,
         const scraper_config::ScrollBarThumbProbeConfig &thumb_probe);
 
@@ -74,6 +75,17 @@ public:
     // length. Returns nullopt when no scrollbar is present (a short, non-scrollable page). Used to detect a
     // completed tab snapping back to the top after a character switch.
     [[nodiscard]] std::optional<double> topMargin(const Frame &frame) const;
+
+    // Scroll-bar-derived content-pixel guess of the scroll offset between two frames: the delta of the
+    // placeholder-track upper_gap over a cap-corrected thumb length, scaled by the true viewport. It normally
+    // divides both upper_gap terms by from's single length, which cancels the absolute scroll position (so
+    // ±1px thumb-length jitter cannot amplify) and freezes the length at the bottom for free (the terminating
+    // frame's own thumb collapses, but from is the previous unclipped latch). Only when the thumb genuinely
+    // re-scales mid-scroll (inheritance history appended, detected by an absolute-pixel thumb-length change)
+    // does it divide each upper_gap by its OWN frame's length -- the form that stays correct across the length
+    // change. Coarse by design -- used only as a far-outlier veto on the image estimate, never to decide the
+    // offset. nullopt when either frame has no scrollbar or on a mid-scroll resolution change.
+    [[nodiscard]] std::optional<double> scrollGuess(const Frame &from, const Frame &to) const;
 
 private:
     // Placeholder-track geometry from one frame, all width-normalized. The thumb and track ends come from
@@ -103,6 +115,7 @@ private:
     const Range<Color> scroll_bar_bg_color_range;
     const Line<double> scroll_bar_scan_line;
     const Range<Color> scroll_bar_margin_color_range;
+    const double viewport;
     const double cap_offset;
     const scraper_config::ScrollBarThumbProbeConfig thumb_probe;
 };
@@ -193,19 +206,24 @@ private:
 class ScrollAreaOffsetEstimator {
 public:
     ScrollAreaOffsetEstimator(
-        const ScrollBarOffsetEstimator &scroll_bar_offset_estimator, const ImageOffsetEstimator &image_offset_estimator);
+        const ScrollBarOffsetEstimator &scroll_bar_offset_estimator,
+        const ImageOffsetEstimator &image_offset_estimator,
+        double guess_window_margin);
 
     [[nodiscard]] std::optional<double> position(const FrameDescriptor &descriptor) const;
 
-    // Content scroll offset between the frames, decided purely by the image estimator. The scroll bar is NOT
-    // consulted: its guess is wrong exactly when it matters most (the thumb pins to the track bottom on the
-    // terminating frame, collapsing the measured travel), and a keypoint window built on a wrong guess
-    // rejects the true offset. The scroll-bar estimator remains only for position()/topMargin().
+    // Content scroll offset between the frames. The image estimator decides the offset (candidate + overlap
+    // verify); the scroll-bar guess is then applied only as an independent far-outlier veto: an image offset
+    // more than guess_window_margin (width units) from scrollGuess() is rejected (nullopt). The veto catches
+    // periodic-row aliases that clear the overlap gate yet land far from where the scroll bar says the scroll
+    // is. When the guess is unavailable (no scrollbar / mid-scroll resolution change) the pure image result
+    // stands.
     [[nodiscard]] std::optional<double> estimate(FrameDescriptor &from, FrameDescriptor &to) const;
 
 private:
     const ScrollBarOffsetEstimator scroll_bar_offset_estimator;
     const ImageOffsetEstimator image_offset_estimator;
+    const double guess_window_margin;
 };
 
 class PageScrapingBox {

--- a/native/src/chara_detail/chara_detail_scene_scraper.h
+++ b/native/src/chara_detail/chara_detail_scene_scraper.h
@@ -84,8 +84,10 @@ public:
     // re-scales mid-scroll (inheritance history appended, detected by an absolute-pixel thumb-length change)
     // does it divide each upper_gap by its OWN frame's length -- the form that stays correct across the length
     // change. Coarse by design -- used only as a far-outlier veto on the image estimate, never to decide the
-    // offset. nullopt when either frame has no scrollbar or on a mid-scroll resolution change.
-    [[nodiscard]] std::optional<double> scrollGuess(const Frame &from, const Frame &to) const;
+    // offset. nullopt when either frame has no scrollbar or on a mid-scroll resolution change. `refine` snaps
+    // both thumbs to sub-pixel tips (see refineThumbEdges), which is what removes the coarse per-tip-pixel
+    // quantization that otherwise dominates the guess on a short thumb; the veto path passes it.
+    [[nodiscard]] std::optional<double> scrollGuess(const Frame &from, const Frame &to, bool refine = false) const;
 
 private:
     // Placeholder-track geometry from one frame, all width-normalized. The thumb and track ends come from
@@ -100,11 +102,24 @@ private:
         double thumb_logical;  // thumb tip-to-tip length - 2 * cap_offset, guaranteed > 0
     };
 
-    [[nodiscard]] std::optional<TrackGeometry> trackGeometry(const Frame &frame) const;
+    [[nodiscard]] std::optional<TrackGeometry> trackGeometry(const Frame &frame, bool refine = false) const;
 
     // TrackGeometry from the colour runs along one scan column. trackGeometry() picks the column
-    // (trackCenterX, falling back to the config line) and delegates here.
-    [[nodiscard]] std::optional<TrackGeometry> geometryAt(const Frame &frame, const Line<double> &scan_line) const;
+    // (trackCenterX, falling back to the config line) and delegates here. When `refine` is set the two thumb
+    // tips are additionally snapped to sub-pixel via refineThumbEdges; scrollGuess() (the veto path) sets it,
+    // while position()/topMargin() keep the plain integer tips.
+    [[nodiscard]] std::optional<TrackGeometry>
+    geometryAt(const Frame &frame, const Line<double> &scan_line, bool refine = false) const;
+
+    // Sub-pixel refinement of the two thumb tip rows. The colour-run detection quantizes each tip to a whole
+    // pixel (the last background pixel before the thumb), so a tip whose true position sits mid-pixel jitters by
+    // +-1 px frame to frame -- and on a short thumb one tip pixel is worth tens of content pixels in the guess.
+    // Here the anti-aliased intensity ramp across the tip locates the bright(background)->dark(thumb) mid-point
+    // crossing at sub-pixel resolution along the scan column. Returns {thumb_top, thumb_bottom} width-normalized,
+    // or nullopt (caller falls back to the integer tips) when the ramp is missing / too low contrast / out of
+    // bounds. `thumb_top_norm`/`thumb_bottom_norm` are the integer tips from the colour runs, used as anchors.
+    [[nodiscard]] std::optional<std::pair<double, double>> refineThumbEdges(
+        const Frame &frame, const Line<double> &scan_line, double thumb_top_norm, double thumb_bottom_norm) const;
 
     // Sub-pixel thumb centre x (width-normalized) from an AA intensity-weighted centroid over the thumb's
     // central rows, so the vertical scan self-centres on the thumb instead of trusting the fixed config x

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -8,11 +8,12 @@
 // with hand-built CV_8UC3 mats through Frame::fixed(), whose anchor normalizes BOTH axes by the frame
 // width, so on a square frame a pixel (px, py) is addressed at normalized (px/w, py/w).
 //
-// The image estimator's full AKAZE/FLANN match on synthetic frames is not asserted (it is brittle on
-// feature-poor test images); its deterministic pieces are pinned instead: the "no features -> nullopt"
-// guard, the candidate extraction (detectOffsetCandidates on hand-built displacement sets), and the
-// symmetric overlap verification (overlapScore on hand-built grayscale mats). The end-to-end match is
-// arbitrated by the integration golden harness on real footage.
+// The image estimator's full AKAZE/FLANN match is asserted only on a deliberately feature-RICH blob
+// texture (see blobTexture / the guess-window veto test); it is brittle on feature-poor synthetic images,
+// so its deterministic pieces are pinned separately: the "no features -> nullopt" guard, the candidate
+// extraction (detectOffsetCandidates on hand-built displacement sets), and the symmetric overlap
+// verification (overlapScore on hand-built grayscale mats). The end-to-end match is arbitrated by the
+// integration golden harness on real footage.
 
 #include <doctest/doctest.h>
 
@@ -346,6 +347,47 @@ TEST_CASE("ImageOffsetEstimator::overlapScore returns no evidence on degenerate 
     // otherwise a blank band would outscore every genuine candidate.
     const cv::Mat uniform(100, 40, CV_8UC1, cv::Scalar(128));
     CHECK(estimator.overlapScore(uniform, uniform, 10) == 0.0);
+}
+
+// A deterministic feature-RICH texture for the full-match veto test: a mosaic of 4 px random-colour blocks
+// puts a unique high-contrast corner at every block junction, which survives AKAZE's nonlinear scale space
+// (raw per-pixel noise gets diffused away, leaving it feature-poor -- see the file header). cv::RNG is a
+// fixed-algorithm LCG, so a fixed seed reproduces everywhere. Two windows of one tall texture d rows apart
+// simulate a genuine scroll of d content pixels, exactly like texturedColumn above.
+cv::Mat blockMosaic(int height, int width) {
+    cv::Mat coarse(height / 4, width / 4, CV_8UC3);
+    cv::RNG rng(24680);
+    rng.fill(coarse, cv::RNG::UNIFORM, 0, 256);
+    cv::Mat mat;
+    cv::resize(coarse, mat, cv::Size(width, height), 0, 0, cv::INTER_NEAREST);
+    return mat;
+}
+
+TEST_CASE("ScrollAreaOffsetEstimator admits an image offset near the scroll-bar guess and vetoes a far one") {
+    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    const ScrollAreaOffsetEstimator estimator(scroll_bar, ImageOffsetEstimator(), kGuessMargin);
+
+    // Content: two 300-row windows of one tall texture, 90 rows apart -> the image estimator reads ~+90 px.
+    // 300 px wide (not the 100 px of the geometry tests): AKAZE keypoint counts scale with resolution, and
+    // this is the smallest round size that comfortably clears the estimator's minimum trusted-match count.
+    const cv::Mat tall = blockMosaic(420, 300);
+    const Frame content_from = Frame::fixed(tall.rowRange(0, 300).clone());
+    const Frame content_to = Frame::fixed(tall.rowRange(90, 390).clone());
+
+    // Agreeing scroll bar: the thumb (length 60) travels 18 px, so the guess is 300 * 18 / 60 = 90 px --
+    // right on the image offset, well inside the 150 px window: the image result passes through.
+    FrameDescriptor from_near{content_from, scrollbarFrame(300, 120, 180)};
+    FrameDescriptor to_near{content_to, scrollbarFrame(300, 138, 198)};
+    const auto accepted = estimator.estimate(from_near, to_near);
+    REQUIRE(accepted.has_value());
+    CHECK(accepted.value() == doctest::Approx(90.0).epsilon(0.05));
+
+    // Same content pair, but the scroll bar now reads a 480 px scroll (thumb travel 96 px): the image offset
+    // sits 390 px from the guess, far outside the 150 px window, and is vetoed even though its overlap is
+    // perfect -- the alias-rejection behaviour the window exists for.
+    FrameDescriptor from_far{content_from, scrollbarFrame(300, 120, 180)};
+    FrameDescriptor to_far{content_to, scrollbarFrame(300, 216, 276)};
+    CHECK_FALSE(estimator.estimate(from_far, to_far).has_value());
 }
 
 TEST_CASE("StationaryFrameCatcher latches once its region holds still for the threshold") {

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -38,10 +38,15 @@ const Color kThumb{60, 60, 60};  // the scroll thumb
 const Range<Color> kTrackRange{Color(200, 200, 200), Color(255, 255, 255)};  // thumb vs. background
 const Range<Color> kMarginRange{Color(228, 228, 228), Color(255, 255, 255)};  // near-white margin vs. track
 
-// Estimator physics for the tests: a zero cap offset so the logical thumb length is exactly the measured
-// tip-to-tip span and the geometric expectations below stay clean. The real cap correction is validated
-// end-to-end (video harness), not here.
+// Estimator physics for the tests: a unit viewport keeps scrollGuess in frame-width pixels, and a zero cap
+// offset makes the logical thumb length exactly the measured tip-to-tip span, so the geometric expectations
+// below stay clean. The real cap correction is validated end-to-end (video harness), not here.
+constexpr double kViewport = 1.0;
 constexpr double kCapOffset = 0.0;
+
+// Guess-window half-width for the veto tests, width-normalized. On these 100 px-wide frames it scales to
+// 50 px, wide enough to admit a matching guess and narrow enough to reject a far alias.
+constexpr double kGuessMargin = 0.5;
 
 // Thumb-centre probe geometry. These tests render a full-width thumb, so trackCenterX finds no pill contrast
 // and falls back to the fixed scan column (see scrollbarFrame); the exact probe values are never exercised,
@@ -67,7 +72,7 @@ Frame scrollbarFrame(int size, int thumb_top, int thumb_bottom) {
 const Line<double> kScanLine{Point<double>(0.5, 0.0), Point<double>(0.5, 0.99)};
 
 TEST_CASE("ScrollBarOffsetEstimator reads the thumb margins from a rendered track") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kCapOffset, kThumbProbe);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const Frame frame = scrollbarFrame(100, 40, 60);
 
     CHECK(estimator.hasScrollbar(frame));
@@ -85,7 +90,7 @@ TEST_CASE("ScrollBarOffsetEstimator reads the thumb margins from a rendered trac
 }
 
 TEST_CASE("ScrollBarOffsetEstimator reports no scrollbar on a uniform frame") {
-    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kCapOffset, kThumbProbe);
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const Frame frame = Frame::fixed(testutil::solid(100, kTrack));
 
     CHECK_FALSE(estimator.hasScrollbar(frame));
@@ -93,10 +98,44 @@ TEST_CASE("ScrollBarOffsetEstimator reports no scrollbar on a uniform frame") {
     CHECK_FALSE(estimator.topMargin(frame).has_value());
 }
 
+TEST_CASE("ScrollBarOffsetEstimator::scrollGuess turns a thumb move into a content-pixel guess") {
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    // from: thumb [40, 60) (length 20, upper_gap 40-8 = 32). to: thumb [50, 70) (upper_gap 42), same length.
+    // guess = viewport_px * (ug_to - ug_from) / tl_from = 100 * (42 - 32) / 20 = 50 (unit viewport => px = width).
+    const Frame from = scrollbarFrame(100, 40, 60);
+    const Frame to = scrollbarFrame(100, 50, 70);
+
+    const auto guess = estimator.scrollGuess(from, to);
+    REQUIRE(guess.has_value());
+    CHECK(*guess == doctest::Approx(50.0).epsilon(0.05));
+
+    // Identical frames imply no scroll, and the sign follows the thumb direction.
+    const auto still = estimator.scrollGuess(from, from);
+    REQUIRE(still.has_value());
+    CHECK(*still == doctest::Approx(0.0));
+    const auto back = estimator.scrollGuess(to, from);
+    REQUIRE(back.has_value());
+    CHECK(*back < 0.0);  // thumb moved up => negative (backward) guess
+}
+
+TEST_CASE("ScrollBarOffsetEstimator::scrollGuess returns nullopt without a usable scrollbar pair") {
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    const Frame bar = scrollbarFrame(100, 40, 60);
+    const Frame uniform = Frame::fixed(testutil::solid(100, kTrack));
+
+    // A missing scrollbar on either frame disables the guess (=> the caller applies no veto).
+    CHECK_FALSE(estimator.scrollGuess(bar, uniform).has_value());
+    CHECK_FALSE(estimator.scrollGuess(uniform, bar).has_value());
+
+    // A mid-scroll resolution change mixes pixel scales, so the guess bails.
+    const Frame smaller = scrollbarFrame(80, 32, 48);
+    CHECK_FALSE(estimator.scrollGuess(bar, smaller).has_value());
+}
+
 TEST_CASE("ScrollAreaOffsetEstimator delegates position and rejects featureless frames") {
-    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kCapOffset, kThumbProbe);
+    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const ImageOffsetEstimator image;  // default config
-    const ScrollAreaOffsetEstimator estimator(scroll_bar, image);
+    const ScrollAreaOffsetEstimator estimator(scroll_bar, image, kGuessMargin);
 
     // FrameDescriptor carries the content crop (frame) and the scroll-bar band (scroll_bar_frame) separately;
     // the scroll-area estimator reads geometry from scroll_bar_frame. Here they are the same synthetic frame.
@@ -115,9 +154,9 @@ TEST_CASE("ScrollAreaOffsetEstimator delegates position and rejects featureless 
 TEST_CASE("ScrollAreaOffsetEstimator reads scrollbar geometry from scroll_bar_frame, not frame") {
     // Guards the scroll-area / scroll-bar decoupling: geometry must come from the dedicated band, so that the
     // content crop (frame) can change without disturbing detection.
-    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kCapOffset, kThumbProbe);
+    const ScrollBarOffsetEstimator scroll_bar(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const ImageOffsetEstimator image;  // default config
-    const ScrollAreaOffsetEstimator estimator(scroll_bar, image);
+    const ScrollAreaOffsetEstimator estimator(scroll_bar, image, kGuessMargin);
 
     const Frame bar = scrollbarFrame(100, 40, 60);
     const Frame uniform = Frame::fixed(testutil::solid(100, kTrack));

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -16,6 +16,8 @@
 
 #include <doctest/doctest.h>
 
+#include <algorithm>
+#include <cmath>
 #include <optional>
 
 #include "chara_detail/chara_detail_scene_scraper.h"
@@ -64,6 +66,26 @@ Frame scrollbarFrame(int size, int thumb_top, int thumb_bottom) {
     cv::Mat mat = testutil::solid(size, kMargin);
     mat(cv::Rect(0, track_inset, size, size - 2 * track_inset)).setTo(cv::Scalar(kTrack.b(), kTrack.g(), kTrack.r()));
     mat(cv::Rect(0, thumb_top, size, thumb_bottom - thumb_top)).setTo(cv::Scalar(kThumb.b(), kThumb.g(), kThumb.r()));
+    return Frame::fixed(mat);
+}
+
+// Like scrollbarFrame but with anti-aliased thumb tips placed at *fractional* rows: each track-band row is
+// blended track<->thumb by the fraction of it the thumb covers (proper area coverage). The integer colour-run
+// rounds such a tip to a whole pixel, but the sub-pixel refinement recovers the fraction from the blend -- so a
+// pair of these frames exercises exactly the quantization the refinement removes.
+Frame scrollbarFrameAA(int size, double thumb_top, double thumb_bottom) {
+    const int track_inset = size * 8 / 100;
+    cv::Mat mat = testutil::solid(size, kMargin);
+    mat(cv::Rect(0, track_inset, size, size - 2 * track_inset)).setTo(cv::Scalar(kTrack.b(), kTrack.g(), kTrack.r()));
+    for (int r = track_inset; r < size - track_inset; r++) {
+        const double coverage =
+            std::clamp(std::min<double>(r + 1, thumb_bottom) - std::max<double>(r, thumb_top), 0.0, 1.0);
+        const auto blend = [coverage](int track, int thumb) {
+            return static_cast<uchar>(std::lround(track * (1.0 - coverage) + thumb * coverage));
+        };
+        mat.row(r).setTo(cv::Scalar(blend(kTrack.b(), kThumb.b()), blend(kTrack.g(), kThumb.g()),
+                                    blend(kTrack.r(), kThumb.r())));
+    }
     return Frame::fixed(mat);
 }
 
@@ -130,6 +152,39 @@ TEST_CASE("ScrollBarOffsetEstimator::scrollGuess returns nullopt without a usabl
     // A mid-scroll resolution change mixes pixel scales, so the guess bails.
     const Frame smaller = scrollbarFrame(80, 32, 48);
     CHECK_FALSE(estimator.scrollGuess(bar, smaller).has_value());
+}
+
+TEST_CASE("scrollGuess sub-pixel refinement matches the integer guess on hard-edged frames") {
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    const Frame from = scrollbarFrame(100, 40, 60);
+    const Frame to = scrollbarFrame(100, 50, 70);  // same length, moved 10 px
+
+    // A hard tip carries only a constant half-pixel bias (the mid-point sits half a pixel past the last full
+    // background pixel), and that bias cancels in the upper_gap delta -- so on clean edges refine=true reproduces
+    // the integer guess to within a fraction of a pixel. This pins that the refinement never disturbs the clean
+    // case; its sub-pixel win on real (anti-aliased) tips is covered below and end-to-end by the video harness.
+    const auto integer = estimator.scrollGuess(from, to, false);
+    const auto refined = estimator.scrollGuess(from, to, true);
+    REQUIRE(integer.has_value());
+    REQUIRE(refined.has_value());
+    CHECK(*refined == doctest::Approx(*integer).epsilon(0.05));
+}
+
+TEST_CASE("scrollGuess sub-pixel refinement resolves a move the integer tips round away") {
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    // Both tips slide 0.6 px -- below one pixel, so the colour-run rounds both frames to the same integer tips
+    // and the integer guess reads ~0. The anti-aliased tip blend encodes the fraction, so the refined guess
+    // recovers the forward move (amplified by viewport / thumb_length ~= 5x here). This is the quantization the
+    // refinement is adopted to remove, in miniature.
+    const Frame from = scrollbarFrameAA(100, 40.0, 60.0);
+    const Frame to = scrollbarFrameAA(100, 40.6, 60.6);
+
+    const auto integer = estimator.scrollGuess(from, to, false);
+    const auto refined = estimator.scrollGuess(from, to, true);
+    REQUIRE(integer.has_value());
+    REQUIRE(refined.has_value());
+    CHECK(std::abs(*integer) < 1.0);  // the whole-pixel tips cannot see a sub-pixel move
+    CHECK(*refined > 1.5);  // the blend does: a clear forward guess
 }
 
 TEST_CASE("ScrollAreaOffsetEstimator delegates position and rejects featureless frames") {

--- a/native/test/chara_detail/test_scraper_estimators.cpp
+++ b/native/test/chara_detail/test_scraper_estimators.cpp
@@ -155,6 +155,35 @@ TEST_CASE("ScrollBarOffsetEstimator::scrollGuess returns nullopt without a usabl
     CHECK_FALSE(estimator.scrollGuess(bar, smaller).has_value());
 }
 
+TEST_CASE("ScrollBarOffsetEstimator::scrollGuess divides by each frame's own length across a genuine re-scale") {
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    // from: thumb [40, 70) (length 30, upper_gap 32). to: thumb [50, 70) (length 20, upper_gap 42): the thumb
+    // length changed by 10 px (>> the re-scale cut) and stays clear of the track bottom, so this is read as a
+    // genuine mid-scroll re-scale and each upper_gap is divided by its OWN frame's length:
+    // guess = 100 * (42/20 - 32/30) ~= +103. The shared-reference form would read 100 * (42-32)/30 ~= +33, so
+    // the assertion separates the two forms decisively; the loose epsilon absorbs the ~1px sampling-grid skew.
+    const Frame from = scrollbarFrame(100, 40, 70);
+    const Frame to = scrollbarFrame(100, 50, 70);
+
+    const auto guess = estimator.scrollGuess(from, to);
+    REQUIRE(guess.has_value());
+    CHECK(*guess == doctest::Approx(103.3).epsilon(0.1));
+}
+
+TEST_CASE("ScrollBarOffsetEstimator::scrollGuess keeps the reference length while the thumb is bottom-clipped") {
+    const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
+    // to's thumb bottom is pinned to the track bottom (row 92 here), the overscroll signature under which to's
+    // own measured length is unreliable -- so even though the length changed by 10 px (which alone would select
+    // the own-length form, see the re-scale case above) the guess must keep dividing by from's length:
+    // guess = 100 * (44 - 32) / 30 = +40. The own-length form would read 100 * (44/40 - 32/30) ~= +3.
+    const Frame from = scrollbarFrame(100, 40, 70);
+    const Frame to = scrollbarFrame(100, 52, 92);
+
+    const auto guess = estimator.scrollGuess(from, to);
+    REQUIRE(guess.has_value());
+    CHECK(*guess == doctest::Approx(40.0).epsilon(0.1));
+}
+
 TEST_CASE("scrollGuess sub-pixel refinement matches the integer guess on hard-edged frames") {
     const ScrollBarOffsetEstimator estimator(kTrackRange, kScanLine, kMarginRange, kViewport, kCapOffset, kThumbProbe);
     const Frame from = scrollbarFrame(100, 40, 60);

--- a/native/tool/builder/chara_detail_scene_scraper_builder.h
+++ b/native/tool/builder/chara_detail_scene_scraper_builder.h
@@ -57,15 +57,22 @@ private:
             200,
             18,
             100,
-            // Cap offset c fit across player_standard/player_inheritance/friend_inheritance (common layout):
-            // tip_len = 2c + V*slope, R^2 = 1.0 -> c = 0.94 px at 736 px width, stored width-normalized
-            // (0.94/736 = 0.00126). c is a widget constant, shared by both layouts.
+            // Viewport V and cap offset c fit across player_standard/player_inheritance/friend_inheritance
+            // (common layout): tip_len = 2c + V*slope, R^2 = 1.0 -> V = 543 px, c = 0.94 px at 736 px width.
+            // Stored width-normalized: 543/736 = 0.738, 0.94/736 = 0.00126. c is a widget constant (shared).
+            0.738,
             0.00126,
             // Placeholder track is faintly coloured (satisfies R < 228 or G < 228); the near-white scroll-area
             // margin flanking it is all channels >= 228. This box catches that margin and excludes the track,
             // so the top/bottom margin runs locate the fixed track ends.
             Range<Color>{{228, 228, 228}, {255, 255, 255}},
             thumbProbe(),
+            // Guess-window half-width for the scroll-guess veto (see ScrollAreaOffsetEstimator::estimate). ~0.10
+            // of the width (~74 px at 736): safely above the worst measured V2 true-offset guess error (~41 px on
+            // the tiny-thumb friend_standard_many_rental clip) yet far below the periodicity alias distance
+            // (hundreds of px), so it rejects the far aliases without ever rejecting a genuine offset. Shared by
+            // both layouts.
+            0.10,
         };
     }
 
@@ -100,6 +107,10 @@ private:
         config.tab_button_rect = {{0.0222, 0.7259 + shift, IS}, {0.9759, 0.8037 + shift, IS}};
         config.scroll_area_rect = {{0.0000, 0.8093 + shift, IS}, {0.0000, -0.2426, {IPE, ILE}}};
         config.scroll_bar_rect = {{0.0000, 0.8093 + shift, IS}, {0.0000, -0.2426, {IPE, ILE}}};
+        // The shorter friend scroll area has a smaller viewport: fit across friend_standard /
+        // friend_standard_many_rental gives V = 407 px (0.553 width-normalized), R^2 = 1.0. cap_offset,
+        // the margin colour and the guess-window margin are shared, unchanged from common().
+        config.viewport = 0.553;
         return config;
     }
 


### PR DESCRIPTION
## Summary

Adds an independent far-outlier safeguard to scroll-offset estimation: the image estimator (candidate + overlap verify, PR #133) still decides the offset alone, but its result is now vetoed when it lands farther than a configured window from a scroll-bar-derived guess. This catches periodic-row aliases that clear the overlap gate yet sit hundreds of pixels from where the scroll bar says the scroll is, without ever letting the guess decide the offset.

## What changed

### 1. Scroll-bar guess (`ScrollBarOffsetEstimator::scrollGuess`)

- **Content-pixel guess** from the placeholder-track geometry: `viewport * Δ(upper_gap) / thumb_length`, using a per-layout `viewport` fitted on real footage (R² = 1.0).
- **Two divisor forms, gated in absolute pixels**: the shared-reference-length form cancels ±1 px thumb-length jitter and stays correct across a bottom-clipped terminating frame; the per-frame-own-length form handles a genuine mid-scroll thumb re-scale (inheritance history appended). The gate (`kRescaleThumbChangePx = 2.0`) sits in a measured empty band between jitter (max 1.23 px) and the sole genuine re-scale (5.14 px) across all 11 golden clips (3879 frame pairs).
- **Documented invariant**: a re-scale is content appended at the END of the scroll area, so a post-re-scale frame can never be bottom-clipped — the clip check outranking the re-scale gate can never mis-route a genuine re-scale.
- `nullopt` (fail-open, no veto) when either frame lacks a scrollbar or on a mid-scroll resolution change.

### 2. Sub-pixel thumb-tip refinement (`refineThumbEdges`)

- The colour-run tip detection quantizes each tip to a whole pixel; on a tiny thumb one tip pixel is worth ~27 content px, freezing the guess onto discrete values. The refinement interpolates the bright→dark mid-point crossing of the anti-aliased tip ramp, with median-of-3 plateau sampling and a contrast gate (fail-open to integer tips).
- Measured on real footage: guess error roughly halved on every clip; tiny-thumb worst case cut from ~44 px to ~17 px.
- `scrollGuess` defaults to the refined path (it is what the gate is calibrated on); `position()`/`topMargin()` keep integer tips, as their threshold consumers are calibrated on them and have no quantization sensitivity.

### 3. Guess-window veto (`ScrollAreaOffsetEstimator::estimate`)

- An accepted image offset farther than `guess_window_margin` (0.10 width, ~74 px at 736) from the guess returns `nullopt`: the frame is skipped and the reference freezes until a matching frame comes. The window sits well above the worst measured true-offset guess error (~17 px refined) and far below the periodicity alias distance (hundreds of px).
- The block is deliberately self-contained: delete it plus `scrollGuess` and the config entries to fully remove the safeguard.

### 4. Config plumbing

- `viewport` (0.738 common / 0.553 friend) and `guess_window_margin` (0.10 shared) added to `SceneScraperConfig`, the config builder, and `scene_scraper.json`.

## Testing

- Native unit tests: **213/213 pass** (fresh build this session), including new cases for the guess forms (steady / re-scale / bottom-clipped), sub-pixel refinement (hard-edge parity, sub-pixel move the integer tips round away), and an end-to-end veto accept/reject pair on a deterministic feature-rich mosaic.
- Integration golden harness: **11/11 PASS** on this branch (recognition output unchanged); the subsequent gate re-calibration commits were sized from measurements over all 11 clips (3879 frame pairs).
- Guess-error measurements on real clips recorded in the code comments (worst true-offset error vs. margin sizing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
