### PR TITLE
feat(capture): start capture on a worker thread with guaranteed start signals

### DIFF
--- a/lib/src/gui/capture.dart
+++ b/lib/src/gui/capture.dart
@@ -72,7 +72,13 @@ class StackedIndicator extends StatelessWidget {
   }
 }
 
-class _TwoStateButton extends ConsumerStatefulWidget {
+/// A two-state toggle button whose visual state follows [provider], not the press.
+///
+/// A press only requests the transition (e.g. start/stop capture); the button shows a spinner and stays
+/// disabled until the provider confirms the requested state, an error event arrives, or the fallback
+/// timeout expires. Public (rather than a private helper of the capture page) so the pending/confirm
+/// state machine can be widget-tested in isolation.
+class TwoStateButton extends ConsumerStatefulWidget {
   final Widget trueWidget;
   final Widget falseWidget;
   final VoidCallback onTruePressed;
@@ -80,7 +86,8 @@ class _TwoStateButton extends ConsumerStatefulWidget {
   final bool elevateWhen;
   final Provider<bool> provider;
 
-  const _TwoStateButton({
+  const TwoStateButton({
+    super.key,
     required this.trueWidget,
     required this.falseWidget,
     required this.onTruePressed,
@@ -93,7 +100,7 @@ class _TwoStateButton extends ConsumerStatefulWidget {
   ConsumerState<ConsumerStatefulWidget> createState() => _TwoStateButtonState();
 }
 
-class _TwoStateButtonState extends ConsumerState<_TwoStateButton> {
+class _TwoStateButtonState extends ConsumerState<TwoStateButton> {
   // The state we requested by pressing the button, kept until the provider actually reports it. This is
   // what drives the loading spinner: a request (e.g. start capture) is only fulfilled once native confirms
   // it, which on the first capture can take several seconds (model load). A fixed timer would hide the
@@ -571,7 +578,7 @@ class CaptureControlGroup extends ConsumerWidget {
           child: Disabled(
             disabled: ref.watch(platformControllerProvider) == null,
             tooltip: "$tr_capture.capture_control.disabled_tooltip".tr(),
-            child: _TwoStateButton(
+            child: TwoStateButton(
               elevateWhen: false,
               falseWidget: Text("$tr_capture.capture_control.start_capture_button".tr()),
               trueWidget: Text("$tr_capture.capture_control.stop_capture_button".tr()),

--- a/lib/src/gui/capture.dart
+++ b/lib/src/gui/capture.dart
@@ -94,22 +94,45 @@ class _TwoStateButton extends ConsumerStatefulWidget {
 }
 
 class _TwoStateButtonState extends ConsumerState<_TwoStateButton> {
-  bool _isInTransition;
-  Timer? _transitionTimer;
+  // The state we requested by pressing the button, kept until the provider actually reports it. This is
+  // what drives the loading spinner: a request (e.g. start capture) is only fulfilled once native confirms
+  // it, which on the first capture can take several seconds (model load). A fixed timer would hide the
+  // spinner while the request is still pending, so we wait for the real state change instead.
+  bool? _pendingTarget;
 
-  _TwoStateButtonState() : _isInTransition = false;
+  // Safety fallback: if the requested state never arrives (e.g. start failed and no confirming event is
+  // emitted), stop showing the spinner so the button does not stay disabled forever.
+  Timer? _timeoutTimer;
+
+  static const _timeout = Duration(seconds: 15);
 
   @override
   void dispose() {
-    _transitionTimer?.cancel();
+    _timeoutTimer?.cancel();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    // A native error means the pending request will never be confirmed by a state change; stop the spinner
+    // immediately instead of waiting for the fallback timeout.
+    ref.listen<AsyncValue<int>>(errorEventProvider, (_, current) {
+      current.whenData((_) {
+        if (_pendingTarget != null) {
+          _timeoutTimer?.cancel();
+          setState(() => _pendingTarget = null);
+        }
+      });
+    });
     final state = ref.watch(widget.provider);
+    // The request is fulfilled once the provider reports the target state; clear the pending marker so the
+    // spinner stops and the button becomes actionable again.
+    if (_pendingTarget != null && state == _pendingTarget) {
+      _pendingTarget = null;
+      _timeoutTimer?.cancel();
+    }
     return StackedIndicator(
-      loading: _isInTransition,
+      loading: _pendingTarget != null,
       child: AnimatedSwitcher(duration: const Duration(milliseconds: 100), child: _buildButton(state)),
     );
   }
@@ -125,17 +148,17 @@ class _TwoStateButtonState extends ConsumerState<_TwoStateButton> {
   }
 
   VoidCallback? _buildOnPressedHandler(bool state) {
-    if (_isInTransition) {
-      return null; // Prevent the button pressed until the transition is completed.
+    if (_pendingTarget != null) {
+      return null; // Prevent the button pressed until the requested state has been confirmed.
     }
     final callback = state ? widget.onTruePressed : widget.onFalsePressed;
     return () {
       callback();
-      setState(() => _isInTransition = true);
-      _transitionTimer?.cancel();
-      _transitionTimer = Timer(const Duration(milliseconds: 500), () {
-        if (mounted) {
-          setState(() => _isInTransition = false);
+      setState(() => _pendingTarget = !state);
+      _timeoutTimer?.cancel();
+      _timeoutTimer = Timer(_timeout, () {
+        if (mounted && _pendingTarget != null) {
+          setState(() => _pendingTarget = null);
         }
       });
     };

--- a/native/src/core/native_api.cpp
+++ b/native/src/core/native_api.cpp
@@ -41,6 +41,12 @@ void NativeApi::startEventLoop(const std::string &native_config) {
             log_error("startEventLoop failed: {}", e.what());
             teardownLocked();
             start_error = e.what();
+        } catch (...) {
+            // WinRT exceptions (winrt::hresult_error) do not derive from std::exception; without this catch-all
+            // they would escape with no onError, leaving a half-built pipeline behind.
+            log_error("startEventLoop failed: unknown non-standard exception");
+            teardownLocked();
+            start_error = "startEventLoop failed: unknown non-standard exception";
         }
     }
     // notifyError routes to the Dart callback; call it after releasing the lock so a re-entrant FFI call

--- a/native/src/core/native_api.cpp
+++ b/native/src/core/native_api.cpp
@@ -9,6 +9,14 @@
 #include "frame_rate.h"
 #include "native_api.h"
 
+// This backend relies on exception messages surviving until the catch site (they are forwarded to Dart
+// via onError). Under _HAS_EXCEPTIONS=0 the MSVC STL swaps std::exception for a fallback that stores the
+// message as a raw non-owning pointer, so any dynamically built message dangles by the time it is caught.
+// The stock Flutter Windows template defines _HAS_EXCEPTIONS=0; fail the build if that ever comes back.
+#if defined(_MSC_VER) && defined(_HAS_EXCEPTIONS) && !_HAS_EXCEPTIONS
+#error "_HAS_EXCEPTIONS=0 breaks exception messages (fallback std::exception does not copy them)."
+#endif
+
 namespace uma::app {
 
 NativeApi::NativeApi() = default;  // Do not use Native::instance() in this constructor.

--- a/native/src/core/native_api_messages.h
+++ b/native/src/core/native_api_messages.h
@@ -21,7 +21,12 @@ inline std::string screenshotTaken(const std::string &path, const std::string &r
 }
 
 inline std::string error(const std::string &message) {
-    return json_util::Json{{"type", "onError"}, {"message", message}}.dump();
+    // [message] often embeds an exception's what(), which is not guaranteed to be UTF-8 (e.g. a
+    // CP932-localized system message on a Japanese Windows). dump() is strict by default and would
+    // throw on such bytes, killing the very error notification the caller is trying to deliver;
+    // replace invalid sequences with U+FFFD instead so onError always reaches the Dart side.
+    return json_util::Json{{"type", "onError"}, {"message", message}}.dump(
+        -1, ' ', false, json_util::Json::error_handler_t::replace);
 }
 
 inline std::string captureStarted() { return json_util::Json{{"type", "onCaptureStarted"}}.dump(); }

--- a/native/test/core/test_native_api_messages.cpp
+++ b/native/test/core/test_native_api_messages.cpp
@@ -40,6 +40,19 @@ TEST_CASE("string-payload messages") {
     checkMessage(error("boom"), R"({"type":"onError","message":"boom"})");
 }
 
+TEST_CASE("error survives a non-UTF-8 message instead of throwing") {
+    // The message often embeds an exception's what(), which can carry non-UTF-8 bytes (e.g. a
+    // CP932-localized system message). A strict dump() would throw here and the onError notification
+    // would never reach Dart; error() must degrade the bytes (U+FFFD) and still produce valid JSON.
+    const std::string cp932_like = "boom: \x8e\xc0\x8d\x73";
+    std::string built;
+    CHECK_NOTHROW(built = error(cp932_like));
+    const Json parsed = Json::parse(built);
+    CHECK(parsed.at("type") == "onError");
+    const auto message = parsed.at("message").get<std::string>();
+    CHECK(message.rfind("boom: ", 0) == 0);
+}
+
 TEST_CASE("scroll messages") {
     checkMessage(scrollReady(3), R"({"type":"onScrollReady","index":3})");
     checkMessage(pageReady(2), R"({"type":"onPageReady","index":2})");

--- a/test/two_state_button_test.dart
+++ b/test/two_state_button_test.dart
@@ -1,0 +1,88 @@
+// Regression tests for [TwoStateButton]'s pending-request state machine.
+// Run: .fvm/flutter_sdk/bin/flutter test test/two_state_button_test.dart
+//
+// A press only requests the state transition; the spinner must persist until the provider confirms the
+// requested state -- and, since the capture-start path became asynchronous, a native onError (surfaced
+// through errorEventProvider) must clear the pending spinner immediately instead of leaving the button
+// disabled until the 15 s fallback timeout.
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:umacapture/src/core/platform_controller.dart';
+import 'package:umacapture/src/gui/capture.dart';
+
+final _stateProvider = Provider<bool>((ref) => false);
+
+Future<void> _pumpButton(WidgetTester tester, StreamController<int> errorEvents) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [errorEventProvider.overrideWith((ref) => errorEvents.stream)],
+      child: MaterialApp(
+        home: Scaffold(
+          body: TwoStateButton(
+            trueWidget: const Text('stop'),
+            falseWidget: const Text('start'),
+            onTruePressed: () {},
+            onFalsePressed: () {},
+            provider: _stateProvider,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+bool _spinnerShown(WidgetTester tester) => find.byType(CircularProgressIndicator).evaluate().isNotEmpty;
+
+void main() {
+  testWidgets('press shows the spinner and disables the button until confirmation', (tester) async {
+    final errorEvents = StreamController<int>.broadcast();
+    addTearDown(errorEvents.close);
+    await _pumpButton(tester, errorEvents);
+    expect(_spinnerShown(tester), isFalse);
+
+    await tester.tap(find.text('start'));
+    await tester.pump();
+
+    expect(_spinnerShown(tester), isTrue);
+    expect(tester.widget<OutlinedButton>(find.byType(OutlinedButton)).onPressed, isNull);
+
+    // Drain the 15 s fallback timer so the test ends with no pending timers.
+    await tester.pump(const Duration(seconds: 16));
+    expect(_spinnerShown(tester), isFalse);
+  });
+
+  testWidgets('an error event clears the pending spinner and cancels the fallback timer', (tester) async {
+    final errorEvents = StreamController<int>.broadcast();
+    addTearDown(errorEvents.close);
+    await _pumpButton(tester, errorEvents);
+
+    await tester.tap(find.text('start'));
+    await tester.pump();
+    expect(_spinnerShown(tester), isTrue);
+
+    errorEvents.add(1);
+    await tester.pump();
+    await tester.pump();
+
+    expect(_spinnerShown(tester), isFalse);
+    expect(tester.widget<OutlinedButton>(find.byType(OutlinedButton)).onPressed, isNotNull);
+    // No further pump(16 s) here: if the fallback timer were still alive, testWidgets would fail the
+    // test with a pending-timer assertion on teardown, so finishing cleanly asserts the cancel.
+  });
+
+  testWidgets('an error event before any press is a no-op', (tester) async {
+    final errorEvents = StreamController<int>.broadcast();
+    addTearDown(errorEvents.close);
+    await _pumpButton(tester, errorEvents);
+
+    errorEvents.add(1);
+    await tester.pump();
+    await tester.pump();
+
+    expect(_spinnerShown(tester), isFalse);
+    expect(tester.widget<OutlinedButton>(find.byType(OutlinedButton)).onPressed, isNotNull);
+  });
+}

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -57,7 +57,13 @@ function(APPLY_STANDARD_SETTINGS TARGET)
             /bigobj
             )
     target_compile_options(${TARGET} PRIVATE /EHsc)
-    target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
+    # Deviation from the stock Flutter template: do NOT define _HAS_EXCEPTIONS=0. The native backend
+    # (compiled into the runner) throws and catches exceptions whose messages are dynamically built
+    # std::strings. Under _HAS_EXCEPTIONS=0 the MSVC STL substitutes a fallback std::exception that
+    # stores the message as a raw non-owning pointer (stdext::exception in <exception>), so
+    # runtime_error(std::string) keeps a c_str() into a destroyed temporary and what() returns freed
+    # memory. That silently corrupted every dynamic error message (and broke onError delivery when the
+    # garbage bytes later failed strict UTF-8 JSON serialization).
     target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()
 

--- a/windows/runner/native_controller.h
+++ b/windows/runner/native_controller.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <stdexcept>
+#include <string>
 
 #include <flutter/dart_project.h>
 #include <flutter/flutter_view_controller.h>
@@ -27,6 +29,16 @@ public:
         recorder_runner = recorder_runner_impl;
         window_recorder = std::make_unique<WindowRecorder>(connection);
 
+        // Dedicated worker for capture start: NativeApi::startEventLoop loads the ONNX models (~1s), so
+        // running it on the platform thread would freeze the UI. NoLimit mode so no start request is ever
+        // dropped -- every request must resolve to exactly one onCaptureStarted or onError.
+        const auto capture_worker_impl =
+            event_util::makeSingleThreadRunner(event_util::QueueLimitMode::NoLimit, nullptr, "capture_lifecycle");
+        start_requested = capture_worker_impl->makeConnection<std::string>();
+        start_requested->listen([this](const auto &config) { doStartCapture(config); });
+        capture_worker = capture_worker_impl;
+        capture_worker->start();
+
         channel->addMethodCallHandler("setConfig", [this](const auto &config_string) {
             vlog_debug(config_string.length());
             native_config = config_string;
@@ -42,7 +54,11 @@ public:
             setPlatformConfig(windows_config);
         });
 
-        channel->addMethodCallHandler("startCapture", [this]() { startEventLoop(); });
+        channel->addMethodCallHandler("startCapture", [this]() {
+            // Snapshot native_config by value here: the member is only ever read on the platform thread,
+            // so the worker must receive its own copy instead of touching the member later.
+            start_requested->send(native_config);
+        });
 
         channel->addMethodCallHandler("stopCapture", [this]() { joinEventLoop(); });
 
@@ -75,6 +91,11 @@ public:
 
     ~NativeController() {
         log_debug("");
+        // Join the capture worker first so an in-flight start request finishes before teardown. Do NOT take
+        // capture_mutex here: holding it while joining would deadlock (dtor holds the lock -> the worker job
+        // waits for it -> the dtor waits for the job). After the join no other thread runs controller code,
+        // so the teardown below needs no lock.
+        capture_worker->join();
         if (recorder_runner) {
             joinEventLoop();
             recorder_runner = nullptr;
@@ -88,26 +109,51 @@ public:
     }
 
 private:
-    void startEventLoop() {
+    // Runs on the capture worker thread. Every start request resolves to exactly one onCaptureStarted or
+    // onError, so the Dart side never waits forever on a request that silently went nowhere.
+    void doStartCapture(const std::string &config) {
         log_debug("");
+        std::lock_guard<std::mutex> lock(capture_mutex);
         assert_(recorder_runner);
         if (recorder_runner->isRunning()) {
+            // Already capturing: resend the started notification so this request still resolves.
+            app::NativeApi::instance().notifyCaptureStarted();
             return;
         }
-        app::NativeApi::instance().startEventLoop(native_config);
+        app::NativeApi::instance().startEventLoop(config);
         if (!app::NativeApi::instance().isRunning()) {
             // The pipeline failed to build (config parse, model load, ...). NativeApi already emitted onError and
             // tore itself down. Do not start the recorder or emit onCaptureStarted, or the Dart side would reset
             // the error state and show a running capture backed by a dead pipeline.
             return;
         }
-        recorder_runner->start();
-        window_recorder->startRecord();
+        try {
+            recorder_runner->start();
+            window_recorder->startRecord();
+        } catch (const std::exception &e) {
+            rollbackFailedStart();
+            app::NativeApi::instance().notifyError(std::string("startCapture failed: ") + e.what());
+            return;
+        } catch (...) {
+            // WinRT exceptions (winrt::hresult_error) do not derive from std::exception.
+            rollbackFailedStart();
+            app::NativeApi::instance().notifyError("startCapture failed: unknown non-standard exception");
+            return;
+        }
         app::NativeApi::instance().notifyCaptureStarted();  // In Windows, start operation will never be canceled.
+    }
+
+    // Undo a partial capture start so the next request begins from a clean state. Each step is a no-op for
+    // a component that never started.
+    void rollbackFailedStart() {
+        window_recorder->stopRecord();
+        recorder_runner->join();
+        app::NativeApi::instance().joinEventLoop();
     }
 
     void joinEventLoop() {
         log_debug("");
+        std::lock_guard<std::mutex> lock(capture_mutex);
         // The recorder will be terminated, but the event loop will remain.
         window_recorder->stopRecord();
         recorder_runner->join();
@@ -116,6 +162,7 @@ private:
 
     void updateRecord(const std::string &id) {
         log_debug("");
+        std::lock_guard<std::mutex> lock(capture_mutex);
         app::NativeApi::instance().startEventLoop(native_config);
         if (!app::NativeApi::instance().isRunning()) {
             // Regeneration pipeline failed to build; NativeApi already reported onError and tore down. Skip the
@@ -127,6 +174,9 @@ private:
 
     void finishUpdate() {
         log_debug("");
+        // Serialize against an in-flight doStartCapture: without the lock this could observe the recorder as
+        // not yet running right after the worker built the pipeline, and silently tear the fresh loop down.
+        std::lock_guard<std::mutex> lock(capture_mutex);
         // Record regeneration starts the event loop (via updateRecord) without the recorder. When a live capture
         // is running the recorder is active and the loop is shared, so it must stay up. Only tear down a loop
         // that was started solely for regeneration. Call NativeApi::joinEventLoop() directly rather than this
@@ -138,6 +188,7 @@ private:
     }
 
     void setPlatformConfig(const windows_config::WindowsConfig &config) {
+        std::lock_guard<std::mutex> lock(capture_mutex);
         if (config.window_recorder.has_value()) {
             window_recorder->setConfig(config.window_recorder.value());
         }
@@ -147,6 +198,17 @@ private:
     std::unique_ptr<WindowRecorder> window_recorder;
     event_util::EventRunner recorder_runner;
 
+    event_util::SingleThreadMultiEventRunner capture_worker;
+    event_util::Connection<std::string> start_requested;
+
+    // Serializes capture lifecycle transitions: doStartCapture on the capture worker against the
+    // platform-thread handlers (stopCapture / updateRecord / finishUpdate / setConfig). Lock order is
+    // always capture_mutex -> NativeApi's pipeline_mutex, never the reverse. The notifyXxx calls made
+    // under this lock are non-blocking (queued + PostMessage), so holding it across them is safe.
+    std::mutex capture_mutex;
+
+    // Written by the "setConfig" handler and read by the "startCapture" handler, both on the platform
+    // thread only; the capture worker receives a value snapshot instead.
     std::string native_config;
 };
 


### PR DESCRIPTION
## Summary

Move capture start off the platform thread onto a dedicated worker so the UI no longer freezes during the ~1 s ONNX model load, and guarantee that every start request resolves to exactly one `onCaptureStarted` or `onError`. Also remove the stock Flutter template's `_HAS_EXCEPTIONS=0`, which silently corrupted every dynamically built exception message before it could reach `onError`.

## What changed

### 1. Asynchronous capture start (`windows/runner/native_controller.h`)

- **Dedicated `capture_lifecycle` worker**: the `startCapture` method-channel handler now snapshots `native_config` and queues the request; `doStartCapture` runs on the worker (NoLimit queue, so no request is ever dropped).
- **Guaranteed resolution**: already-running requests resend `onCaptureStarted`; recorder start failures (including non-`std::exception` WinRT errors) roll back the partial start via `rollbackFailedStart()` and emit `onError`.
- **`capture_mutex`**: serializes the worker against the platform-thread handlers (`stopCapture` / `updateRecord` / `finishUpdate` / `setConfig`). Lock order is documented as `capture_mutex` -> `pipeline_mutex`, and the destructor joins the worker before teardown without taking the lock (deadlock-free by construction).

### 2. Exception-message integrity (`windows/CMakeLists.txt`, `native/src/core`)

- **Drop `_HAS_EXCEPTIONS=0`**: under that define the MSVC STL substitutes a fallback `std::exception` that stores the message as a raw non-owning pointer, so `runtime_error(std::string)` returned freed memory from `what()`. A `#error` guard in `native_api.cpp` prevents reintroduction.
- **Catch-all in `NativeApi::startEventLoop`**: WinRT exceptions do not derive from `std::exception`; without this they escaped with no `onError` and left a half-built pipeline behind.
- **Non-UTF-8-safe `onError` serialization**: `messages::error()` now dumps with `error_handler_t::replace` so a CP932-localized `what()` cannot kill the very error notification it rides on (regression test added).

### 3. Pending-request UI (`lib/src/gui/capture.dart`, `test/two_state_button_test.dart`)

- **`TwoStateButton` state machine**: a press now shows the spinner until the provider confirms the requested state, an `errorEventProvider` event arrives, or a 15 s fallback timeout expires -- instead of the old fixed 500 ms timer that hid the spinner while the request was still pending.
- **Widget tests** cover press-to-confirmation, error-clears-pending (including fallback-timer cancellation), and error-before-press no-op.

## Testing

- `flutter test test/two_state_button_test.dart` -- 3/3 passed.
- `dart analyze` on the changed Dart files -- no issues.
- Native `umacapture_tests` rebuilt from the working tree (VS18 / MSVC 14.51) -- 214/214 passed, including the new non-UTF-8 `error()` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
