### PR TITLE
fix(windows): fix the shutdown crash and refresh the vendored runner template

### DIFF
--- a/.claude/skills/sentry-issues/SKILL.md
+++ b/.claude/skills/sentry-issues/SKILL.md
@@ -191,11 +191,17 @@ were `unwind_status: unused`, i.e. no frame needed them — but if a similar rep
 appears with those modules in play, the gap above is the reason the middle of the
 stack looks incoherent.
 
-**Version tagging is consistent.** Both the Dart side (`assets/version_info.json`)
-and the native side (`windows/runner/Runner.rc` `FLUTTER_VERSION`) derive from the
-pubspec `version` at build time, so a given build reports the same release on both
-paths. If you see two events with different release strings, that's two different
-app builds/users — not a tagging bug.
+**Version tagging is consistent, but not for the reason it looks like.** Every
+event — Dart exception or native minidump — gets its `release` from the Dart side
+(`assets/version_info.json`), because `sentry_flutter` passes its options down to
+the native SDK. The exe's own version resource plays no part in it. So if you see
+two events with different release strings, that's two different app builds/users,
+not a tagging bug.
+
+Do **not** infer the app version from the exe's file properties as a cross-check.
+`windows/runner/Runner.rc` reads `FLUTTER_VERSION*`, and until the 2026-07-19 fix
+`windows/runner/CMakeLists.txt` never defined them, so every build before that
+took the `#else` branch and stamped itself `1.0.0` regardless of the pubspec.
 
 ## Ad-hoc curl (when the script doesn't cover it)
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -4,6 +4,10 @@ project(umacapture LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(BINARY_NAME "umacapture")
 
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(VERSION 3.14...3.25)
+
 cmake_policy(SET CMP0063 NEW)
 
 set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
@@ -111,6 +115,12 @@ install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
 # Install the AOT library on non-Debug builds only.
 install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
         CONFIGURATIONS Profile;Release
+        COMPONENT Runtime)
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+        DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
         COMPONENT Runtime)
 
 # clip

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -61,6 +61,16 @@ target_link_options(
         "$<${RELEASE_OR_PROFILE}:/OPT:ICF>"
 )
 
+# Version resource inputs for Runner.rc. Without these the #else branches in
+# Runner.rc take over and the exe reports itself as 1.0.0 forever, no matter what
+# pubspec.yaml says. FLUTTER_VERSION* come from the top-level CMakeLists.txt,
+# which the Flutter tool populates from the pubspec version at configure time.
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION=\"${FLUTTER_VERSION}\"")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MAJOR=${FLUTTER_VERSION_MAJOR}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_MINOR=${FLUTTER_VERSION_MINOR}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_PATCH=${FLUTTER_VERSION_PATCH}")
+target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_BUILD=${FLUTTER_VERSION_BUILD}")
+
 target_compile_definitions(
         ${BINARY_NAME} PRIVATE
         NOMINMAX
@@ -71,6 +81,7 @@ target_link_libraries(
         ${BINARY_NAME} PRIVATE
         flutter
         flutter_wrapper_app
+        "dwmapi.lib"
         "${OpenCV_LIBS}"
         "${ONNX_DIR}/lib/onnxruntime.lib"
         clip

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -14,7 +14,32 @@ FlutterWindow::FlutterWindow(const flutter::DartProject &project)
     uma::logger_util::init();
 }
 
-FlutterWindow::~FlutterWindow() = default;
+FlutterWindow::~FlutterWindow() {
+    // Tear the Flutter controller down here rather than leaving it to the
+    // member's own destructor.
+    //
+    // Destroying the controller makes the engine call DestroyWindow() on the
+    // view's child HWND, and Windows dispatches the resulting messages to this
+    // window's top-level WndProc *synchronously*. MessageHandler() guards on
+    // `flutter_controller_`, but a member being destroyed is not null: only
+    // unique_ptr::reset() clears the pointer before running the deleter, while
+    // ~unique_ptr() leaves it dangling. So on this path the guard passes, the
+    // re-entrant call reaches a controller whose view is already gone, and
+    // FlutterWindowsView::GetEngine() dereferences null -- the 0.2.1 shutdown
+    // crash (EXCEPTION_ACCESS_VIOLATION_READ at null+0x10).
+    //
+    // Destroy() routes through FlutterWindow::OnDestroy(): virtual dispatch
+    // still resolves to this class inside its own destructor, so the pointer is
+    // nulled first and the re-entrant call is skipped. Leaving this to
+    // ~Win32Window() is too late -- by then the derived object is gone and only
+    // Win32Window::OnDestroy() runs.
+    //
+    // The WM_DESTROY path already reached OnDestroy() and Destroy() is
+    // idempotent, so this is a no-op when the window closed normally. Upstream's
+    // runner template has the same defect as of Flutter 3.44.4; this is a local
+    // patch, not a vendored change.
+    Destroy();
+}
 
 bool FlutterWindow::OnCreate() {
     log_debug("");

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -18,6 +18,16 @@ FlutterWindow::~FlutterWindow() {
     // Tear the Flutter controller down here rather than leaving it to the
     // member's own destructor.
     //
+    // This runs only when the app leaves its message loop while the window is
+    // still alive, so the window is torn down by this destructor instead of by
+    // WM_DESTROY. In production that means a Windows logoff or shutdown, which
+    // posts WM_QUIT without ever closing the window. To reproduce it by hand,
+    // start the release build, resolve the UI thread with
+    // GetWindowThreadProcessId() on the main window, post WM_QUIT (0x0012) to
+    // that thread, and check the exit code: before this fix it was reliably
+    // 0xC0000005, after it is 0. Check WM_CLOSE (the X button) too -- that path
+    // was always safe, and it is what proves the doubled Destroy() is harmless.
+    //
     // Destroying the controller makes the engine call DestroyWindow() on the
     // view's child HWND, and Windows dispatches the resulting messages to this
     // window's top-level WndProc *synchronously*. MessageHandler() guards on

--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -45,18 +45,23 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
+  // First, find the length of the string with a safe upper bound (CWE-126).
+  // UNICODE_STRING_MAX_CHARS (32767) is the maximum length of a UNICODE_STRING.
+  int input_length = static_cast<int>(wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS));
+  // Now use that bounded length to determine the required buffer size.
+  // When an explicit length is passed, WideCharToMultiByte does not include
+  // the null terminator in its returned size.
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
-  if (target_length == 0) {
-    return std::string();
-  }
+      input_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
+  if (target_length == 0 || static_cast<size_t>(target_length) > utf8_string.max_size()) {
+    return utf8_string;
+  }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -1,12 +1,30 @@
 #include "win32_window.h"
 
+#include <dwmapi.h>
 #include <flutter_windows.h>
 
 #include "resource.h"
 
 namespace {
 
+/// Window attribute that enables dark mode window decorations.
+///
+/// Redefined in case the developer's machine has a Windows SDK older than
+/// version 10.0.22000.0.
+/// See: https://docs.microsoft.com/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+
 constexpr const wchar_t kWindowClassName[] = L"FLUTTER_RUNNER_WIN32_WINDOW";
+
+/// Registry key for app theme preference.
+///
+/// A value of 0 indicates apps should use dark mode. A non-zero or missing
+/// value indicates apps should use light mode.
+constexpr const wchar_t kGetPreferredBrightnessRegKey[] =
+  L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+constexpr const wchar_t kGetPreferredBrightnessRegValue[] = L"AppsUseLightTheme";
 
 // The number of Win32Window objects that currently exist.
 static int g_active_window_count = 0;
@@ -31,8 +49,8 @@ void EnableFullDpiSupportIfAvailable(HWND hwnd) {
           GetProcAddress(user32_module, "EnableNonClientDpiScaling"));
   if (enable_non_client_dpi_scaling != nullptr) {
     enable_non_client_dpi_scaling(hwnd);
-    FreeLibrary(user32_module);
   }
+  FreeLibrary(user32_module);
 }
 
 }  // namespace
@@ -42,7 +60,7 @@ class WindowClassRegistrar {
  public:
   ~WindowClassRegistrar() = default;
 
-  // Returns the singleton registar instance.
+  // Returns the singleton registrar instance.
   static WindowClassRegistrar* GetInstance() {
     if (!instance_) {
       instance_ = new WindowClassRegistrar();
@@ -126,6 +144,8 @@ bool Win32Window::CreateAndShow(const std::wstring& title,
     return false;
   }
 
+  UpdateTheme(window);
+
   return OnCreate();
 }
 
@@ -188,6 +208,10 @@ Win32Window::MessageHandler(HWND hwnd,
         SetFocus(child_content_);
       }
       return 0;
+
+    case WM_DWMCOLORIZATIONCOLORCHANGED:
+      UpdateTheme(hwnd);
+      return 0;
   }
 
   return DefWindowProc(window_handle_, message, wparam, lparam);
@@ -242,4 +266,19 @@ bool Win32Window::OnCreate() {
 
 void Win32Window::OnDestroy() {
   // No-op; provided for subclasses.
+}
+
+void Win32Window::UpdateTheme(HWND const window) {
+  DWORD light_mode;
+  DWORD light_mode_size = sizeof(light_mode);
+  LSTATUS result = RegGetValue(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
+                               kGetPreferredBrightnessRegValue,
+                               RRF_RT_REG_DWORD, nullptr, &light_mode,
+                               &light_mode_size);
+
+  if (result == ERROR_SUCCESS) {
+    BOOL enable_dark_mode = light_mode == 0;
+    DwmSetWindowAttribute(window, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                          &enable_dark_mode, sizeof(enable_dark_mode));
+  }
 }

--- a/windows/runner/win32_window.h
+++ b/windows/runner/win32_window.h
@@ -86,6 +86,9 @@ class Win32Window {
   // Retrieves a class instance pointer for |window|
   static Win32Window* GetThisFromHandle(HWND const window) noexcept;
 
+  // Update the window frame's theme to match the system theme.
+  static void UpdateTheme(HWND const window);
+
   bool quit_on_close_ = false;
 
   // window handle for top level window.


### PR DESCRIPTION
## Summary

Fixes the 0.2.1 shutdown crash reported to Sentry (`UMACAPTURE-RELEASE-A9`,
`EXCEPTION_ACCESS_VIOLATION_READ` at null+0x10) and, while in the same files,
brings the vendored Flutter runner template forward from its ~2022 snapshot.
`windows/runner/` had never been refreshed, and diffing it against the pinned
3.44.4 template surfaced a security fix and a latent version-resource bug.

## What changed

### 1. The shutdown crash

`~FlutterWindow()` now calls `Destroy()` instead of leaving the controller to its
member's destructor.

- **Trigger:** the app leaves its message loop while the window is still alive —
  a Windows logoff or shutdown posts WM_QUIT without ever closing the window — so
  `FlutterWindow` is torn down by its destructor rather than by WM_DESTROY.
- **Mechanism:** destroying the view controller makes the engine call
  `DestroyWindow()` on the view's child HWND, and Windows dispatches the
  resulting messages to the top-level WndProc **synchronously**.
  `MessageHandler()` guards on `flutter_controller_`, but **a member being
  destroyed is not null** — only `unique_ptr::reset()` clears the pointer before
  running the deleter, while `~unique_ptr()` leaves it dangling. The guard
  passes, the re-entrant call reaches a controller whose `view_` is already null,
  and `view_->GetEngine()` faults reading `engine_` at offset 0x10.
- **Fix:** `Destroy()` routes through `FlutterWindow::OnDestroy()` — virtual
  dispatch still resolves to this class inside its own destructor — so the
  pointer is nulled first and the re-entrant call is skipped. `~Win32Window()` is
  too late: the derived object is gone by then and only
  `Win32Window::OnDestroy()` runs.
- **Upstream still has this defect** as of 3.44.4, so it is a deliberate local
  patch, commented as such, along with the repro recipe.

### 2. Version resource was stuck at 1.0.0

`Runner.rc` reads `FLUTTER_VERSION*`, but `runner/CMakeLists.txt` never defined
them, so every build so far took the `#else` branch and stamped itself 1.0.0
regardless of `pubspec.yaml`. Sentry tagging was never affected —
`sentry_flutter` passes the Dart-side release down to the native SDK — but the
exe's file properties were wrong. The `sentry-issues` skill claimed the opposite
and is corrected here.

### 3. Upstream changes taken

- **Bounded UTF-16 conversion (CWE-126)** — `Utf8FromUtf16` passed length `-1`,
  relying on the input being null-terminated. Upstream bounds the scan with
  `wcsnlen(s, UNICODE_STRING_MAX_CHARS)` and guards `max_size()`. Side effect:
  the returned string no longer carries a trailing NUL.
- **`FreeLibrary` leak** when `EnableNonClientDpiScaling` is unavailable.
- **Dark mode window decorations**, the `registar` typo,
  `cmake_policy(VERSION 3.14...3.25)`, and the **native assets install rule**.

### 4. Deliberately not taken

- The `Create`/`Show` split and `SetNextFrameCallback`/`ForceRedraw` first-frame
  handling. Measured from the instant the window becomes visible: the window
  appears at 537 ms with the UI **already laid out**, and there is no white
  flash. `windowManager.waitUntilReadyToShow` already solves what upstream's
  callback solves, so adopting it would only add a second show path.
- Switching back to the native title bar. Dark mode does work — verified with a
  screenshot under `TitleBarStyle.normal` — but the app's own caption carries the
  feedback button, and it follows the **app** theme (`theme.brightness`) whereas
  the native caption follows the **OS** theme. Since the app theme is
  user-selectable, that would mean a dark caption over a light app. The
  dark-mode code is kept anyway to reduce drift from upstream; it is simply inert
  while the caption is hidden.

## Testing

All against release builds produced from this tree in the same session.

- **Crash repro** — posting WM_QUIT straight to the UI thread reproduces the
  exact path. **Before:** exit code -1073741819 (0xC0000005), deterministic.
  **After:** clean exit, 3/3.
- **Ordinary close** — WM_CLOSE still exits cleanly, 2/2, confirming the
  now-doubled `Destroy()` is harmless on the path that was already safe.
- **Version resource** — the built exe reports FileVersion / ProductVersion
  0.2.1, matching `pubspec.yaml`.
- **Startup** — app launches, window shows, `App version: local=0.2.1` logged.
- **Symbols** — `debug-files check` still reports a Debug ID and `unwind`, so the
  `/DEBUG` flags survived the CMake edits.

## Risk / scope

`windows/runner/` only, plus one skill doc. No Dart or native-backend code is
touched, so neither CI suite exercises these files — the verification above was
done by hand.

## Follow-up

The Sentry issue is marked `resolvedInNextRelease`, so it reopens only if the
crash recurs on a build that contains this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
