### PR TITLE
fix(sentry): upload PE binaries so native crash stacks are walkable

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -213,22 +213,37 @@ release the publisher creates attaches to the pushed `v<version>` tag.
    exe that was just packaged, and they cannot be regenerated later.
 
 9.5. Upload debug symbols so Sentry can symbolicate this build's native crashes.
-   Two files matter: `umacapture.pdb` (covers the runner **and** the native C++
-   backend, which is linked straight into the exe) and the engine's
-   `flutter_windows.dll.pdb` (already in the FVM SDK cache — no download). Third-
-   party DLLs (`opencv_world4130.dll`, `onnxruntime.dll`) ship without PDBs and
-   stay unsymbolicated; that is expected.
+   **Four** files matter, in two pairs:
+   - The **PDBs** — `umacapture.pdb` (covers the runner **and** the native C++
+     backend, which is linked straight into the exe) and the engine's
+     `flutter_windows.dll.pdb` (already in the FVM SDK cache — no download).
+     These give function names, files, and line numbers.
+   - The **PE binaries themselves** — `umacapture.exe` and `flutter_windows.dll`.
+     A PDB carries no unwind tables; the `.pdata` section of the binary does.
+     Without them Sentry reports `unwind_status: missing` and falls back to
+     scanning the crash stack for plausible return addresses, so almost every
+     frame comes back `trust: scan` — a plausible-looking but **causally wrong**
+     call stack. Uploading the binaries is what makes `trust: cfi` frames, and
+     therefore real stack traces, possible.
+
+   Third-party DLLs (`opencv_world4130.dll`, `onnxruntime.dll`) ship without PDBs
+   and stay unsymbolicated; that is expected.
    ```bash
    export SENTRY_AUTH_TOKEN="$(tr -d ' \t\r\n' < ~/.sentry_token)"
-   ENGINE_PDB=".fvm/flutter_sdk/bin/cache/artifacts/engine/windows-x64-release/flutter_windows.dll.pdb"
+   ENGINE_DIR=".fvm/flutter_sdk/bin/cache/artifacts/engine/windows-x64-release"
    sentry-cli debug-files upload --include-sources \
-     build/windows/x64/runner/Release/umacapture.pdb "$ENGINE_PDB"
+     build/windows/x64/runner/Release/umacapture.pdb \
+     "$ENGINE_DIR/flutter_windows.dll.pdb" \
+     build/windows/x64/runner/Release/umacapture.exe \
+     "$ENGINE_DIR/flutter_windows.dll"
    ```
-   Expect `UPLOADED` lines for both debug-ids (source warnings about oversized
-   Windows SDK headers are harmless). Verify the exe carries a matching debug-id
-   with `sentry-cli debug-files check build/windows/x64/runner/Release/umacapture.exe`
-   — if the Debug ID is absent, the `/DEBUG` link flags in
-   `windows/runner/CMakeLists.txt` regressed and symbols will never match.
+   Expect `UPLOADED` lines for four entries — two `pdb` and two `pe` (source
+   warnings about oversized Windows SDK headers are harmless). Verify the exe
+   carries a matching debug-id **and** unwind info with
+   `sentry-cli debug-files check build/windows/x64/runner/Release/umacapture.exe`
+   — it must print the Debug ID plus `Contained debug information: unwind`. If the
+   Debug ID is absent, the `/DEBUG` link flags in `windows/runner/CMakeLists.txt`
+   regressed and symbols will never match.
 10. Attach `version_info.json` as a release asset. flutter_distributor only
    uploads the packaged exe/zip, so add this lightweight file separately (it lets
    a client read the published version without downloading a build). `--clobber`

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -228,22 +228,21 @@ release the publisher creates attaches to the pushed `v<version>` tag.
 
    Third-party DLLs (`opencv_world4130.dll`, `onnxruntime.dll`) ship without PDBs
    and stay unsymbolicated; that is expected.
+
+   `tool/upload_symbols.sh` does all four, so the set cannot be trimmed by
+   accident — do not hand-roll the `sentry-cli` invocation instead:
    ```bash
    export SENTRY_AUTH_TOKEN="$(tr -d ' \t\r\n' < ~/.sentry_token)"
-   ENGINE_DIR=".fvm/flutter_sdk/bin/cache/artifacts/engine/windows-x64-release"
-   sentry-cli debug-files upload --include-sources \
-     build/windows/x64/runner/Release/umacapture.pdb \
-     "$ENGINE_DIR/flutter_windows.dll.pdb" \
-     build/windows/x64/runner/Release/umacapture.exe \
-     "$ENGINE_DIR/flutter_windows.dll"
+   tool/upload_symbols.sh
    ```
-   Expect `UPLOADED` lines for four entries — two `pdb` and two `pe` (source
-   warnings about oversized Windows SDK headers are harmless). Verify the exe
-   carries a matching debug-id **and** unwind info with
-   `sentry-cli debug-files check build/windows/x64/runner/Release/umacapture.exe`
-   — it must print the Debug ID plus `Contained debug information: unwind`. If the
-   Debug ID is absent, the `/DEBUG` link flags in `windows/runner/CMakeLists.txt`
-   regressed and symbols will never match.
+   It refuses to run if a binary lacks unwind info or a Debug ID (which would
+   mean the `/DEBUG` link flags in `windows/runner/CMakeLists.txt` regressed and
+   symbols can never match), then asks the Sentry API to confirm an
+   unwind-capable object is really on the server for both binaries. Success ends
+   with two `ok:` lines and `==> done`. Source warnings about oversized Windows
+   SDK headers are harmless, and `Nothing to upload, all files are on the server`
+   just means this build's symbols were already uploaded — the server-side check
+   still runs, so that is a pass, not a skip.
 10. Attach `version_info.json` as a release asset. flutter_distributor only
    uploads the packaged exe/zip, so add this lightweight file separately (it lets
    a client read the published version without downloading a build). `--clobber`

--- a/.claude/skills/sentry-issues/SKILL.md
+++ b/.claude/skills/sentry-issues/SKILL.md
@@ -158,6 +158,39 @@ locally with `cdb`. It also means an old event cannot be re-symbolicated by
 reprocessing after a late symbol upload — fixing symbols only helps events that
 arrive afterwards.
 
+**Only two shipped modules can ever symbolicate: `umacapture.exe` and
+`flutter_windows.dll`.** If a crash stack runs through anything else in the app
+directory, that segment degrades to `trust: scan` and there is no upload that
+would fix it — so read those frames as "roughly here", never as a call chain.
+This is a known, accepted gap (decided 2026-07-19), not something to re-diagnose:
+
+- **Plugin DLLs built from our own tree** — `window_manager_plugin.dll`,
+  `screen_retriever_windows_plugin.dll`, `audioplayers_windows_plugin.dll`,
+  `desktop_drop_plugin.dll`, `pasteboard_plugin.dll`,
+  `url_launcher_windows_plugin.dll` — plus `sentry.dll`, `crashpad_handler.exe`
+  and `crashpad_wer.dll` from the FetchContent'd sentry-native. These *contain*
+  `symtab, unwind` but carry an all-zero Debug ID (`Usable: no (missing debug
+  identifier, likely stripped)`), so Sentry cannot match an upload to the module
+  in the dump. Cause: `/Zi` and `/DEBUG` are set as `target_*` options on the
+  runner binary alone (`windows/runner/CMakeLists.txt`), and MSVC's `Release`
+  config adds neither by default, so every other CMake target is stripped.
+- **Third-party prebuilts** — `opencv_world4130.dll`, `onnxruntime.dll`,
+  `dartjni.dll` — ship without PDBs at all.
+
+The fix, if a crash ever actually lands in one of these, is to move `/Zi` and
+`/DEBUG` to the Release/Profile globals in `windows/CMakeLists.txt` so every
+locally built target emits a Debug ID, then widen `tool/upload_symbols.sh` to
+sweep the build tree. It was deliberately not done up front: it needs a full
+rebuild to verify the flags reach the FetchContent'd sentry-native, and costs
+build time and artifact size for modules that had never appeared in a crash.
+
+Worth knowing for triage: the window-teardown crash on 0.2.1
+(`UMACAPTURE-RELEASE-A9`) is exactly the shape that *could* route through
+`window_manager_plugin` / `screen_retriever_windows_plugin`. In that event they
+were `unwind_status: unused`, i.e. no frame needed them — but if a similar report
+appears with those modules in play, the gap above is the reason the middle of the
+stack looks incoherent.
+
 **Version tagging is consistent.** Both the Dart side (`assets/version_info.json`)
 and the native side (`windows/runner/Runner.rc` `FLUTTER_VERSION`) derive from the
 pubspec `version` at build time, so a given build reports the same release on both

--- a/.claude/skills/sentry-issues/SKILL.md
+++ b/.claude/skills/sentry-issues/SKILL.md
@@ -132,6 +132,32 @@ The `--query` value is standard Sentry issue search:
   OS frames to infer *what* the app was doing (window teardown, graphics
   release), not the exact function.
 
+**Symbolicated is not the same as trustworthy — always check `trust`.** Resolving
+a name needs a PDB; reconstructing the *call chain* needs unwind tables, which
+live in the PE binary, not the PDB. Releases up to and including **0.2.1**
+uploaded PDBs only, so their events carry `unwind_status: missing` and Sentry
+walks the stack by scanning memory for plausible return addresses. Those frames
+come back fully named and file/line-annotated while being **causally wrong** —
+sibling calls, stale frames, and unrelated leaf functions get spliced into what
+looks like a clean call stack. Before reasoning about any native stack, pull the
+raw event (`--json`) and inspect each frame's `trust`:
+
+- `context` — the crashing frame, taken from the register set. Always reliable.
+- `cfi` — walked with real unwind data. Reliable.
+- `scan` / `fp` — guessed. **Do not treat the ordering as a call relationship.**
+
+Also check `entries[].data.images[].unwind_status` in the `debugmeta` entry and
+the `native_missing_dsym` items in the event's `errors` array; both name the
+images whose unwind info was unavailable. Since the binary upload was added to
+the `release` skill's step 9.5, builds after 0.2.1 should show
+`unwind_status: found` for `umacapture.exe` and `flutter_windows.dll`.
+
+**Minidumps are not retained.** The org's `storeCrashReports` is `0`, so the
+attachments endpoint 404s for every native event and there is no dump to analyze
+locally with `cdb`. It also means an old event cannot be re-symbolicated by
+reprocessing after a late symbol upload — fixing symbols only helps events that
+arrive afterwards.
+
 **Version tagging is consistent.** Both the Dart side (`assets/version_info.json`)
 and the native side (`windows/runner/Runner.rc` `FLUTTER_VERSION`) derive from the
 pubspec `version` at build time, so a given build reports the same release on both

--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,6 @@ assets/version_info.json                       eol=lf
 # fresh clone would write CRLF, and a `#!/usr/bin/env bash\r` shebang fails to
 # run. Pin to LF so the hook stays executable on Windows.
 tool/hooks/pre-commit                          eol=lf
+
+# Same shebang trap for the shell scripts run directly from a skill runbook.
+tool/*.sh                                      eol=lf

--- a/tool/upload_symbols.sh
+++ b/tool/upload_symbols.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Upload this build's debug information to Sentry so native crashes symbolicate
+# *and* stack-walk correctly. Run it from the repo root right after
+# flutter_distributor (or `flutter build windows --release`) produced the exe,
+# and before anything cleans build/. See the `release` skill, step 9.5.
+#
+#   export SENTRY_AUTH_TOKEN="$(tr -d ' \t\r\n' < ~/.sentry_token)"
+#   tool/upload_symbols.sh
+#
+# Four files go up, in two pairs:
+#
+#   * PDBs (umacapture.pdb, flutter_windows.dll.pdb) carry symbol names, files
+#     and line numbers.
+#   * The PE binaries themselves (umacapture.exe, flutter_windows.dll) carry the
+#     unwind tables, which live in the `.pdata` section and are *not* in a PDB.
+#
+# Uploading only the PDBs is the failure this script exists to prevent. Sentry
+# then reports `unwind_status: missing` and walks the crash stack by scanning
+# memory for plausible return addresses, so every frame arrives fully named and
+# annotated while the call chain itself is wrong (`trust: scan`). That looks like
+# a good stack trace and silently misdirects the whole diagnosis -- it already
+# did once, on the 0.2.1 shutdown crash.
+#
+# Org/project coordinates come from .sentryclirc; the auth token must come from
+# the environment. Override paths via the env vars below (e.g. to upload an
+# older build that is still lying around).
+set -euo pipefail
+
+RUNNER_DIR="${RUNNER_DIR:-build/windows/x64/runner/Release}"
+ENGINE_DIR="${ENGINE_DIR:-.fvm/flutter_sdk/bin/cache/artifacts/engine/windows-x64-release}"
+SENTRY_CLI="${SENTRY_CLI:-sentry-cli}"
+
+APP_PDB="$RUNNER_DIR/umacapture.pdb"
+APP_EXE="$RUNNER_DIR/umacapture.exe"
+ENGINE_PDB="$ENGINE_DIR/flutter_windows.dll.pdb"
+ENGINE_DLL="$ENGINE_DIR/flutter_windows.dll"
+
+if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+  echo "error: SENTRY_AUTH_TOKEN is not set." >&2
+  echo "  export SENTRY_AUTH_TOKEN=\"\$(tr -d ' \\t\\r\\n' < ~/.sentry_token)\"" >&2
+  exit 1
+fi
+
+missing=0
+for f in "$APP_PDB" "$APP_EXE" "$ENGINE_PDB" "$ENGINE_DLL"; do
+  if [ ! -f "$f" ]; then
+    echo "error: not found: $f" >&2
+    missing=1
+  fi
+done
+if [ "$missing" -ne 0 ]; then
+  echo "hint: build first, and do not clean build/ before uploading." >&2
+  exit 1
+fi
+
+# Fail before uploading if a binary cannot actually contribute what we need. A
+# PE without unwind info, or an exe whose Debug ID is absent (the /DEBUG link
+# flags in windows/runner/CMakeLists.txt regressed), would upload "successfully"
+# and still leave crashes unreadable.
+for pe in "$APP_EXE" "$ENGINE_DLL"; do
+  info="$("$SENTRY_CLI" debug-files check "$pe")"
+  if ! grep -q 'unwind' <<<"$info"; then
+    echo "error: $pe carries no unwind info; uploading it would be pointless." >&2
+    echo "$info" >&2
+    exit 1
+  fi
+  if ! grep -q 'Debug ID:' <<<"$info"; then
+    echo "error: $pe has no Debug ID -- symbols will never match this build." >&2
+    echo "check the /DEBUG link flags in windows/runner/CMakeLists.txt." >&2
+    exit 1
+  fi
+done
+
+echo "==> uploading 2 PDBs + 2 PE binaries"
+"$SENTRY_CLI" debug-files upload --include-sources \
+  "$APP_PDB" "$ENGINE_PDB" "$APP_EXE" "$ENGINE_DLL"
+
+# `upload` prints UPLOADED only for files Sentry did not already have, so a
+# re-run legitimately reports nothing. Ask the API what the server actually holds
+# for each debug id instead of trusting the upload output. (`sentry-cli
+# debug-files find` is no help here -- it searches the local disk, not Sentry, so
+# it would match the very file we just handed it.)
+ORG="$(sed -n 's/^org=//p' .sentryclirc | head -1)"
+PROJECT="$(sed -n 's/^project=//p' .sentryclirc | head -1)"
+
+echo "==> verifying unwind info is present server-side"
+for pe in "$APP_EXE" "$ENGINE_DLL"; do
+  debug_id="$("$SENTRY_CLI" debug-files check "$pe" | sed -n 's/.*Debug ID: *//p' | head -1)"
+  dsyms="$(curl -sf -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+    "https://sentry.io/api/0/projects/$ORG/$PROJECT/files/dsyms/?debug_id=$debug_id")"
+  if ! grep -q '"unwind"' <<<"$dsyms"; then
+    echo "error: Sentry holds no unwind-capable object for $(basename "$pe")" >&2
+    echo "       ($debug_id). Native stacks from this build would be guesswork." >&2
+    exit 1
+  fi
+  echo "  ok: $(basename "$pe") $debug_id"
+done
+
+echo "==> done"


### PR DESCRIPTION
## Summary

Native crash reports were being read as if their stack traces were real. They
were not: the release flow uploaded only PDBs, so Sentry had no unwind data and
reconstructed the call stack by scanning memory for plausible return addresses.
The result is a fully symbolicated, file/line-annotated, **causally wrong** stack
that looks trustworthy — it already sent one investigation down the wrong path.
This uploads the PE binaries too, moves the step into a script that verifies its
own work, and records how to read a native stack safely.

## What changed

### 1. `tool/upload_symbols.sh` (new)

- **Uploads four files, not two** — the two PDBs plus `umacapture.exe` and
  `flutter_windows.dll`. Unwind tables live in the binary's `.pdata` section and
  are absent from a PDB, so the binaries are what make `trust: cfi` frames
  possible.
- **Preflight** rejects a binary with no unwind info, or no Debug ID — the latter
  means the `/DEBUG` link flags in `windows/runner/CMakeLists.txt` regressed and
  no upload could ever match the build.
- **Server-side verification** queries the dsyms API per debug id. `sentry-cli
  debug-files upload` prints `UPLOADED` only for files the server did not already
  have, so its output cannot distinguish "already there" from "never uploaded".
  (`sentry-cli debug-files find` does not help — it searches local disk, so it
  matches the very file it was handed.)
- Org/project come from `.sentryclirc`; the token stays in the environment.

### 2. `release` skill

- Step 9.5 now calls the script instead of spelling out a four-path `sentry-cli`
  invocation, so the file set cannot be trimmed by accident, and explains why
  `Nothing to upload, all files are on the server` is a pass rather than a skip.

### 3. `sentry-issues` skill

- **How to read a native stack** — check each frame's `trust` (`context` and
  `cfi` are reliable; `scan` and `fp` are guesses whose ordering means nothing),
  plus `unwind_status` in `debugmeta` and the `native_missing_dsym` entries in
  `errors`.
- **Which modules can never symbolicate** — only `umacapture.exe` and
  `flutter_windows.dll` carry a usable Debug ID. The six plugin DLLs and the
  three sentry-native binaries we build ourselves contain unwind info but are
  stripped of their debug identifier, because `/Zi` and `/DEBUG` are target
  options on the runner alone and MSVC's `Release` config adds neither; the
  third-party prebuilts have no PDBs at all. Documented rather than fixed, with
  the fix and its cost written down.
- **Minidumps are not retained** (`storeCrashReports` is `0`), so a late symbol
  upload cannot repair an existing event.

### 4. `.gitattributes`

- **`tool/*.sh` pinned to LF**, so `core.autocrlf=true` cannot hand a fresh clone
  a `#!/usr/bin/env bash\r` shebang. Same rationale as the existing
  `tool/hooks/pre-commit` rule.

## Testing

Ran `tool/upload_symbols.sh` end to end against the 0.2.1 release build, whose
Debug IDs and Code IDs match the crash event exactly:

- **Success path** — server-side check confirms unwind-capable objects for both
  binaries (`ok:` twice, `==> done`, exit 0), including the re-run case where
  `upload` reports nothing to do.
- **Failure paths** — missing `SENTRY_AUTH_TOKEN` and missing build outputs both
  exit 1 with an actionable message.
- **Guard is meaningful** — `debug-files check` on `umacapture.pdb` reports
  `symtab, debug` with no `unwind`, i.e. the unwind assertion would reject a
  PDB-only object rather than passing vacuously.

The uploads for 0.2.1 are already on the server, so its `unwind_status` is now
`found` for future events.

## Risk / scope

Documentation, a new standalone script, and one `.gitattributes` line. No
application code is touched and nothing runs at build time.

## Follow-up

- Enabling `storeCrashReports` is a Sentry org setting and has to be done in the
  web UI; until then no minidump is retained for local analysis.
- The 0.2.1 shutdown crash itself is diagnosed but unfixed, and its fix lands in
  `windows/runner/` — a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
