### PR TITLE
feat(sentry): identify sessions with an app-owned anonymous telemetry ID

### DIFF
--- a/lib/src/core/sentry_util.dart
+++ b/lib/src/core/sentry_util.dart
@@ -10,6 +10,7 @@ import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:uuid/uuid.dart';
 
 import '/const.dart';
 import '/src/core/mapper_init.dart';
@@ -62,6 +63,54 @@ void incrementSentryReportCount() {
   final count = box.entry<int>(SettingsEntryKey.sentryReportTotalCount.name);
   month.push(DateTime.now());
   count.push((count.pull() ?? 0) + 1);
+}
+
+/// The ID gets its own box rather than sitting next to the consent flag in `settings`:
+/// that box is the [SettingsEntryKey]-keyed preference store, whereas an opaque
+/// generated ID with a lifetime of its own belongs beside [trainerIdProvider]'s
+/// `trainer_id`, whose box this mirrors.
+StorageEntry<String> _getTelemetryIdEntry() {
+  return StorageBox(StorageBoxKey.telemetryId).entry<String>("telemetry_id");
+}
+
+/// Returns the anonymous telemetry ID, generating and persisting one on first call.
+///
+/// Registered as the Sentry user, this ends up as the `distinct_id` on sentry-native's
+/// session — the identity behind Release Health's `count_unique(user)` and each issue's
+/// user count.
+///
+/// Left alone, sentry-native fills that field with its own installation ID instead. That
+/// ID is scoped to the DSN (a DSN change silently restarts the user count from zero) and
+/// only arrived in 0.14.1, which a patch-level dependency bump switched on without a code
+/// change here. Owning the ID keeps the metric from shifting under a `pub upgrade`.
+/// [trainerIdProvider]'s ID is unsuitable for the opposite reason: it is game data written
+/// into records, with its own lifetime and deletion rules.
+///
+/// It carries no personal data and is never logged: diagnostic logs ship inside bug
+/// reports, and printing the ID there would tie a report to every other report from
+/// the same installation.
+String getTelemetryId() {
+  final entry = _getTelemetryIdEntry();
+  final stored = entry.pull();
+  if (stored != null) {
+    return stored;
+  }
+  final generated = const Uuid().v4();
+  entry.push(generated);
+  return generated;
+}
+
+/// Drops the stored telemetry ID. Idempotent, and safe to call when none exists.
+///
+/// Called on opt-out, so a later opt-in mints a fresh ID instead of resurrecting the old
+/// one, which intentionally leaves the two stretches of use unlinkable.
+///
+/// Only the persisted ID is cleared. [runWithSentry]'s consent gate is evaluated once at
+/// startup, so opting out mid-session stops neither the reporting already under way nor
+/// the ID on the live scope; both last until restart. Unsetting the scope user would not
+/// close that gap either, since sentry-native then falls back to its own installation ID.
+void deleteTelemetryId() {
+  _getTelemetryIdEntry().delete();
 }
 
 class ScreenshotResult {
@@ -488,6 +537,16 @@ Future<void> _runWithSentry(AppRunner runner) async {
         return event;
       };
     }, appRunner: startAppOnce);
+    // Attach the anonymous telemetry ID so the session's distinct_id is one we own
+    // rather than sentry-native's DSN-scoped installation ID. NativeScopeObserver
+    // forwards this to sentry_set_user, which back-fills the session already started
+    // by init (verified on a release build: the session envelope carries this ID).
+    //
+    // Placement matters, keep it here: inside runWithSentry's gates the ID is never
+    // even generated when the user has opted out (or in debug), and inside this try a
+    // failure still lands in the catch below, which starts the app anyway. Wrapping
+    // appRunner instead would put failable work in front of the runApp guarantee.
+    await Sentry.configureScope((scope) => scope.setUser(SentryUser(id: getTelemetryId())));
   } catch (exception, stackTrace) {
     // Never let a Sentry/startup-prep failure prevent the app from launching.
     logger.e("Failed to initialize Sentry; starting app without it.", exception, stackTrace);

--- a/lib/src/preference/privacy_setting.dart
+++ b/lib/src/preference/privacy_setting.dart
@@ -8,8 +8,26 @@ import '/src/preference/storage_box.dart';
 // ignore: constant_identifier_names
 const tr_privacy = "app.privacy";
 
+/// The consent switch, which additionally discards the telemetry ID on opt-out.
+///
+/// Every opt-out reaches [set] (the settings switch calls it directly, and `toggle`
+/// delegates to it), so this is the one place the deletion has to hang off. Opting
+/// in again mints a fresh ID rather than resurrecting the old one; see
+/// [deleteTelemetryId].
+class _AllowPostUserDataNotifier extends BooleanNotifier {
+  _AllowPostUserDataNotifier({required super.defaultValue, super.entryKey});
+
+  @override
+  void set(bool value) {
+    super.set(value);
+    if (!value) {
+      deleteTelemetryId();
+    }
+  }
+}
+
 final allowPostUserDataStateProvider = BooleanNotifierProvider(() {
-  return BooleanNotifier(entryKey: SettingsEntryKey.allowPostUserData.name, defaultValue: true);
+  return _AllowPostUserDataNotifier(entryKey: SettingsEntryKey.allowPostUserData.name, defaultValue: true);
 });
 
 StorageEntry<bool> _getAllowPostUserDataSettingEntry() {

--- a/lib/src/preference/storage_box.dart
+++ b/lib/src/preference/storage_box.dart
@@ -6,7 +6,7 @@ import 'package:recase/recase.dart';
 import '/const.dart';
 import '/src/preference/hive_adapter.dart';
 
-enum StorageBoxKey { settings, windowState, trainerId, columnSpec, versionCheck, addon, dataMigration }
+enum StorageBoxKey { settings, windowState, trainerId, columnSpec, versionCheck, addon, dataMigration, telemetryId }
 
 extension _BoxKeyExtension on StorageBoxKey {
   static Iterable<String> get names {

--- a/test/privacy_setting_test.dart
+++ b/test/privacy_setting_test.dart
@@ -1,5 +1,6 @@
 // Provider/storage tests for the privacy (post-user-data) setting: the tri-state
-// read that drives the consent prompt, and the notifier's default + persistence.
+// read that drives the consent prompt, the notifier's default + persistence, and
+// the telemetry ID's disposal on opt-out.
 // isFeedbackAvailable additionally gates on Sentry, which is not initialized in
 // tests, so only its Sentry-unavailable branch is asserted here.
 //
@@ -7,6 +8,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
+import 'package:umacapture/src/core/sentry_util.dart';
 import 'package:umacapture/src/preference/privacy_setting.dart';
 import 'package:umacapture/src/preference/settings_state.dart';
 import 'package:umacapture/src/preference/storage_box.dart';
@@ -17,8 +19,9 @@ void main() {
   late Future<void> Function() closeHive;
 
   setUpAll(() async {
-    // allowPostUserData() and the notifier both resolve StorageBox(settings).
-    closeHive = await initHiveForTest(['settings']);
+    // allowPostUserData() and the notifier both resolve StorageBox(settings); the
+    // notifier also drops the telemetry ID on opt-out, which lives in its own box.
+    closeHive = await initHiveForTest(['settings', 'telemetry_id']);
   });
 
   tearDownAll(() async {
@@ -27,6 +30,7 @@ void main() {
 
   setUp(() async {
     await Hive.box('settings').clear();
+    await Hive.box('telemetry_id').clear();
   });
 
   StorageEntry<bool> entry() => StorageBox(StorageBoxKey.settings).entry<bool>(SettingsEntryKey.allowPostUserData.name);
@@ -63,6 +67,49 @@ void main() {
       final reopened = ProviderContainer.test();
       addTearDown(reopened.dispose);
       expect(reopened.read(allowPostUserDataStateProvider), isFalse);
+    });
+
+    test('discards the telemetry ID on opt-out, and mints a new one on opt-in', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+      final original = getTelemetryId();
+
+      container.read(allowPostUserDataStateProvider.notifier).set(false);
+
+      // The persisted ID is dropped, so no later launch reports under it. The live
+      // scope keeps it until restart; see deleteTelemetryId.
+      expect(StorageBox(StorageBoxKey.telemetryId).pull<String>('telemetry_id'), isNull);
+
+      container.read(allowPostUserDataStateProvider.notifier).set(true);
+
+      // Opting back in is a fresh identity, not a resurrection of the old one.
+      expect(getTelemetryId(), isNot(original));
+    });
+
+    test('keeps the telemetry ID when consent is granted', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+      final original = getTelemetryId();
+
+      container.read(allowPostUserDataStateProvider.notifier).set(true);
+
+      expect(getTelemetryId(), original);
+    });
+  });
+
+  group('getTelemetryId', () {
+    test('generates a persistent ID on first call and reuses it after', () {
+      final generated = getTelemetryId();
+
+      expect(generated, isNotEmpty);
+      expect(getTelemetryId(), generated);
+      // Persisted, so a later launch reports as the same user rather than a new one.
+      expect(StorageBox(StorageBoxKey.telemetryId).pull<String>('telemetry_id'), generated);
+    });
+
+    test('deleteTelemetryId is a no-op when no ID is stored', () {
+      expect(deleteTelemetryId, returnsNormally);
+      expect(StorageBox(StorageBoxKey.telemetryId).pull<String>('telemetry_id'), isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary

Sentry sessions now carry a `distinct_id` this app owns: a UUID generated on first use and persisted in its own Hive box, registered as the Sentry user right after init. This is the identity behind Release Health's `count_unique(user)` and each issue's user count.

This does **not** enable Release Health — it was already working. sentry-native supplies its own installation ID for that field when `setUser` is never called, so the change is a transfer of ownership, not a switch being turned on. See **Risk / scope** for the consequence.

## What changed

- **`getTelemetryId()` / `deleteTelemetryId()`** (`lib/src/core/sentry_util.dart`) — lazily mint a UUIDv4, persist it, and drop it on request. The ID gets its own `telemetry_id` box rather than sitting beside the consent flag in `settings`, which is the `SettingsEntryKey`-keyed preference store; it mirrors `trainerIdProvider`'s `trainer_id` box instead.
- **`setUser` at startup** (`_runWithSentry`) — placed inside `runWithSentry`'s existing gates, so the ID is never even generated in debug builds or after an opt-out, and inside the existing `try`, so a failure still falls through to the catch that guarantees `runApp()` runs.
- **`_AllowPostUserDataNotifier`** (`lib/src/preference/privacy_setting.dart`) — overrides `set` to delete the ID on opt-out. Every opt-out reaches `set` (the settings switch calls it directly; `toggle` delegates to it), so this is the one place the deletion has to hang off.
- **`StorageBoxKey.telemetryId`** — new box, opened by the existing `ensureOpened` loop.

## Design notes

**Why not sentry-native's installation ID.** It is scoped to the DSN — a DSN change silently restarts the user count from zero — and it only arrived in 0.14.1, enabled here by a lockfile-only patch bump with no code change. Owning the ID keeps the metric from shifting under a `pub upgrade`.

**Why not the trainer ID.** Unsuitable for the opposite reason: it is game data written into records, with its own lifetime and deletion rules.

**What the opt-out does and does not do.** Opting out deletes the stored ID, so a later opt-in mints a fresh, unlinkable one. Only the persisted ID is cleared, though: the consent gate is evaluated once at startup, so opting out mid-session stops neither the reporting already under way nor the ID on the live scope, and both last until restart. Unsetting the scope user would not close that gap either, since sentry-native then falls back to its installation ID. Closing it properly means stopping reporting on opt-out, which is a pre-existing gap (`captureException` and friends gate on `isSentryAvailable()`, not on consent) and out of scope here. The comments say as much rather than overclaiming.

## Risk / scope

Because `did` was already populated by the installation ID, this **switches** the identifier rather than adding one. On the release that ships it, existing installs report under a new UUID and appear as new users, so Release Health will show a one-time discontinuity in the user count.

## Testing

- `flutter test test/privacy_setting_test.dart` — 8/8 pass, covering the ID's generation and persistence, its disposal on opt-out, the fresh ID on opt-in, retention while consent stands, and `deleteTelemetryId` as a no-op.
- `dart analyze` on the changed files — no issues. `dart format` — no changes.
- Verified on a fresh release build: the native session's `did` matches the stored ID byte for byte, survives a restart with a new session id, and Sentry counts it as a distinct user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
