### PR TITLE
chore(packaging): pin Inno Setup to 6.7.3 and modernize the arch identifiers

### DIFF
--- a/.claude/skills/project-setup/SKILL.md
+++ b/.claude/skills/project-setup/SKILL.md
@@ -75,8 +75,10 @@ or get approval before installing anything — do not install them unprompted.**
 | **Visual Studio 2022+** (Desktop C++ workload) | MSVC toolchain for the native/Windows build | Provides `cl.exe`; VS ships `cmake` + `ninja`. Required for `flutter build windows` and the native CLI/tests. |
 | **7-Zip** (optional) | faster OpenCV extraction | `tool/fetch_deps.py` falls back to the OpenCV `.exe`'s own self-extractor if `7z` is absent. |
 
-Releasing additionally needs **Inno Setup** + `flutter_distributor` + a
-`GITHUB_TOKEN` — out of scope here; see the **release** skill.
+Releasing additionally needs **Inno Setup 6.7.3** (pinned via winget; deliberately
+on the 6.x line even though 7.x exists) + `flutter_distributor` + a
+`GITHUB_TOKEN` — out of scope here; see the **release** skill for the version
+check and the reasoning.
 
 ## Setup steps
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -74,10 +74,49 @@ resolves to the FVM default, but verify rather than assume.
    ```
    If it does not match, prepend `.fvm/flutter_sdk/bin` to PATH for the session.
 
-2. **Inno Setup `iscc` is available** (needed by the `exe` job):
+2. **Inno Setup is installed and pinned to 6.7.3** (needed by the `exe` job).
+   The version is pinned in winget, so this should already hold; verify rather
+   than assume, because `ISCC.exe` carries no VersionInfo and reports only
+   "Inno Setup 6" on the banner:
    ```bash
-   where iscc || ls "/c/Program Files (x86)/Inno Setup 6/ISCC.exe"
+   ls "/c/Program Files (x86)/Inno Setup 6/ISCC.exe"
+   winget pin list --id JRSoftware.InnoSetup    # expect a "Gating" pin at 6.7.3
+   powershell -NoProfile -Command "Get-ItemProperty 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' | Where-Object { \$_.DisplayName -like '*Inno Setup*' } | Select-Object DisplayVersion"
    ```
+   If the version differs, restore it before releasing:
+   ```bash
+   winget install --id JRSoftware.InnoSetup --version 6.7.3 --exact
+   winget pin add --id JRSoftware.InnoSetup --version 6.7.3 --exact
+   ```
+   **Stay on the 6.x line.** Inno Setup 7 exists (7.0.2 is the current stable,
+   alongside 6.7.3 on the 6.x line) and 6.7.3 is not being left behind — this is
+   a "no reason to move" call, not a blocker:
+   - Nothing in 7.0 pays off here. Its headline features are 64-bit *installers*
+     (a 32-bit installer installs a 64-bit app just fine; the real gain is an
+     lzma dictionary above 3.8 GB, irrelevant to a ~50 MB payload) and
+     extended-length path support (the install target is well under `MAX_PATH`).
+     Its Pascal-scripting breaking changes cannot bite us — `inno_template.iss`
+     has no `[Code]` section. `x64compatible`, which 7.0 makes the default, is
+     already set explicitly in the template.
+   - 7.0 *does* change defaults the template leaves unset (`AppVerName`,
+     `TimeStampsInUTC`, `ArchiveExtraction`), so moving would require re-verifying
+     the installer rather than being a drop-in swap.
+
+   Note for whoever revisits this: the **path** objection is obsolete. The
+   `flutter_app_packager` that runs today (0.6.5, pulled in by the globally
+   activated `flutter_distributor` 0.6.6) does hardcode
+   `C:\Program Files (x86)\Inno Setup 6\ISCC.exe` with no override, but 0.6.7 added
+   an `INNO_SETUP_PATH` environment variable plus a `PATH`-lookup fallback, and
+   0.6.9 is current. Re-running `dart pub global activate flutter_distributor`
+   picks that up — so a future 7.x move costs one environment variable, not a
+   patched dependency. Beware that the same reactivation silently changes how
+   `ISCC.exe` is resolved (the hardcoded path survives only as priority 2).
+
+   Licensing is **not** a factor either way. Inno Setup's license is unchanged
+   and still grants use "for any purpose, including commercial applications";
+   the commercial licenses introduced in 6.5.0 are a voluntary request aimed at
+   organizations above ~$5,000 USD annual revenue, and the CLI compiler emits no
+   nag when unlicensed (verified).
 
 3. **`GITHUB_TOKEN` is set** (the GitHub publisher reads it). Confirm presence
    without printing the value:

--- a/windows/packaging/exe/inno_template.iss
+++ b/windows/packaging/exe/inno_template.iss
@@ -15,8 +15,11 @@ SolidCompression=yes
 SetupIconFile={{SETUP_ICON_FILE}}
 WizardStyle=modern
 PrivilegesRequired={{PRIVILEGES_REQUIRED}}
-ArchitecturesAllowed=x64
-ArchitecturesInstallIn64BitMode=x64
+; "x64" is deprecated since Inno Setup 6.3 (the compiler warns and substitutes
+; "x64os"). "x64compatible" additionally covers Arm64 Windows running the x64
+; binaries under emulation, which is what this app needs to keep working there.
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
 
 [Languages]
 {% for locale in LOCALES %}


### PR DESCRIPTION
## Summary

Pin the Inno Setup toolchain to 6.7.3 via winget (deliberately staying on the 6.x line even though 7.x exists) and replace the deprecated `x64` architecture identifiers in the installer template with `x64compatible`, so the installer keeps working on Arm64 Windows under x64 emulation.

## What changed

- **`windows/packaging/exe/inno_template.iss`** — `ArchitecturesAllowed` / `ArchitecturesInstallIn64BitMode` now use `x64compatible` instead of the `x64` alias deprecated since Inno Setup 6.3. `x64compatible` retains the pre-6.3 behavior of matching Arm64 Windows running the x64 binaries under emulation, which plain `x64os` (the substituted meaning of `x64`) would drop.
- **`.claude/skills/release/SKILL.md`** — the prerequisite check now verifies the winget "Gating" pin at 6.7.3 (with a registry fallback, since `ISCC.exe` reports no detailed version), documents the restore commands, and records the reasoning for staying on 6.x: nothing in 7.0 pays off for this payload, 7.0 changes defaults the template leaves unset, licensing is not a factor, and the historical `flutter_app_packager` hardcoded-path objection is obsolete as of its 0.6.7 `INNO_SETUP_PATH` support.
- **`.claude/skills/project-setup/SKILL.md`** — the toolchain table now names the pinned 6.7.3 and points at the release skill for the reasoning.

## Testing

- Compiled a minimal `.iss` using `ArchitecturesAllowed=x64compatible` / `ArchitecturesInstallIn64BitMode=x64compatible` with the pinned ISCC 6.7.3 — successful compile, no warnings.
- Verified the winget Gating pin exists at 6.7.3 and that the documented claims match reality: `ISCC.exe` banner carries no detailed version, the template has no `[Code]` section, and the cached `flutter_app_packager` 0.6.5 hardcodes `C:\Program Files (x86)\Inno Setup 6\ISCC.exe` as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
