### PR TITLE
fix(app-update): make in-app update download and launch actually work

### DIFF
--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -27,7 +27,9 @@
                     "exe": "インストーラー",
                     "zip": "ダウンロードフォルダ"
                 },
-                "download_failed": "更新のダウンロードに失敗しました。"
+                "download_failed": {
+                    "template": "更新のダウンロードに失敗しました。\n{error}"
+                }
             },
             "module_updater": {
                 "title": "認識モジュール更新",

--- a/lib/src/core/path_entity.dart
+++ b/lib/src/core/path_entity.dart
@@ -68,6 +68,30 @@ class PathEntity {
     }
   }
 
+  /// Asynchronous counterpart of [deleteSync] for callers on the UI isolate.
+  ///
+  /// Retries the same way, but waits with [Future.delayed] instead of [sleep],
+  /// so a locked file stalls only this chain rather than the whole isolate.
+  Future<void> delete({bool recursive = false, bool emptyOk = false}) async {
+    if (emptyOk && !existsSync()) {
+      return;
+    }
+
+    // Retry up to 3 times to avoid file lock issues.
+    int attempts = 0;
+    while (true) {
+      try {
+        await toEntity().delete(recursive: recursive);
+        return;
+      } catch (e) {
+        if (++attempts >= 3) {
+          rethrow;
+        }
+        await Future.delayed(const Duration(milliseconds: 100));
+      }
+    }
+  }
+
   void deleteSyncWithCheck({bool recursive = false, bool emptyOk = false}) {
     try {
       deleteSync(recursive: recursive, emptyOk: emptyOk);
@@ -167,6 +191,9 @@ class FilePath extends PathEntity {
   /// underlying OS error, which carries the reason a replace was refused — most
   /// often a sharing violation because another process holds the destination.
   void renameSync(FilePath destination) => toFile().renameSync(destination.path);
+
+  /// Asynchronous counterpart of [renameSync]; the same same-volume caveat applies.
+  Future<void> rename(FilePath destination) => toFile().rename(destination.path);
 
   T deserializeSync<T>() => MapperContainer.globals.fromJson<T>(readAsStringSync());
 }

--- a/lib/src/core/path_entity.dart
+++ b/lib/src/core/path_entity.dart
@@ -4,6 +4,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
+import 'package:url_launcher/url_launcher.dart' show launchUrl;
 
 import '/src/core/utils.dart';
 import '/src/gui/toast.dart';
@@ -108,8 +109,19 @@ class PathEntity {
 
   FileSystemEntity toEntity() => isFileSync ? File(path) : Directory(path);
 
-  Future<void> launch() {
-    return Process.run("start", [path], runInShell: true);
+  /// Opens this path with the shell's default action: Explorer for a
+  /// directory, execution or the associated application for a file.
+  ///
+  /// Goes through ShellExecuteW (via url_launcher) instead of a `cmd start`
+  /// command line, because cmd re-parses the path: spaces turn it into a
+  /// window title and `&` splits it into two commands, so such paths fail to
+  /// open without any error. ShellExecuteW takes the path as data, reports
+  /// failures (which this method rethrows so awaiting callers can surface
+  /// them), and handles UAC elevation when the target is an installer.
+  Future<void> launch() async {
+    if (!await launchUrl(Uri.file(path))) {
+      throw FileSystemException("The shell has no handler to open this path", path);
+    }
   }
 
   FilePath toFilePath() {

--- a/lib/src/core/path_entity.dart
+++ b/lib/src/core/path_entity.dart
@@ -160,6 +160,14 @@ class FilePath extends PathEntity {
 
   void writeAsStringSync(String contents) => toFile().writeAsStringSync(contents);
 
+  /// Renames this file to [destination], replacing it if it already exists.
+  ///
+  /// Same-volume only, so callers must keep the temporary and final paths in the
+  /// same directory. Throws (rather than reporting) so the caller can surface the
+  /// underlying OS error, which carries the reason a replace was refused — most
+  /// often a sharing violation because another process holds the destination.
+  void renameSync(FilePath destination) => toFile().renameSync(destination.path);
+
   T deserializeSync<T>() => MapperContainer.globals.fromJson<T>(readAsStringSync());
 }
 

--- a/lib/src/gui/dashboard.dart
+++ b/lib/src/gui/dashboard.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:auto_route/auto_route.dart';
+import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
@@ -41,6 +44,32 @@ class AppUpdaterGroup extends ConsumerWidget {
 
   const AppUpdaterGroup({super.key, required this.version});
 
+  /// Renders [error] as a single short line for the failure toast.
+  ///
+  /// Deliberately descriptive rather than diagnostic: it reports what the OS or
+  /// the HTTP layer actually said instead of guessing a cause, so an unfamiliar
+  /// failure is not mislabelled as a familiar one.
+  static String describeError(Object error) {
+    final String detail = switch (error) {
+      FileSystemException(:final osError?) => "${error.message}: ${osError.message} (errno ${osError.errorCode})",
+      FileSystemException() => error.message,
+      DioException(:final response?) => "${error.type.name}: HTTP ${response.statusCode}",
+      DioException() => "${error.type.name}: ${error.message ?? error.error ?? ''}",
+      _ => error.toString(),
+    };
+    // Naming what was being acted on lets the user act on it directly (close
+    // whatever holds the file, or check the URL) instead of only learning that
+    // something went wrong.
+    final String target = switch (error) {
+      FileSystemException(:final path?) => "\n$path",
+      DioException(:final requestOptions) => "\n${requestOptions.uri}",
+      _ => "",
+    };
+    const limit = 300;
+    final trimmed = detail.trim();
+    return (trimmed.length <= limit ? trimmed : "${trimmed.substring(0, limit)}...") + target;
+  }
+
   void downloadAndOpen(WidgetRef ref) {
     // Capture the (top-level, non-autoDispose) provider objects before the async chain so the deferred
     // callbacks never touch the build-phase WidgetRef after this card is disposed (e.g. tab switch).
@@ -51,27 +80,67 @@ class AppUpdaterGroup extends ConsumerWidget {
         .read(isInstallerModeLoader.future)
         .then((isInstallerMode) {
           final downloadUrl = isInstallerMode ? Const.appExeUrl(version: version) : Const.appZipUrl(version: version);
-          final FilePath downloadPath = pathInfo.downloadDir.filePath(Uri.parse(downloadUrl).pathSegments.last);
-          logger.d(downloadUrl);
+          final String fileName = Uri.parse(downloadUrl).pathSegments.last;
+          final FilePath downloadPath = pathInfo.downloadDir.filePath(fileName);
+          // Stream into a sibling temp file and rename on success, so an aborted
+          // transfer never leaves a truncated executable under the real name for
+          // the user to run. Sibling, not tempDir: a rename cannot cross volumes.
+          final FilePath incompletePath = pathInfo.downloadDir.filePath("$fileName.part");
+          logger.d("Downloading the app update from $downloadUrl to ${downloadPath.path}");
+          // Always discard a previous artifact rather than reusing it: its
+          // provenance is unknown (it may be a truncated or tampered-with file
+          // from an earlier run). Deleting up front also surfaces a locked
+          // destination here, before spending a 50 MB transfer that could only
+          // fail at the rename.
+          downloadPath.deleteSync(emptyOk: true);
+          incompletePath.deleteSync(emptyOk: true);
           return createDiagnosticDio(operation: "download_app_update")
               .download(
                 downloadUrl,
-                downloadPath.path,
+                incompletePath.path,
                 onReceiveProgress: (int count, int total) {
                   progress.set(Progress(count: count, total: total));
                 },
               )
               .then((_) {
+                incompletePath.renameSync(downloadPath);
                 progress.set(null);
-                (isInstallerMode ? downloadPath : downloadPath.parent).launch();
+                return (isInstallerMode ? downloadPath : downloadPath.parent).launch();
+              })
+              .onError<Object>((error, stackTrace) {
+                // Drop the half-written temp file so an abandoned download does
+                // not strand 50 MB in the user's Downloads folder. Best-effort:
+                // a cleanup failure must not replace the error being reported.
+                try {
+                  incompletePath.deleteSync(emptyOk: true);
+                } catch (cleanupError) {
+                  logger.w("Failed to remove the incomplete app update download.", cleanupError);
+                }
+                throw error;
               });
         })
         .catchError((Object error, StackTrace stackTrace) {
           // Reset the progress so the card stops spinning and becomes tappable again;
           // without this a failed download leaves it stuck on the spinner forever.
-          logger.w("Failed to download app update: $error\n$stackTrace");
+          // Report at error level and to Sentry: this was the only network
+          // operation that stayed a local warning, which left production failures
+          // with no trace at all.
+          logger.e("Failed to download the app update.", error, stackTrace);
+          if (error is DioException) {
+            logger.e(
+              "App update download detail: type=${error.type} url=${error.requestOptions.uri} "
+              "status=${error.response?.statusCode} inner=${error.error} (${error.error.runtimeType})",
+            );
+          }
+          captureException(error, stackTrace);
           progress.set(null);
-          Toaster.show(ToastData.error(description: "$tr_dashboard.app_updater.download_failed".tr()));
+          Toaster.show(
+            ToastData.error(
+              description: "$tr_dashboard.app_updater.download_failed.template".tr(
+                namedArgs: {"error": describeError(error)},
+              ),
+            ),
+          );
         });
   }
 

--- a/lib/src/gui/dashboard.dart
+++ b/lib/src/gui/dashboard.dart
@@ -4,6 +4,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
@@ -55,6 +56,11 @@ class AppUpdaterGroup extends ConsumerWidget {
       FileSystemException() => error.message,
       DioException(:final response?) => "${error.type.name}: HTTP ${response.statusCode}",
       DioException() => "${error.type.name}: ${error.message ?? error.error ?? ''}",
+      // url_launcher wraps ShellExecuteW failures (e.g. launching the finished
+      // installer) in a PlatformException whose message already names the
+      // target and the OS error code; toString would bury it in "(code, ...,
+      // null, null)" noise.
+      PlatformException() => error.message ?? error.code,
       _ => error.toString(),
     };
     // Naming what was being acted on lets the user act on it directly (close

--- a/lib/src/gui/dashboard.dart
+++ b/lib/src/gui/dashboard.dart
@@ -78,7 +78,7 @@ class AppUpdaterGroup extends ConsumerWidget {
     progress.set(Progress(count: 0, total: 100));
     ref
         .read(isInstallerModeLoader.future)
-        .then((isInstallerMode) {
+        .then((isInstallerMode) async {
           final downloadUrl = isInstallerMode ? Const.appExeUrl(version: version) : Const.appZipUrl(version: version);
           final String fileName = Uri.parse(downloadUrl).pathSegments.last;
           final FilePath downloadPath = pathInfo.downloadDir.filePath(fileName);
@@ -91,9 +91,10 @@ class AppUpdaterGroup extends ConsumerWidget {
           // provenance is unknown (it may be a truncated or tampered-with file
           // from an earlier run). Deleting up front also surfaces a locked
           // destination here, before spending a 50 MB transfer that could only
-          // fail at the rename.
-          downloadPath.deleteSync(emptyOk: true);
-          incompletePath.deleteSync(emptyOk: true);
+          // fail at the rename. Async variants: a locked file makes the delete
+          // retry, and the sync retry would stall the UI isolate.
+          await downloadPath.delete(emptyOk: true);
+          await incompletePath.delete(emptyOk: true);
           return createDiagnosticDio(operation: "download_app_update")
               .download(
                 downloadUrl,
@@ -102,21 +103,21 @@ class AppUpdaterGroup extends ConsumerWidget {
                   progress.set(Progress(count: count, total: total));
                 },
               )
-              .then((_) {
-                incompletePath.renameSync(downloadPath);
+              .then((_) async {
+                await incompletePath.rename(downloadPath);
                 progress.set(null);
                 return (isInstallerMode ? downloadPath : downloadPath.parent).launch();
               })
-              .onError<Object>((error, stackTrace) {
+              .onError<Object>((error, stackTrace) async {
                 // Drop the half-written temp file so an abandoned download does
                 // not strand 50 MB in the user's Downloads folder. Best-effort:
                 // a cleanup failure must not replace the error being reported.
                 try {
-                  incompletePath.deleteSync(emptyOk: true);
+                  await incompletePath.delete(emptyOk: true);
                 } catch (cleanupError) {
                   logger.w("Failed to remove the incomplete app update download.", cleanupError);
                 }
-                throw error;
+                Error.throwWithStackTrace(error, stackTrace);
               });
         })
         .catchError((Object error, StackTrace stackTrace) {

--- a/windows/packaging/exe/make_config.yaml
+++ b/windows/packaging/exe/make_config.yaml
@@ -1,5 +1,11 @@
 app_id: bb3e45c0-725c-428e-aeb4-0076a37d4873
 display_name: umacapture
+# Must be set explicitly. flutter_app_packager otherwise defaults to the first
+# *.exe it finds in the packaging directory, which since Sentry was added is
+# crashpad_handler.exe, not the app. That name feeds both [Run] and [Icons], so
+# leaving it unset breaks the post-install launch, the Start Menu entry, the
+# desktop icon and the "launch at startup" shortcut alike.
+executable_name: umacapture.exe
 publisher_name: umasagashi
 publisher_url: https://github.com/umasagashi
 create_desktop_icon: true


### PR DESCRIPTION
## Summary

The in-app updater could not deliver an update end to end: the installer it built launched the wrong executable, a failed download left a truncated file under the real name, and every failure surfaced as a single untranslatable sentence with no trace anywhere. This fixes the delivery path and makes its failures reportable.

## What changed

### 1. Installer launches the app, not the crash handler

- **`executable_name` is now pinned** in `windows/packaging/exe/make_config.yaml`. `flutter_app_packager` defaults to the first `*.exe` in the packaging directory, which since Sentry was added is `crashpad_handler.exe`. That name feeds both `[Run]` and `[Icons]`, so leaving it unset broke the post-install launch, the Start Menu entry, the desktop icon and the "launch at startup" shortcut alike.

### 2. Download to a temp file, then rename

- **Streams into a sibling `<name>.part`** and renames on success, so an aborted transfer never leaves a truncated executable under the real name for the user to run. Sibling rather than temp dir, because a rename cannot cross volumes.
- **Pre-existing artifacts are deleted up front** instead of reused: their provenance is unknown, and deleting early surfaces a locked destination before spending a 50 MB transfer that could only fail at the rename.
- **The partial file is cleaned up on failure**, best-effort, so a cleanup error never replaces the error being reported.
- **New `PathEntity.delete` / `FilePath.rename`** provide async counterparts of the existing sync helpers; the sync retry loop uses `sleep`, which would stall the UI isolate on a locked file.

### 3. Failures are reported faithfully

- **`catchError` now logs at error level and calls `captureException`.** This was the only network operation that stayed a local warning, so production failures left no trace at all.
- **`Error.throwWithStackTrace`** preserves the original stack across the cleanup handler.
- **`describeError`** renders `FileSystemException`, `DioException` and `PlatformException` into one short line naming what the OS or HTTP layer actually said plus the target path or URL, instead of guessing a cause. The toast string became a template taking `{error}`.

### 4. Paths with spaces open again

- **`PathEntity.launch()` goes through `ShellExecuteW`** (via `url_launcher`) instead of `Process.run("start", …, runInShell: true)`. cmd re-parses the path: a space turns it into a window title and `&` splits it into two commands, so such paths failed to open silently. `ShellExecuteW` takes the path as data, reports failure (now rethrown so awaiting callers can surface it), and handles UAC elevation for the installer.

## Testing

- `flutter test` — passes.
- Manual: built the installer from this branch and confirmed the post-install launch, Start Menu entry and desktop icon all point at `umacapture.exe`; exercised the download path with the app installed under a directory whose name contains a space.

## Risk / scope

Limited to the app-update path plus two new `PathEntity` helpers. The `launch()` change is shared with other callers (download folder, log folder), all of which gain the spaced-path fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
